### PR TITLE
fix(ci): include uv.lock in semantic-release version commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,19 +35,3 @@ jobs:
         id: release
         with:
           github_token: ${{ secrets.GH_TOKEN }}
-
-      - name: Update lockfile after version bump
-        if: steps.release.outputs.released == 'true'
-        env:
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
-        run: |
-          if [[ ! "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "ERROR: Unexpected version format: ${RELEASE_VERSION}" >&2
-            exit 1
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          uv lock
-          git add uv.lock
-          git diff --cached --quiet || git commit -m "chore(lockfile): regenerate uv.lock for v${RELEASE_VERSION} [skip ci]"
-          git push origin HEAD:main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ version_toml = ["pyproject.toml:project.version"]
 allow_zero_version = true
 major_on_zero = false
 tag_format = "v{version}"
+build_command = "uv lock"
 
 [tool.semantic_release.changelog]
 mode = "init"


### PR DESCRIPTION
## Summary

- Use semantic-release's `build_command = "uv lock"` to regenerate the lockfile before the version commit, so `pyproject.toml` and `uv.lock` are always in sync at the tagged release
- Remove the separate post-release lockfile regeneration workflow step that created a second commit

Fixes the Docker build failure (`uv sync --locked` fails) that occurred on every release because the tagged commit had a stale `uv.lock`.

## Test plan

- [ ] Verify `command make check` passes (2348 tests, black, mypy, ruff all clean)
- [ ] Trigger a release and confirm `uv.lock` is included in the version bump commit
- [ ] Confirm Docker build succeeds from the tagged release

🤖 Generated with [Claude Code](https://claude.com/claude-code)