### PR TITLE
fix(ci): use semantic-release CLI instead of Docker action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --extra dev
 
-      - uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
-        id: release
-        with:
-          github_token: ${{ secrets.GH_TOKEN }}
+      - name: Configure git for semantic-release
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: uv run python -m semantic_release version --push --commit --tag --vcs-release


### PR DESCRIPTION
## Summary

- Switch from the Docker-based `python-semantic-release` GitHub Action to running `semantic-release` as a CLI via `uv run` — the Docker container doesn't have `uv`, so `build_command = "uv lock"` (added in #23) fails with "uv: command not found"
- Add explicit git config for the bot identity since the Docker action previously handled that internally

Follows up on #23 which added the `build_command` but didn't account for the Docker isolation.

## Test plan

- [ ] Trigger a release and confirm semantic-release runs successfully via CLI
- [ ] Confirm `uv.lock` is included in the version bump commit
- [ ] Confirm Docker build succeeds from the tagged release

🤖 Generated with [Claude Code](https://claude.com/claude-code)