### PR TITLE
fix(storage): never silently delete unreadable credentials

### DIFF
--- a/src/storage/credential_migration.py
+++ b/src/storage/credential_migration.py
@@ -86,11 +86,13 @@ def migrate_config_credentials(
                     )
                     entry.pop(field.name, None)
                 else:
-                    # Stale row with no config fallback — purge it
-                    storage.delete_credential(user_id, source_id, field.name)
+                    # Stale row with no config fallback — leave it alone.
+                    # Never silently delete credentials; the user may be able
+                    # to fix the encryption key and recover the value.
                     logger.warning(
-                        "Purged unreadable %s.%s credential from database "
-                        "(encryption key changed, no config value to re-encrypt from)",
+                        "Cannot decrypt %s.%s credential in database "
+                        "(encryption key changed?). Fix the key file or "
+                        "reconnect via the web UI to re-save the credential.",
                         source_id,
                         field.name,
                     )

--- a/tests/storage/test_credential_migration.py
+++ b/tests/storage/test_credential_migration.py
@@ -1,6 +1,8 @@
 """Tests for config-to-DB credential migration."""
 
+import logging
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -153,11 +155,18 @@ class TestMigrateConfigCredentials:
 
         assert storage.get_credential(1, "gog", "refresh_token") == "fresh_token"
 
-    def test_stale_credential_purged_when_no_config_value(
-        self, storage: StorageManager
+    def test_stale_credential_preserved_when_no_config_value(
+        self, storage: StorageManager, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Stale credential with no config fallback is purged from DB."""
-        # Write a stale row
+        """Stale credential with no config fallback is preserved, not purged.
+
+        Bug reported: GOG credential was silently deleted during startup
+        when decryption failed and config had no fallback value.
+        Root cause: migration purged unreadable credentials instead of
+        leaving them for the user to fix (e.g. by restoring the key file).
+        Fix: log a warning but never delete credentials automatically.
+        """
+        # Write a stale row (can't be decrypted — raw garbage, not encrypted)
         with storage.connection() as conn:
             conn.execute(
                 "INSERT INTO credentials "
@@ -167,7 +176,7 @@ class TestMigrateConfigCredentials:
             conn.commit()
 
         # Config has no refresh_token
-        config = {
+        config: dict[str, Any] = {
             "inputs": {
                 "gog": {
                     "plugin": "gog",
@@ -176,10 +185,12 @@ class TestMigrateConfigCredentials:
             }
         }
 
-        migrate_config_credentials(config, storage)
+        with caplog.at_level(logging.WARNING):
+            migrate_config_credentials(config, storage)
 
-        # Row should be gone
-        assert not storage.credential_row_exists(1, "gog", "refresh_token")
+        # Row must still exist — never silently delete credentials
+        assert storage.credential_row_exists(1, "gog", "refresh_token")
+        assert "Cannot decrypt" in caplog.text
 
     def test_multiple_sources_migrated(self, storage: StorageManager) -> None:
         """Multiple sources with sensitive fields are all migrated."""


### PR DESCRIPTION
## Summary

- Credential migration no longer purges DB credentials that can't be decrypted
- Previously, if decryption failed and no config fallback existed, the credential row was silently deleted
- Now logs a warning instead, preserving the row for the user to fix (restore key file or reconnect via web UI)

## Context

This bug was discovered when switching branches caused an encryption key mismatch. The GOG refresh token was silently deleted on startup because the migration couldn't decrypt it and the config file had no `refresh_token` fallback. The user had to re-authenticate to restore it.

## Test plan

- [ ] Write a stale credential row to DB (raw garbage, not properly encrypted)
- [ ] Start with no `refresh_token` in config
- [ ] Verify the row is NOT deleted — warning logged instead
- [ ] 2348 tests pass, black/ruff/mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)