### PR TITLE
fix(ci): pass GH_TOKEN to checkout for branch protection bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
 
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:


### PR DESCRIPTION
## Summary
- Pass `GH_TOKEN` PAT to `actions/checkout` so git credentials use the admin PAT instead of the default `GITHUB_TOKEN`
- Fixes release workflow failing with "Changes must be made through a pull request" error when semantic-release tries to push version bump commits to `main`

## Test plan
- [ ] Merge this PR and verify the Release workflow succeeds (creates version tag, pushes changelog/version bump, pushes lockfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)