### PR TITLE
fix(ollama): default base URL to ollama container

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -17,7 +17,7 @@ features:
 
 # Ollama configuration (only used if features.ai_enabled is true)
 ollama:
-  base_url: "http://localhost:11434"
+  base_url: "http://ollama:11434"
   model: "mistral:7b"  # Model for recommendations (text generation)
   embedding_model: "nomic-embed-text"  # Model for generating embeddings
   # Separate model for conversation chat (defaults to main model when empty).

--- a/docs/MODEL_RECOMMENDATIONS.md
+++ b/docs/MODEL_RECOMMENDATIONS.md
@@ -77,7 +77,7 @@ Edit `config/config.yaml`:
 
 ```yaml
 ollama:
-  base_url: "http://localhost:11434"
+  base_url: "http://ollama:11434"
   model: "mistral:7b"  # or "deepseek-r1:latest"
   embedding_model: "nomic-embed-text"
 ```

--- a/docs/OLLAMA_SETUP_GUIDE.md
+++ b/docs/OLLAMA_SETUP_GUIDE.md
@@ -53,7 +53,7 @@ features:
   llm_reasoning_enabled: true
 
 ollama:
-  base_url: "http://localhost:11434"  # adjust if Docker networking differs
+  base_url: "http://ollama:11434"  # Docker service name; use localhost:11434 if running Ollama on host
   model: "qwen2.5:14b"
   embedding_model: "nomic-embed-text"
 ```

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -138,7 +138,7 @@ def create_llm_components(
         return None, None, None
 
     ollama_config = config.get("ollama", {})
-    base_url = ollama_config.get("base_url", "http://localhost:11434")
+    base_url = ollama_config.get("base_url", "http://ollama:11434")
     model = ollama_config.get("model", "mistral:7b")
     embedding_model = ollama_config.get("embedding_model", "nomic-embed-text")
     conversation_model = ollama_config.get("conversation_model", "")

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -20,7 +20,7 @@ class OllamaClient:
 
     def __init__(
         self,
-        base_url: str = "http://localhost:11434",
+        base_url: str = "http://ollama:11434",
         default_model: str = "mistral:7b",
         embedding_model: str = "nomic-embed-text",
         timeout: float = 300.0,


### PR DESCRIPTION
## Summary
- Changed default Ollama base URL from `http://localhost:11434` to `http://ollama:11434` across config, source code defaults, and documentation

Fixes #5

## What Changed
- `config/example.yaml`: Updated default `base_url` to `http://ollama:11434`
- `src/llm/client.py`: Updated `OllamaClient.__init__` default parameter
- `src/cli/config.py`: Updated fallback default in `create_llm_components()`
- `docs/OLLAMA_SETUP_GUIDE.md`: Updated config example with note about localhost fallback
- `docs/MODEL_RECOMMENDATIONS.md`: Updated config example

## Test Plan
- All 2296 existing tests pass (tests use explicit config values, not defaults)
- Verify Docker Compose AI profile connects to Ollama sidecar with default config

Generated with [Claude Code](https://claude.com/claude-code)