### PR TITLE
feat: CLI/UI parity — full feature mirror between CLI and web interfaces

### DIFF
--- a/.claude/agents/parity-review.md
+++ b/.claude/agents/parity-review.md
@@ -1,0 +1,130 @@
+---
+name: parity-review
+description: |
+  CLI/UI parity enforcement agent. Use this agent as part of the pre-commit review workflow whenever a PR touches files in src/web/ or src/cli/.
+
+  Examples:
+  - user: "I've added a new API endpoint for wishlist management"
+    assistant: "Let me run the parity-review agent to check if the CLI has matching commands."
+
+  - user: "I've added a new CLI command for bulk imports"
+    assistant: "Let me run the parity-review agent to verify the web UI exposes the same functionality."
+
+  - user: "I refactored the preferences API endpoints"
+    assistant: "Let me run the parity-review agent to make sure the CLI preferences commands still match."
+model: sonnet
+color: magenta
+---
+
+You are the parity enforcer. Your job is simple and non-negotiable: **the CLI and web UI are mirrors of each other.** Every capability in one interface MUST have a counterpart in the other. No exceptions. No "we'll add it later." No "the CLI doesn't need that." If a feature exists in only one interface, that is a bug — full stop.
+
+The dual-interface principle is a core architectural guarantee of this project. When a user chooses the CLI over the web UI (or vice versa), they are choosing an interaction style, NOT choosing to give up features. Breaking this guarantee means lying to users about what the product can do. You do not tolerate liars.
+
+**Interface-specific glue code is expected to differ.** The web UI has HTML templates and OAuth redirect pages. The CLI has `click.prompt()` and `--format` flags. These differences are fine — they are the same capability delivered through different transport. What is NOT fine is a capability that simply does not exist on one side. A missing CLI command for an existing API endpoint is not a "nice to have" — it is a parity violation that blocks the commit.
+
+## Tool Usage
+
+**Use the right tool for the job.** You have access to dedicated tools — use them instead of Bash whenever possible:
+
+- **Read** — to read file contents (never use `cat`, `head`, `tail`)
+- **Grep** — to search file contents (never use `grep` or `rg` via Bash)
+- **Glob** — to find files by pattern (never use `find` or `ls` via Bash)
+
+**Bash is only for git commands.** The only Bash commands you should run are:
+
+- `git diff HEAD` — see all uncommitted changes (staged + unstaged)
+- `git diff --cached` — see only staged changes
+- `git log --oneline -5` — see recent commit messages
+- `git diff HEAD~1` — see the last commit's diff (if changes were already committed)
+- `git status` — check repo state
+- `git diff main...HEAD --name-only` — see all files changed on the branch
+
+Do NOT use Bash for anything else. Do NOT pipe output, use `head`/`tail`, or chain commands.
+
+## Review Process
+
+### Step 0: Check for Interface Changes
+
+Run `git diff HEAD --name-only` (or `git diff main...HEAD --name-only` for branch reviews).
+
+If no files match `src/web/**` or `src/cli/**`, **APPROVE immediately** with:
+
+> "No interface changes detected. APPROVE."
+
+Stop here. Do not continue to further steps.
+
+### Step 1: Build the Complete Capability Map
+
+This is not optional. Do NOT skip it. Do NOT sample. Read the actual source files.
+
+1. **Scan ALL web API endpoints.** Use Grep to find every `@router.get`, `@router.post`, `@router.put`, `@router.patch`, `@router.delete` in `src/web/`. For each endpoint, record: the route, the HTTP method, every query parameter, every request body field, and what it returns.
+
+2. **Scan ALL CLI commands.** Use Grep to find every `@click.command`, `@click.group`, `@group.command` in `src/cli/`. For each command, record: the command name, every `@click.option`, every `@click.argument`, and what it outputs.
+
+3. **Build a mapping table.** For every API endpoint, identify the corresponding CLI command. For every CLI command, identify the corresponding API endpoint. If either side has no counterpart, that is a CRITICAL finding.
+
+### Step 2: Check Parameter Parity
+
+For each matched pair, verify — parameter by parameter, not vibes:
+
+- All API query parameters have corresponding CLI `--option` flags
+- All API request body fields have corresponding CLI options or arguments
+- Enum values (content types, statuses, sort orders) are **identical** on both sides — not "similar," identical
+- Default values match where applicable
+- If the API supports filtering/sorting that the CLI doesn't, that is a MAJOR finding
+
+Do NOT assume parameters match because the names are similar. Read the actual code. Compare the actual values. "Close enough" is not good enough.
+
+### Step 3: Check Output Parity
+
+- CLI `--format json` output should match API JSON response structure
+- If the API returns fields that the CLI omits in its JSON output, that is a MAJOR finding
+- Table output can differ from JSON (it's a presentation concern), but JSON output must be equivalent
+
+### Step 4: Identify Intentional Exclusions
+
+These are NOT parity gaps — do not flag them:
+- Theme selection (`GET /api/themes`, `GET /api/themes/default`) — web-only visual concern
+- OAuth redirect UI chrome (the browser callback page — CLI uses code paste instead)
+- `POST /api/config/reload` — CLI reloads config on every invocation
+- WebSocket streaming — CLI uses synchronous equivalents
+- Static asset serving — web-only infrastructure
+
+Everything else is fair game. "It's a CLI, it doesn't need a web equivalent" is not an excuse. "It's a web feature, the CLI doesn't need it" is not an excuse. Both interfaces serve the same users with the same capabilities.
+
+## Severity Framework
+
+**Parity is binary. Any drift blocks.** Do not grade structural differences as "minor and approve." If you find ANY drift between CLI and web in the following categories, the verdict MUST be REJECT or REQUEST CHANGES:
+
+- Missing fields in JSON output on one side (e.g., CLI omits `review`, `source`, `seasons_watched` that web returns, or vice versa)
+- Missing parameters on one side
+- Different enum values between sides
+- Different default values that change user-visible behavior
+- Missing commands/endpoints on one side
+
+| Severity | Criteria | Action |
+|----------|----------|--------|
+| **CRITICAL** | Feature exists in one interface but is completely absent from the other. A user switching interfaces loses functionality. | **REJECT.** This is a broken contract. |
+| **MAJOR** | Feature exists in both but parameters, capabilities, or output shape differ. A user gets different results from the same operation depending on interface. | **REQUEST CHANGES.** The interfaces are lying about being equivalent. |
+| **MINOR** | Purely cosmetic text/formatting differences in human-readable output (table layout, prose messages, prompt wording). These do not affect machine-readable JSON output, parameter sets, or capabilities. | Note it. Does not block. |
+
+**JSON output is a contract, not cosmetic.** Any JSON field difference between CLI `--format json` and the corresponding web API response is at minimum MAJOR. "Cosmetic" only applies to human-readable table/prose output.
+
+## Output Format
+
+### Summary
+One paragraph. What changed, what you found, whether parity holds. No hedging. No "mostly good." It either holds or it doesn't.
+
+### Critical Issues
+Numbered list with **exact file locations** (file:line) and what's missing. For each: what exists on side A, what's absent on side B, and what the user loses.
+
+### Major Issues
+Numbered list with specific parameter or capability differences. Show the API signature and the CLI signature side by side so the gap is undeniable.
+
+### Minor Issues
+Numbered list. An empty section is fine and welcome.
+
+### Verdict
+- **REJECT** — Any critical parity gap. A feature exists in one interface but not the other. Non-negotiable.
+- **REQUEST CHANGES** — Major parameter or capability differences that cause different behavior across interfaces.
+- **APPROVE** — Both interfaces expose equivalent functionality. Every API endpoint has a CLI command. Every CLI command has an API endpoint. Parameters match. The mirror is clean.

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ ENV/
 .vscode/
 .idea/
 .claude/settings.local.json
+.claude/worktrees/
 .beads/
 *.swp
 *.swo

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ outputs/
 # Private plugins (user-specific, not shared)
 private/
 
+# Design specs (local working docs, not shared)
+docs/superpowers/
+
 # Frontend
 node_modules/
 src/web/static/dist/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,7 +165,7 @@ When enabled (recommended for 3B models), the engine uses a condensed system pro
 
 #### CLI (`src/cli/`)
 - Click-based command structure
-- Commands: `recommend`, `update`, `complete`, `preferences`, `enrichment`
+- Commands: `status`, `recommend`, `update`, `complete`, `preferences`, `enrichment`, `library`, `auth`, `memory`, `profile`, `chat`
 - Supports batch operations and multiple output formats
 
 #### Web (`src/web/` + `resources/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,8 +159,9 @@ The project uses Claude Code plugins and custom agents to maintain code quality 
 - **document-review** — Documentation accuracy and completeness audit. See `.claude/agents/document-review.md`.
 - **commit-hygiene** — Atomic commit structure and conventional format. See `.claude/agents/commit-hygiene.md`.
 - **accessibility-review** — WCAG 2.1 AA compliance for frontend code. See `.claude/agents/accessibility-review.md`.
+- **parity-review** — CLI/UI parity enforcement. See `.claude/agents/parity-review.md`.
 
-**All agents must approve changes before marking tasks as complete.** Run security-review, code-review, test-review, document-review, and accessibility-review before `command make check`. Run commit-hygiene before committing (to plan the split) and before pushing (to verify commit structure). The accessibility-review agent self-gates on frontend file presence — it immediately approves when no frontend files are in the diff.
+**All agents must approve changes before marking tasks as complete.** Run security-review, code-review, test-review, document-review, parity-review, and accessibility-review before `command make check`. Run commit-hygiene before committing (to plan the split) and before pushing (to verify commit structure). The accessibility-review agent self-gates on frontend file presence — it immediately approves when no frontend files are in the diff.
 
 ## Architecture Principles
 
@@ -169,6 +170,7 @@ The project uses Claude Code plugins and custom agents to maintain code quality 
 3. **Extensibility**: Easy to add new data sources/content types
 4. **Configuration**: No hardcoded values
 5. **Error Handling**: Graceful with clear messages
+6. **Interface Parity**: CLI and web UI are alternative interfaces to the same capabilities
 
 ## Plan Mode Workflow
 
@@ -213,6 +215,56 @@ This ensures every plan step is tracked, has clear acceptance criteria, and noth
 6. Ensure all checks pass (`command make check`)
 7. Update documentation (ARCHITECTURE.md, README.md, QUICKSTART.md, CLAUDE.md, relevant docs/ files)
 8. Atomic commits with proper message format following conventional commit standards
+
+## Anti-Churn Checklist (run BEFORE writing code)
+
+Review agents repeatedly flag the same classes of issues. Reading this list before each task — and actively searching for the relevant patterns in the codebase — avoids the same fixes round after round.
+
+### Before writing ANY code
+
+1. **Grep for a sibling that already does the thing.** New CLI subcommand? Read an existing one in `src/cli/commands.py` end-to-end first. New API endpoint? Read a sibling in `src/web/api.py`. New test file? Read the nearest neighbor in `tests/` first. Match its structure exactly — imports order, helper usage, naming, error handling, output format branching.
+2. **Search `src/utils/` and module-local helpers before creating a new helper.** If two sites would use it, it already exists or needs to live there. Examples: `extract_tv_season_fields` (item serialization), `_item_to_dict` (CLI item output), `get_feature_flags` (AI flag checks), `list_merge`, `series`, `sorting`.
+3. **For CLI changes, diff against the web API first.** CLI and web UI are mirrors. Before adding a CLI flag/field, read the equivalent endpoint's Pydantic response model and request params. The JSON shape MUST match exactly — same keys, same types, same empty-result behavior.
+4. **For test changes, read `tests/<area>/conftest.py` first.** If a shared fixture or helper exists (`cli_runner`, `_invoke_with_mocks`, `_cli_patches`), use it. Never redefine a fixture locally that already lives in conftest.
+
+### Imports (code-review flags these every time)
+
+- **All imports at module top.** No function-level imports, no `import x as _x` inside a test method. If you catch yourself writing `import json` inside a function, stop and move it to the top of the file.
+- **Don't reorder imports manually** — let ruff/isort handle it. If ruff splits a block you want kept together (aliased auth imports, etc.), the existing fix is `# noqa: I001` on the `from __future__ import annotations` line.
+
+### Tests (test-review flags these every time)
+
+- **Use `spec=RealClass` on MagicMock** for any real type (StorageManager, RecommendationEngine, ContentItem, etc.). A bare `MagicMock()` is almost always wrong.
+- **Use the shared `_invoke_with_mocks` / `_cli_patches` helpers** from `tests/cli/conftest.py`. Do NOT write nested `with patch(): with patch(): with patch():` pyramids — if you see yourself nesting patches more than two deep, you're duplicating what conftest provides.
+- **`ContentItem` construction requires `status`.** Most tests also need `rating` depending on the path. When a test fails with "Missing named argument", check the dataclass signature, don't guess.
+- **Regression tests go in a `Test<Feature>Regression` class with a docstring** documenting: the bug symptom, root cause, and what the fix does. No bare tests with cryptic names.
+- **Assertions must be strong.** `assert result.exit_code == 0` is necessary but not sufficient — also assert specific output strings, mock call args, or parsed JSON keys. "Output is non-empty" is not a real assertion.
+
+### CLI/web parity (parity-review blocks on ANY drift)
+
+- **JSON output on empty results is `[]` or the empty response object — never a text message.** Text messages only go to the human-readable format. Check every `if not items: click.echo("No ...")` — it needs an `if output_format == "json"` branch that emits valid empty JSON first.
+- **JSON field set must match the web Pydantic response exactly.** Before committing a CLI JSON path, open the matching `*Response` model in `src/web/api.py` and diff the key sets. Missing/extra fields = blocking drift.
+- **Every CLI command needs a `--format json` option if the web API returns JSON.** Every web API flag/param needs a matching CLI option. No exceptions.
+- **Serialization goes through shared helpers** (`_item_to_dict`, `extract_tv_season_fields`). Do not hand-roll dict construction in both CLI and API.
+
+### Code style (code-review flags these every time)
+
+- **No backwards-compat shims, no "removed" comments, no unused `_var` renames.** Delete the code outright.
+- **Default to no comments.** Only comment the WHY of a non-obvious constraint — never the WHAT, never "added for task X", never reference the current review round.
+- **No try/except that re-raises unchanged.** No validation for "can't happen" internal states. Trust internal code; only validate at system boundaries.
+- **No feature flags or config toggles unless the user asked for them.** Just change the code.
+- **Click `IntRange` for bounded ints, Click choices for enums.** Don't manually validate `if count > max: abort()` for simple bounds — but DO validate against config-driven limits (e.g., `max_count` from config) since those aren't Click-expressible.
+
+### Shell discipline (user preferences, memory-backed)
+
+- **One Bash call per logical step.** Never chain with `&&`/`;`. See `feedback_dont_chain_commands.md`.
+- **Run `python3.11 -m black src/ tests/` and `python3.11 -m ruff check src/ tests/ --fix` BEFORE `command make check`**, so make check doesn't fail on auto-fixable formatting. See `feedback_always_format_before_check.md`.
+- **Do not read raw subagent output files** to verify agent results — the agent returns its finding in its tool result. See `feedback_no_grep_agent_output.md`.
+- **Never wait/poll on background agents.** The runtime notifies on completion.
+
+### If an agent flags something, fix the CLASS, not the instance
+
+When a review agent flags an issue, search the rest of the diff for the same pattern and fix all occurrences in one pass. Don't wait for round N+1 to discover the same issue elsewhere. After fixing, grep the whole diff for the pattern to confirm it's gone.
 
 ## Adding New Data Sources
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -146,6 +146,9 @@ If you enabled `auto_enrich_on_sync`, enrichment runs automatically after each s
 ```bash
 python3.11 -m src.cli enrichment start
 python3.11 -m src.cli enrichment status
+
+# Retry items that providers couldn't find previously
+python3.11 -m src.cli enrichment start --retry-not-found
 ```
 
 ## Get Recommendations
@@ -164,6 +167,50 @@ python3.11 -m src.cli recommend --type video_game --count 5
 python3.11 -m src.cli recommend --type tv_show --count 5
 ```
 
+## Check System Status
+
+```bash
+# See component health, database stats, and feature flags
+python3.11 -m src.cli status
+```
+
+## Browse & Edit Your Library
+
+```bash
+# List your completed books, sorted by rating
+python3.11 -m src.cli library list --type book --status completed --sort rating
+
+# Show full details for a single item
+python3.11 -m src.cli library show --id 42
+
+# Edit an item's rating or status
+python3.11 -m src.cli library edit --id 42 --rating 5 --status completed
+
+# Exclude an item from recommendations (or reverse it)
+python3.11 -m src.cli library ignore --id 42
+python3.11 -m src.cli library unignore --id 42
+```
+
+## Authenticate Game Sources (GOG/Epic)
+
+```bash
+# Connect your GOG account via browser OAuth
+python3.11 -m src.cli auth connect --source gog
+
+# Check connection status
+python3.11 -m src.cli auth status
+```
+
+## Chat with Your Library (requires AI)
+
+```bash
+# Start an interactive chat session
+python3.11 -m src.cli chat start
+
+# Or send a single question
+python3.11 -m src.cli chat send --message "What should I read next?"
+```
+
 ## Use the Web Interface
 
 ```bash
@@ -173,6 +220,13 @@ python3.11 -m src.web
 Open http://localhost:18473 in your browser. The web UI provides browsing, syncing, recommendations, and (with AI enabled) a conversational chat interface. The version number in the sidebar (e.g., "v0.3.0") shows the running application version. If a new version becomes available while you have the page open, a banner will prompt you to reload.
 
 ## Customize Your Preferences
+
+### View current preferences
+
+```bash
+# Show current weights, length preferences, and custom rules
+python3.11 -m src.cli preferences get
+```
 
 ### Set scoring weights
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ ingestion:
 
 ## CLI Usage
 
+The CLI provides full access to all Recommendinator features. Commands are organized into groups:
+
+### Import & Recommend
+
 ```bash
 # Import data
 python3.11 -m src.cli update --source goodreads
@@ -266,18 +270,125 @@ python3.11 -m src.cli recommend --type video_game --count 5
 
 # Mark content as completed
 python3.11 -m src.cli complete --type book --title "Project Hail Mary" --rating 5
+```
 
-# Manage preferences
+### System Status
+
+```bash
+# Check system health, component readiness, and feature flags
+python3.11 -m src.cli status
+python3.11 -m src.cli status --format json
+```
+
+### Library Management
+
+```bash
+# List items with filtering and sorting
+python3.11 -m src.cli library list --type book --status completed --sort rating --limit 20
+python3.11 -m src.cli library list --format json
+
+# Show item details
+python3.11 -m src.cli library show --id 42
+
+# Edit item metadata
+python3.11 -m src.cli library edit --id 42 --rating 5 --status completed
+
+# Ignore/unignore items (excluded from recommendations)
+python3.11 -m src.cli library ignore --id 42
+python3.11 -m src.cli library unignore --id 42
+
+# Export library data
+python3.11 -m src.cli library export --type book --format csv --output books.csv
+python3.11 -m src.cli library export --type video_game --format json
+```
+
+### Preferences
+
+```bash
+# View current preferences (table or JSON)
 python3.11 -m src.cli preferences get
+python3.11 -m src.cli preferences get --format json
+
+# Adjust scorer weights and content length preferences
 python3.11 -m src.cli preferences set-weight genre_match 3.0
 python3.11 -m src.cli preferences set-length book short
-python3.11 -m src.cli preferences custom-rules add "avoid horror"
-python3.11 -m src.cli preferences custom-rules add "prefer sci-fi"
 
-# Enrich metadata from external APIs (see docs/ENRICHMENT_SETUP.md)
+# Reset all preferences to defaults
+python3.11 -m src.cli preferences reset
+
+# Custom rules (natural-language preferences interpreted by the LLM)
+python3.11 -m src.cli preferences custom-rules add "avoid horror"
+python3.11 -m src.cli preferences custom-rules list
+python3.11 -m src.cli preferences custom-rules interpret "avoid horror" --use-llm
+python3.11 -m src.cli preferences custom-rules remove 0
+python3.11 -m src.cli preferences custom-rules clear --yes
+```
+
+### Enrichment
+
+```bash
+# Run enrichment (all items or filtered by content type)
 python3.11 -m src.cli enrichment start
-python3.11 -m src.cli enrichment start --type movie    # specific content type
+python3.11 -m src.cli enrichment start --type movie
+
+# Re-process items previously marked as not_found (providers can drift over time)
+python3.11 -m src.cli enrichment start --retry-not-found
+python3.11 -m src.cli enrichment start --type movie --retry-not-found
+
+# Check enrichment statistics
 python3.11 -m src.cli enrichment status
+
+# Reset enrichment status so items are re-processed on the next run
+python3.11 -m src.cli enrichment reset
+```
+
+### Authentication (GOG/Epic)
+
+```bash
+# Check OAuth connection status
+python3.11 -m src.cli auth status
+
+# Connect via browser OAuth flow
+python3.11 -m src.cli auth connect --source gog
+python3.11 -m src.cli auth connect --source epic
+
+# Disconnect stored credentials
+python3.11 -m src.cli auth disconnect --source gog
+```
+
+### Conversation & Memories (requires AI)
+
+```bash
+# Interactive chat session
+python3.11 -m src.cli chat start
+python3.11 -m src.cli chat start --type book    # filter to books only
+
+# Single-shot message
+python3.11 -m src.cli chat send --message "What should I read next?"
+
+# Conversation history
+python3.11 -m src.cli chat history --limit 20
+python3.11 -m src.cli chat reset
+
+# Manage memories (persistent preference signals)
+python3.11 -m src.cli memory list
+python3.11 -m src.cli memory add --text "I love hard sci-fi"
+python3.11 -m src.cli memory edit --id 3 --text "I love hard sci-fi and space opera"
+python3.11 -m src.cli memory edit --id 3 --inactive          # Set explicit active state
+python3.11 -m src.cli memory edit --id 3 --text "..." --inactive  # Text + state in one call
+python3.11 -m src.cli memory toggle --id 3                   # Flip active/inactive
+python3.11 -m src.cli memory delete --id 3
+```
+
+### User Profile
+
+```bash
+# View your computed preference profile
+python3.11 -m src.cli profile show
+python3.11 -m src.cli profile show --format json
+
+# Regenerate profile from current library data
+python3.11 -m src.cli profile regenerate
 ```
 
 ## How Scoring Works

--- a/docs/CONVERSATION_GUIDE.md
+++ b/docs/CONVERSATION_GUIDE.md
@@ -65,7 +65,7 @@ Compact mode uses:
 
 ## Using the Chat
 
-Chat is available through the **web interface** — there is no CLI chat command. Start the web server and navigate to the Chat tab.
+Chat is available through both the **web interface** and the **CLI**. In the web UI, navigate to the Chat tab. From the command line, use the `chat` command group (see below).
 
 ### What You Can Do
 
@@ -111,7 +111,7 @@ Memories are persistent preference signals that carry across conversations. They
 
 ### Managing Memories
 
-In the web UI, the chat interface shows a **Memories** panel where you can:
+In the web UI, the chat interface shows a **Memories** panel. You can also manage memories via the `memory` CLI commands (see [CLI Commands](#cli-commands) below). Both interfaces let you:
 - View all active memories
 - Add new memories manually
 - Edit existing memories
@@ -136,6 +136,50 @@ The profile system analyzes your completed and rated items to build a preference
 **Profile regeneration** happens automatically on a configurable interval (default: every 24 hours). You can also manually regenerate your profile from the web UI if you've added a lot of new ratings and want the profile to update immediately.
 
 The profile is not always perfect — it's derived from your data and may occasionally mischaracterize your preferences (e.g., reporting you dislike a genre when you actually just haven't rated enough items in it). As you rate more content, the profile becomes more accurate.
+
+## CLI Commands
+
+The `chat` and `memory` CLI command groups provide terminal-based alternatives to the web UI.
+
+### Chat Commands
+
+```bash
+# Start an interactive REPL session
+python3.11 -m src.cli chat start
+
+# Filter to a specific content type
+python3.11 -m src.cli chat start --type book
+
+# Send a single message without entering the REPL
+python3.11 -m src.cli chat send --message "Recommend a sci-fi book"
+
+# View recent conversation history
+python3.11 -m src.cli chat history --limit 10
+
+# Clear conversation history
+python3.11 -m src.cli chat reset
+```
+
+### Memory Commands
+
+```bash
+# List all memories
+python3.11 -m src.cli memory list
+
+# Add a memory manually
+python3.11 -m src.cli memory add --text "I love hard sci-fi"
+
+# Edit a memory's text and/or active state (matches web API PUT /api/memories/{id})
+python3.11 -m src.cli memory edit --id 3 --text "I love hard sci-fi and space opera"
+python3.11 -m src.cli memory edit --id 3 --inactive
+python3.11 -m src.cli memory edit --id 3 --text "..." --inactive
+
+# Flip a memory's active state (convenience shortcut)
+python3.11 -m src.cli memory toggle --id 3
+
+# Delete a memory
+python3.11 -m src.cli memory delete --id 3
+```
 
 ## Troubleshooting
 

--- a/resources/css/base.css
+++ b/resources/css/base.css
@@ -540,13 +540,14 @@ input[type="checkbox"] {
 }
 
 .btn-danger {
-  background: color-mix(in srgb, var(--color-error) 20%, transparent);
-  color: var(--color-error);
-  border-color: color-mix(in srgb, var(--color-error) 40%, transparent);
+  background: color-mix(in srgb, var(--color-error) 75%, black);
+  color: var(--text-primary);
+  border-color: color-mix(in srgb, var(--color-error) 75%, black);
 }
 
 .btn-danger:hover {
-  background: color-mix(in srgb, var(--color-error) 30%, transparent);
+  background: color-mix(in srgb, var(--color-error) 60%, black);
+  border-color: color-mix(in srgb, var(--color-error) 60%, black);
 }
 
 /* Pill Groups */

--- a/resources/js/components/pages/DataPage.vue
+++ b/resources/js/components/pages/DataPage.vue
@@ -26,6 +26,14 @@ function needsEpicConnect(sourceId: string): boolean {
   return sourceId === 'epic_games' && !data.epicStatus.connected && !!data.epicStatus.authUrl
 }
 
+function showGogDisconnect(sourceId: string): boolean {
+  return sourceId === 'gog' && data.gogStatus.connected
+}
+
+function showEpicDisconnect(sourceId: string): boolean {
+  return sourceId === 'epic_games' && data.epicStatus.connected
+}
+
 const syncAllLabel = computed(() => {
   if (data.syncStatus === 'running' && data.syncingSource === 'all') return 'Syncing...'
   if (data.syncStatus === 'running') return 'Sync in Progress'
@@ -98,6 +106,32 @@ const syncAllLabel = computed(() => {
             service-name="Epic Games"
             @submit="data.submitEpicCode($event)"
           />
+          <template v-else-if="showGogDisconnect(source.id)">
+            <p
+              v-if="data.gogConnectMessage"
+              class="sr-only"
+              aria-live="polite"
+            >{{ data.gogConnectMessage }}</p>
+            <button
+              type="button"
+              class="btn btn-ghost btn-small"
+              :disabled="data.syncStatus === 'running'"
+              @click="data.disconnectGog()"
+            >Disconnect GOG</button>
+          </template>
+          <template v-else-if="showEpicDisconnect(source.id)">
+            <p
+              v-if="data.epicConnectMessage"
+              class="sr-only"
+              aria-live="polite"
+            >{{ data.epicConnectMessage }}</p>
+            <button
+              type="button"
+              class="btn btn-ghost btn-small"
+              :disabled="data.syncStatus === 'running'"
+              @click="data.disconnectEpic()"
+            >Disconnect Epic Games</button>
+          </template>
         </SyncSourceCard>
         <div v-if="data.syncSources.length > 1" class="sync-card">
           <h3>All Sources</h3>

--- a/resources/js/components/pages/DataPage.vue
+++ b/resources/js/components/pages/DataPage.vue
@@ -18,21 +18,15 @@ onUnmounted(() => {
   data.cleanup()
 })
 
-function needsGogConnect(sourceId: string): boolean {
-  return sourceId === 'gog' && !data.gogStatus.connected && !!data.gogStatus.authUrl
-}
+const gogState = computed(() => ({
+  needsConnect: !data.gogStatus.connected && !!data.gogStatus.authUrl,
+  showDisconnect: data.gogStatus.connected,
+}))
 
-function needsEpicConnect(sourceId: string): boolean {
-  return sourceId === 'epic_games' && !data.epicStatus.connected && !!data.epicStatus.authUrl
-}
-
-function showGogDisconnect(sourceId: string): boolean {
-  return sourceId === 'gog' && data.gogStatus.connected
-}
-
-function showEpicDisconnect(sourceId: string): boolean {
-  return sourceId === 'epic_games' && data.epicStatus.connected
-}
+const epicState = computed(() => ({
+  needsConnect: !data.epicStatus.connected && !!data.epicStatus.authUrl,
+  showDisconnect: data.epicStatus.connected,
+}))
 
 const syncAllLabel = computed(() => {
   if (data.syncStatus === 'running' && data.syncingSource === 'all') return 'Syncing...'
@@ -85,28 +79,33 @@ const syncAllLabel = computed(() => {
           :source="source"
           :syncing="data.syncingSource === source.id || data.syncingSource === 'all'"
           :disabled="data.syncStatus === 'running' && data.syncingSource !== source.id && data.syncingSource !== 'all'"
-          :show-sync-button="!needsGogConnect(source.id) && !needsEpicConnect(source.id)"
+          :show-sync-button="
+            !(source.id === 'gog' && gogState.needsConnect) &&
+            !(source.id === 'epic_games' && epicState.needsConnect)
+          "
           @sync="data.triggerSync($event)"
         >
-          <OAuthConnectFlow
-            v-if="needsGogConnect(source.id)"
-            :auth-url="data.gogStatus.authUrl"
-            expected-origin="https://login.gog.com"
-            :connect-message="data.gogConnectMessage"
-            help-text="Paste the redirect URL after logging in:"
-            service-name="GOG Account"
-            @submit="data.submitGogCode($event)"
-          />
-          <OAuthConnectFlow
-            v-else-if="needsEpicConnect(source.id)"
-            :auth-url="data.epicStatus.authUrl"
-            expected-origin="https://www.epicgames.com"
-            :connect-message="data.epicConnectMessage"
-            help-text="Paste the authorization code from the JSON response:"
-            service-name="Epic Games"
-            @submit="data.submitEpicCode($event)"
-          />
-          <template v-else-if="showGogDisconnect(source.id)">
+          <template v-if="source.id === 'gog' && gogState.needsConnect">
+            <OAuthConnectFlow
+              :auth-url="data.gogStatus.authUrl"
+              expected-origin="https://login.gog.com"
+              :connect-message="data.gogConnectMessage"
+              help-text="Paste the redirect URL after logging in:"
+              service-name="GOG Account"
+              @submit="data.submitGogCode($event)"
+            />
+          </template>
+          <template v-else-if="source.id === 'epic_games' && epicState.needsConnect">
+            <OAuthConnectFlow
+              :auth-url="data.epicStatus.authUrl"
+              expected-origin="https://www.epicgames.com"
+              :connect-message="data.epicConnectMessage"
+              help-text="Paste the authorization code from the JSON response:"
+              service-name="Epic Games"
+              @submit="data.submitEpicCode($event)"
+            />
+          </template>
+          <template v-else-if="source.id === 'gog' && gogState.showDisconnect">
             <p
               v-if="data.gogConnectMessage"
               class="sr-only"
@@ -114,12 +113,13 @@ const syncAllLabel = computed(() => {
             >{{ data.gogConnectMessage }}</p>
             <button
               type="button"
-              class="btn btn-ghost btn-small"
+              class="btn btn-danger disconnect-btn"
               :disabled="data.syncStatus === 'running'"
+              aria-label="Disconnect GOG"
               @click="data.disconnectGog()"
-            >Disconnect GOG</button>
+            >Disconnect</button>
           </template>
-          <template v-else-if="showEpicDisconnect(source.id)">
+          <template v-else-if="source.id === 'epic_games' && epicState.showDisconnect">
             <p
               v-if="data.epicConnectMessage"
               class="sr-only"
@@ -127,10 +127,11 @@ const syncAllLabel = computed(() => {
             >{{ data.epicConnectMessage }}</p>
             <button
               type="button"
-              class="btn btn-ghost btn-small"
+              class="btn btn-danger disconnect-btn"
               :disabled="data.syncStatus === 'running'"
+              aria-label="Disconnect Epic Games"
               @click="data.disconnectEpic()"
-            >Disconnect Epic Games</button>
+            >Disconnect</button>
           </template>
         </SyncSourceCard>
         <div v-if="data.syncSources.length > 1" class="sync-card">
@@ -148,3 +149,14 @@ const syncAllLabel = computed(() => {
     <EnrichmentCard />
   </div>
 </template>
+
+<style scoped>
+/* .btn is display:inline-flex, so the Sync button would otherwise sit next
+   to the Disconnect button on the same line. Force a block break so they
+   stack with spacing — separating the destructive action from Sync also
+   makes misclicks less likely. */
+.disconnect-btn {
+  display: flex;
+  margin: 0 auto var(--space-3);
+}
+</style>

--- a/resources/js/stores/data.test.ts
+++ b/resources/js/stores/data.test.ts
@@ -288,7 +288,7 @@ describe('useDataStore', () => {
     await store.disconnectGog()
 
     expect(mockDelete).toHaveBeenCalledWith('/gog/token')
-    expect(store.gogConnectMessage).toContain('Disconnected')
+    expect(store.gogConnectMessage).toBe('Disconnected. You can reconnect below.')
     expect(store.gogStatus.connected).toBe(false)
   })
 
@@ -304,24 +304,86 @@ describe('useDataStore', () => {
     await store.disconnectEpic()
 
     expect(mockDelete).toHaveBeenCalledWith('/epic/token')
-    expect(store.epicConnectMessage).toContain('Disconnected')
+    expect(store.epicConnectMessage).toBe('Disconnected. You can reconnect below.')
     expect(store.epicStatus.connected).toBe(false)
   })
 
-  it('disconnectGog surfaces API error in the connect message', async () => {
+  it('disconnectGog surfaces API error and does not reload sync sources', async () => {
     mockDelete.mockRejectedValue(new ApiError(500, 'Internal Server Error'))
 
     const store = useDataStore()
     await store.disconnectGog()
 
     expect(store.gogConnectMessage).toBe('Error: server returned 500')
+    // Reload must only run on success — otherwise a failed disconnect
+    // triggers a spurious status fetch that itself may error.
+    expect(mockGet).not.toHaveBeenCalled()
+    expect(mockPost).not.toHaveBeenCalled()
   })
 
-  it('disconnectEpic surfaces API error in the connect message', async () => {
+  it('disconnectEpic surfaces API error and does not reload sync sources', async () => {
     mockDelete.mockRejectedValue(new ApiError(500, 'Internal Server Error'))
 
     const store = useDataStore()
     await store.disconnectEpic()
+
+    expect(store.epicConnectMessage).toBe('Error: server returned 500')
+    expect(mockGet).not.toHaveBeenCalled()
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('disconnectGog surfaces generic error with fallback message', async () => {
+    mockDelete.mockRejectedValue(new Error('network timeout'))
+
+    const store = useDataStore()
+    await store.disconnectGog()
+
+    expect(store.gogConnectMessage).toBe('Error: disconnect failed')
+    expect(mockGet).not.toHaveBeenCalled()
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('disconnectEpic surfaces generic error with fallback message', async () => {
+    mockDelete.mockRejectedValue(new Error('network timeout'))
+
+    const store = useDataStore()
+    await store.disconnectEpic()
+
+    expect(store.epicConnectMessage).toBe('Error: disconnect failed')
+    expect(mockGet).not.toHaveBeenCalled()
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('disconnectGog sets in-progress message before awaiting DELETE', async () => {
+    let rejectDelete: (err: Error) => void = () => {}
+    mockDelete.mockImplementation(
+      () => new Promise((_, reject) => { rejectDelete = reject })
+    )
+
+    const store = useDataStore()
+    const pending = store.disconnectGog()
+    // Synchronous assignment must land before the promise resolves so the
+    // aria-live region announces activity immediately.
+    expect(store.gogConnectMessage).toBe('Disconnecting GOG...')
+
+    rejectDelete(new ApiError(500, 'Internal Server Error'))
+    await pending
+
+    expect(store.gogConnectMessage).toBe('Error: server returned 500')
+  })
+
+  it('disconnectEpic sets in-progress message before awaiting DELETE', async () => {
+    let rejectDelete: (err: Error) => void = () => {}
+    mockDelete.mockImplementation(
+      () => new Promise((_, reject) => { rejectDelete = reject })
+    )
+
+    const store = useDataStore()
+    const pending = store.disconnectEpic()
+    expect(store.epicConnectMessage).toBe('Disconnecting Epic Games...')
+
+    rejectDelete(new ApiError(500, 'Internal Server Error'))
+    await pending
 
     expect(store.epicConnectMessage).toBe('Error: server returned 500')
   })

--- a/resources/js/stores/data.test.ts
+++ b/resources/js/stores/data.test.ts
@@ -5,6 +5,7 @@ import { ApiError } from '@/composables/useApi'
 
 const mockGet = vi.fn()
 const mockPost = vi.fn()
+const mockDelete = vi.fn()
 
 vi.mock('@/composables/useApi', () => ({
   ApiError: class ApiError extends Error {
@@ -18,7 +19,7 @@ vi.mock('@/composables/useApi', () => ({
     post: (...args: unknown[]) => mockPost(...args),
     put: vi.fn(),
     patch: vi.fn(),
-    delete: vi.fn(),
+    delete: (...args: unknown[]) => mockDelete(...args),
     raw: vi.fn(),
   }),
 }))
@@ -29,6 +30,7 @@ describe('useDataStore', () => {
     vi.useFakeTimers()
     mockGet.mockReset()
     mockPost.mockReset()
+    mockDelete.mockReset()
   })
 
   afterEach(() => {
@@ -272,5 +274,55 @@ describe('useDataStore', () => {
 
     expect(store.enrichmentStats).toEqual(stats)
     expect(store.enrichmentEnabled).toBe(true)
+  })
+
+  it('disconnectGog calls DELETE /gog/token and reloads sync sources', async () => {
+    mockDelete.mockResolvedValue({})
+    mockPost.mockResolvedValue({})
+    mockGet
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ enabled: true, connected: false, auth_url: 'https://gog.com/auth' })
+      .mockResolvedValueOnce({ enabled: false, connected: false })
+
+    const store = useDataStore()
+    await store.disconnectGog()
+
+    expect(mockDelete).toHaveBeenCalledWith('/gog/token')
+    expect(store.gogConnectMessage).toContain('Disconnected')
+    expect(store.gogStatus.connected).toBe(false)
+  })
+
+  it('disconnectEpic calls DELETE /epic/token and reloads sync sources', async () => {
+    mockDelete.mockResolvedValue({})
+    mockPost.mockResolvedValue({})
+    mockGet
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ enabled: false, connected: false })
+      .mockResolvedValueOnce({ enabled: true, connected: false, auth_url: 'https://epicgames.com/auth' })
+
+    const store = useDataStore()
+    await store.disconnectEpic()
+
+    expect(mockDelete).toHaveBeenCalledWith('/epic/token')
+    expect(store.epicConnectMessage).toContain('Disconnected')
+    expect(store.epicStatus.connected).toBe(false)
+  })
+
+  it('disconnectGog surfaces API error in the connect message', async () => {
+    mockDelete.mockRejectedValue(new ApiError(500, 'Internal Server Error'))
+
+    const store = useDataStore()
+    await store.disconnectGog()
+
+    expect(store.gogConnectMessage).toBe('Error: server returned 500')
+  })
+
+  it('disconnectEpic surfaces API error in the connect message', async () => {
+    mockDelete.mockRejectedValue(new ApiError(500, 'Internal Server Error'))
+
+    const store = useDataStore()
+    await store.disconnectEpic()
+
+    expect(store.epicConnectMessage).toBe('Error: server returned 500')
   })
 })

--- a/resources/js/stores/data.ts
+++ b/resources/js/stores/data.ts
@@ -177,6 +177,38 @@ export const useDataStore = defineStore('data', () => {
     }
   }
 
+  async function disconnectGog() {
+    gogConnectMessage.value = 'Disconnecting GOG...'
+    try {
+      // DELETE /api/gog/token runs the credential delete synchronously and
+      // only returns 200 once the row is gone, so loadSyncSources reads
+      // the post-delete state immediately — no setTimeout needed.
+      await api.delete('/gog/token')
+      gogConnectMessage.value = 'Disconnected. You can reconnect below.'
+      await loadSyncSources()
+    } catch (err) {
+      console.error('GOG disconnect failed:', err)
+      gogConnectMessage.value = err instanceof ApiError
+        ? `Error: server returned ${err.status}`
+        : 'Error: disconnect failed'
+    }
+  }
+
+  async function disconnectEpic() {
+    epicConnectMessage.value = 'Disconnecting Epic Games...'
+    try {
+      // DELETE /api/epic/token is synchronous (see disconnectGog comment).
+      await api.delete('/epic/token')
+      epicConnectMessage.value = 'Disconnected. You can reconnect below.'
+      await loadSyncSources()
+    } catch (err) {
+      console.error('Epic disconnect failed:', err)
+      epicConnectMessage.value = err instanceof ApiError
+        ? `Error: server returned ${err.status}`
+        : 'Error: disconnect failed'
+    }
+  }
+
   // Enrichment actions
   async function loadEnrichmentStats() {
     const app = useAppStore()
@@ -283,6 +315,8 @@ export const useDataStore = defineStore('data', () => {
     checkSyncStatus,
     submitGogCode,
     submitEpicCode,
+    disconnectGog,
+    disconnectEpic,
     loadEnrichmentStats,
     startEnrichment,
     stopEnrichment,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1,14 +1,20 @@
 """CLI commands."""
 
+from __future__ import annotations  # noqa: I001
+
 import importlib.metadata
 import json
+import logging
 import time
+import webbrowser
 from pathlib import Path
 
 import click
 from tabulate import tabulate
 
 from src.cli.config import get_feature_flags
+from src.conversation.engine import ConversationEngine
+from src.conversation.profile import ProfileGenerator
 from src.enrichment.manager import EnrichmentManager
 from src.ingestion.sync import execute_sync
 from src.models.content import (
@@ -24,8 +30,27 @@ from src.recommendations.preference_interpreter import (
 )
 from src.recommendations.scorers import SCORER_NAME_MAP
 from src.storage.credential_migration import migrate_config_credentials
+from src.utils.item_serialization import item_to_dict
+from src.web.epic_auth import (
+    exchange_code_for_tokens as exchange_epic_code,
+    extract_code_from_input as extract_epic_code,
+    get_epic_auth_url,
+    has_epic_token,
+    is_epic_enabled,
+    save_epic_token,
+)
 from src.web.export import export_items_csv, export_items_json
+from src.web.gog_auth import (
+    exchange_code_for_tokens as exchange_gog_code,
+    extract_code_from_input as extract_gog_code,
+    get_gog_auth_url,
+    has_gog_token,
+    is_gog_enabled,
+    save_gog_token,
+)
 from src.web.sync_sources import resolve_inputs, validate_source_config
+
+logger = logging.getLogger(__name__)
 
 
 @click.command()
@@ -38,35 +63,51 @@ from src.web.sync_sources import resolve_inputs, validate_source_config
 )
 @click.pass_context
 def status(ctx: click.Context, output_format: str) -> None:
-    """Show system health, component readiness, and feature flags."""
+    """Show system health, component readiness, and feature flags.
+
+    Mirrors the web API GET /api/status StatusResponse shape.
+    """
     version = importlib.metadata.version("recommendinator")
     config = ctx.obj["config"]
+    flags = get_feature_flags(config)
+    ai_enabled = flags["ai_enabled"]
 
-    # Component readiness
+    # Component readiness (keys and AI-gating match web API)
     components = {
         "engine": ctx.obj.get("engine") is not None,
         "storage": ctx.obj.get("storage") is not None,
-        "embedding_gen": ctx.obj.get("embedding_gen") is not None,
-        "llm_client": ctx.obj.get("llm_client") is not None,
+        "embedding_generator": (
+            ctx.obj.get("embedding_gen") is not None if ai_enabled else True
+        ),
     }
 
-    # Feature flags
-    flags = get_feature_flags(config)
+    # Features (key set matches web FeaturesStatus exactly)
+    features = {
+        "ai_enabled": ai_enabled,
+        "embeddings_enabled": flags["embeddings_enabled"],
+        "llm_reasoning_enabled": flags["llm_reasoning_enabled"],
+    }
 
-    # Max recommendation count
     rec_config = config.get("recommendations", {})
-    max_count = rec_config.get("max_count", 20)
+    recommendations_config = {
+        "max_count": rec_config.get("max_count", 20),
+        "default_count": rec_config.get("default_count", 5),
+    }
+
+    all_ready = all(components.values())
+    status_str = "ready" if all_ready else "initializing"
 
     if output_format == "json":
         output = {
+            "status": status_str,
             "version": version,
             "components": components,
-            "features": flags,
-            "recommendations": {"max_count": max_count},
+            "features": features,
+            "recommendations_config": recommendations_config,
         }
         click.echo(json.dumps(output, indent=2))
     else:
-        click.echo(f"\nRecommendinator v{version}\n")
+        click.echo(f"\nRecommendinator v{version} ({status_str})\n")
 
         click.echo("Components:")
         for name, ready in components.items():
@@ -74,11 +115,14 @@ def status(ctx: click.Context, output_format: str) -> None:
             click.echo(f"  {name}: {label}")
 
         click.echo("\nFeatures:")
-        for name, enabled in flags.items():
+        for name, enabled in features.items():
             label = "enabled" if enabled else "disabled"
             click.echo(f"  {name}: {label}")
 
-        click.echo(f"\nMax recommendations: {max_count}")
+        click.echo(
+            f"\nRecommendations: max={recommendations_config['max_count']}, "
+            f"default={recommendations_config['default_count']}"
+        )
 
 
 @click.command()
@@ -91,9 +135,9 @@ def status(ctx: click.Context, output_format: str) -> None:
 )
 @click.option(
     "--count",
-    type=click.IntRange(min=1, max=20),
+    type=click.IntRange(min=1),
     default=5,
-    help="Number of recommendations to generate (1-20)",
+    help="Number of recommendations to generate (capped by config 'recommendations.max_count').",
 )
 @click.option(
     "--format",
@@ -103,9 +147,9 @@ def status(ctx: click.Context, output_format: str) -> None:
     help="Output format",
 )
 @click.option(
-    "--use-llm",
-    is_flag=True,
-    help="Use LLM for enhanced recommendation reasoning",
+    "--use-llm/--no-use-llm",
+    default=True,
+    help="Use LLM for enhanced recommendation reasoning (default: enabled).",
 )
 @click.option(
     "--user",
@@ -126,6 +170,15 @@ def recommend(
     """Get personalized recommendations."""
     content_type = ContentType.from_string(content_type_str)
 
+    # Enforce config-driven max_count (matches web API /api/recommendations).
+    max_count = ctx.obj["config"].get("recommendations", {}).get("max_count", 20)
+    if count > max_count:
+        click.echo(
+            f"Error: --count {count} exceeds configured max_count={max_count}.",
+            err=True,
+        )
+        raise click.Abort()
+
     engine = ctx.obj["engine"]
     storage = ctx.obj["storage"]
 
@@ -143,26 +196,33 @@ def recommend(
         )
 
         if not recommendations:
-            click.echo(
-                "No recommendations available. Recommendations are based on items "
-                "you haven't consumed yet — try adding new items to your "
-                "wishlist or library."
-            )
+            if output_format == "json":
+                # Emit an empty JSON array (matches web GET /api/recommendations).
+                click.echo(json.dumps([]))
+            else:
+                click.echo(
+                    "No recommendations available. Recommendations are based "
+                    "on items you haven't consumed yet — try adding new items "
+                    "to your wishlist or library."
+                )
             return
 
         if output_format == "json":
-            # JSON output
+            # JSON output matches web API RecommendationResponse shape
             output = []
             for rec in recommendations:
                 item = rec["item"]
                 output.append(
                     {
+                        "db_id": item.db_id,
                         "title": item.title,
                         "author": item.author,
                         "score": rec["score"],
                         "similarity_score": rec["similarity_score"],
                         "preference_score": rec["preference_score"],
                         "reasoning": rec["reasoning"],
+                        "llm_reasoning": rec.get("llm_reasoning"),
+                        "score_breakdown": rec.get("score_breakdown", {}),
                     }
                 )
             click.echo(json.dumps(output, indent=2))
@@ -745,6 +805,11 @@ def enrichment() -> None:
     help="Content type to enrich (default: all types)",
 )
 @click.option(
+    "--retry-not-found",
+    is_flag=True,
+    help="Re-process items previously marked as not_found (matches web API).",
+)
+@click.option(
     "--user",
     "user_id",
     type=int,
@@ -753,7 +818,10 @@ def enrichment() -> None:
 )
 @click.pass_context
 def enrichment_start(
-    ctx: click.Context, content_type_str: str | None, user_id: int
+    ctx: click.Context,
+    content_type_str: str | None,
+    retry_not_found: bool,
+    user_id: int,
 ) -> None:
     """Start background metadata enrichment.
 
@@ -780,7 +848,11 @@ def enrichment_start(
 
     manager = EnrichmentManager(storage, config)
 
-    if not manager.start_enrichment(content_type=content_type, user_id=user_id):
+    if not manager.start_enrichment(
+        content_type=content_type,
+        user_id=user_id,
+        include_not_found=retry_not_found,
+    ):
         click.echo("Enrichment job is already running.", err=True)
         raise click.Abort()
 
@@ -847,14 +919,19 @@ def enrichment_start(
 @click.pass_context
 def enrichment_status(ctx: click.Context, user_id: int, output_format: str) -> None:
     """Show enrichment statistics."""
+    config = ctx.obj["config"]
     storage = ctx.obj["storage"]
 
-    stats = storage.get_enrichment_stats(user_id=user_id)
+    raw_stats = storage.get_enrichment_stats(user_id=user_id)
+    enrichment_enabled = config.get("enrichment", {}).get("enabled", False)
+    # Shape matches web API EnrichmentStatsResponse
+    stats = {"enabled": enrichment_enabled, **raw_stats}
 
     if output_format == "json":
         click.echo(json.dumps(stats, indent=2))
     else:
-        click.echo("Enrichment Statistics:")
+        enabled_label = "enabled" if stats["enabled"] else "disabled"
+        click.echo(f"Enrichment Statistics ({enabled_label}):")
         click.echo(f"  Total items: {stats['total']}")
         click.echo(f"  Enriched: {stats['enriched']}")
         click.echo(f"  Pending: {stats['pending']}")
@@ -964,7 +1041,7 @@ def library() -> None:
     "--status",
     "status_str",
     type=click.Choice(
-        ["unread", "currently_consuming", "completed", "abandoned"],
+        ["unread", "currently_consuming", "completed"],
         case_sensitive=False,
     ),
     default=None,
@@ -984,8 +1061,18 @@ def library() -> None:
     is_flag=True,
     help="Include ignored items",
 )
-@click.option("--limit", type=int, default=None, help="Max items to return")
-@click.option("--offset", type=int, default=0, help="Items to skip")
+@click.option(
+    "--limit",
+    type=click.IntRange(min=1, max=200),
+    default=50,
+    help="Max items to return (1-200, default 50, matches web API)",
+)
+@click.option(
+    "--offset",
+    type=click.IntRange(min=0),
+    default=0,
+    help="Items to skip (for pagination)",
+)
 @click.option(
     "--format",
     "output_format",
@@ -1030,39 +1117,30 @@ def library_list(
         offset=offset,
     )
 
+    if output_format == "json":
+        # Always emit a JSON array, even when empty (matches web GET /api/items).
+        output = [item_to_dict(item) for item in items]
+        click.echo(json.dumps(output, indent=2))
+        return
+
     if not items:
         click.echo("No items found.")
         return
 
-    if output_format == "json":
-        output = [
-            {
-                "db_id": item.db_id,
-                "title": item.title,
-                "author": item.author,
-                "content_type": get_enum_value(item.content_type),
-                "status": get_enum_value(item.status),
-                "rating": item.rating,
-                "ignored": bool(item.ignored),
-            }
-            for item in items
-        ]
-        click.echo(json.dumps(output, indent=2))
-    else:
-        table_data = []
-        for item in items:
-            table_data.append(
-                [
-                    item.db_id,
-                    item.title,
-                    item.author or "N/A",
-                    get_enum_value(item.content_type),
-                    get_enum_value(item.status),
-                    item.rating or "N/A",
-                ]
-            )
-        headers = ["ID", "Title", "Author", "Type", "Status", "Rating"]
-        click.echo(tabulate(table_data, headers=headers, tablefmt="grid"))
+    table_data = []
+    for item in items:
+        table_data.append(
+            [
+                item.db_id,
+                item.title,
+                item.author or "N/A",
+                get_enum_value(item.content_type),
+                get_enum_value(item.status),
+                "N/A" if item.rating is None else item.rating,
+            ]
+        )
+    headers = ["ID", "Title", "Author", "Type", "Status", "Rating"]
+    click.echo(tabulate(table_data, headers=headers, tablefmt="grid"))
 
 
 @library.command("show")
@@ -1094,27 +1172,14 @@ def library_show(
         raise click.Abort()
 
     if output_format == "json":
-        output = {
-            "db_id": item.db_id,
-            "title": item.title,
-            "author": item.author,
-            "content_type": get_enum_value(item.content_type),
-            "status": get_enum_value(item.status),
-            "rating": item.rating,
-            "review": item.review,
-            "date_completed": (
-                item.date_completed.isoformat() if item.date_completed else None
-            ),
-            "ignored": bool(item.ignored),
-        }
-        click.echo(json.dumps(output, indent=2))
+        click.echo(json.dumps(item_to_dict(item), indent=2))
     else:
         table_data = [
             ["Title", item.title],
             ["Author", item.author or "N/A"],
             ["Type", get_enum_value(item.content_type)],
             ["Status", get_enum_value(item.status)],
-            ["Rating", item.rating or "N/A"],
+            ["Rating", "N/A" if item.rating is None else item.rating],
             ["Review", item.review or "N/A"],
             [
                 "Date Completed",
@@ -1131,7 +1196,7 @@ def library_show(
     "--status",
     "status_str",
     type=click.Choice(
-        ["unread", "currently_consuming", "completed", "abandoned"],
+        ["unread", "currently_consuming", "completed"],
         case_sensitive=False,
     ),
     default=None,
@@ -1167,6 +1232,19 @@ def library_edit(
     user_id: int,
 ) -> None:
     """Edit an item's status, rating, or review."""
+    if (
+        status_str is None
+        and rating is None
+        and review is None
+        and seasons_watched is None
+    ):
+        click.echo(
+            "Error: Provide at least one of --status, --rating, --review, "
+            "--seasons-watched.",
+            err=True,
+        )
+        raise click.Abort()
+
     storage = ctx.obj["storage"]
 
     # Look up the item to get current status if not provided
@@ -1179,7 +1257,14 @@ def library_edit(
 
     parsed_seasons: list[int] | None = None
     if seasons_watched is not None:
-        parsed_seasons = [int(s.strip()) for s in seasons_watched.split(",")]
+        try:
+            parsed_seasons = [int(s.strip()) for s in seasons_watched.split(",")]
+        except ValueError:
+            click.echo(
+                "Error: --seasons-watched must be comma-separated integers (e.g. 1,2,3).",
+                err=True,
+            )
+            raise click.Abort() from None
 
     updated = storage.update_item_from_ui(
         db_id=item_id,
@@ -1296,3 +1381,558 @@ def library_export(
         click.echo(f"Exported {len(items)} items to {output_path}")
     else:
         click.echo(data, nl=False)
+
+
+# ---------------------------------------------------------------------------
+# Auth command group
+# ---------------------------------------------------------------------------
+
+# Maps CLI --source name to the internal storage source_id. The CLI accepts
+# "epic" for brevity but credentials are stored under "epic_games" to match
+# the plugin source identifier used across ingestion and storage.
+_SOURCE_ID_MAP = {"gog": "gog", "epic": "epic_games"}
+
+
+@click.group()
+def auth() -> None:
+    """Manage authentication for data sources."""
+
+
+@auth.command("status")
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def auth_status(ctx: click.Context, user_id: int) -> None:
+    """Show authentication status for OAuth sources."""
+    config = ctx.obj["config"]
+    storage = ctx.obj["storage"]
+
+    found = False
+    if is_gog_enabled(config):
+        found = True
+        connected = has_gog_token(config, storage=storage, user_id=user_id)
+        click.echo(f"  gog: {'connected' if connected else 'not connected'}")
+    if is_epic_enabled(config):
+        found = True
+        connected = has_epic_token(config, storage=storage, user_id=user_id)
+        click.echo(f"  epic: {'connected' if connected else 'not connected'}")
+
+    if not found:
+        click.echo("No OAuth sources are enabled in config.")
+
+
+@auth.command("connect")
+@click.option(
+    "--source",
+    type=click.Choice(["gog", "epic"], case_sensitive=False),
+    required=True,
+    help="Source to authenticate",
+)
+@click.option("--no-browser", is_flag=True, help="Don't open browser automatically")
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def auth_connect(
+    ctx: click.Context, source: str, no_browser: bool, user_id: int
+) -> None:
+    """Connect an OAuth source by authenticating in browser."""
+    config = ctx.obj["config"]
+    storage = ctx.obj["storage"]
+
+    if source == "gog":
+        is_enabled_fn, get_auth_url_fn = is_gog_enabled, get_gog_auth_url
+        extract_code_fn = extract_gog_code
+        exchange_fn, save_fn = exchange_gog_code, save_gog_token
+    else:
+        is_enabled_fn, get_auth_url_fn = is_epic_enabled, get_epic_auth_url
+        extract_code_fn = extract_epic_code
+        exchange_fn, save_fn = exchange_epic_code, save_epic_token
+
+    if not is_enabled_fn(config):
+        click.echo(f"Error: {source} is not enabled in config.", err=True)
+        raise click.Abort()
+
+    auth_url = get_auth_url_fn()
+    click.echo(f"\nAuthorize {source} at:\n  {auth_url}\n")
+
+    if not no_browser:
+        try:
+            webbrowser.open(auth_url)
+            click.echo("(Browser opened automatically)")
+        except Exception:
+            logger.debug("Failed to open browser", exc_info=True)
+            click.echo("(Could not open browser — copy the URL above)")
+
+    code = click.prompt("Paste the authorization code or redirect URL")
+
+    try:
+        extracted_code = extract_code_fn(code.strip())
+        tokens = exchange_fn(extracted_code)
+        refresh_token = tokens.get("refresh_token")
+        if not (refresh_token and refresh_token.strip()):
+            click.echo("Error: No refresh token received.", err=True)
+            raise click.Abort()
+        save_fn(storage, refresh_token.strip(), user_id=user_id)
+        click.echo(f"\n{source} connected successfully.")
+    except click.Abort:
+        raise
+    except Exception:
+        logger.error("Failed to connect %s", source, exc_info=True)
+        click.echo(
+            f"Error: Failed to connect {source}. Check logs for details.", err=True
+        )
+        raise click.Abort() from None
+
+
+@auth.command("disconnect")
+@click.option(
+    "--source",
+    type=click.Choice(["gog", "epic"], case_sensitive=False),
+    required=True,
+    help="Source to disconnect",
+)
+@click.option("--yes", is_flag=True, help="Skip confirmation")
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def auth_disconnect(ctx: click.Context, source: str, yes: bool, user_id: int) -> None:
+    """Disconnect an OAuth source by removing stored credentials."""
+    storage = ctx.obj["storage"]
+
+    if not yes:
+        if not click.confirm(f"Disconnect {source} for user {user_id}?"):
+            click.echo("Aborted.")
+            return
+
+    source_id = _SOURCE_ID_MAP[source]
+
+    deleted = storage.delete_credential(user_id, source_id, "refresh_token")
+    if deleted:
+        click.echo(f"{source} disconnected.")
+    else:
+        # Mirror DELETE /api/{source}/token which returns 404 when missing.
+        click.echo(f"No active {source} connection found.", err=True)
+        raise click.Abort()
+
+
+# ---------------------------------------------------------------------------
+# Memory command group
+# ---------------------------------------------------------------------------
+
+
+@click.group()
+def memory() -> None:
+    """Manage core memories for personalization."""
+
+
+@memory.command("list")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format",
+)
+@click.option(
+    "--include-inactive",
+    is_flag=True,
+    help="Include inactive memories (default shows active only, matches web API)",
+)
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def memory_list(
+    ctx: click.Context, output_format: str, include_inactive: bool, user_id: int
+) -> None:
+    """List core memories."""
+    storage = ctx.obj["storage"]
+    memories = storage.get_core_memories(user_id, active_only=not include_inactive)
+
+    if output_format == "json":
+        # JSON output matches web API MemoryResponse shape
+        output = [
+            {
+                "id": mem["id"],
+                "memory_text": mem["memory_text"],
+                "memory_type": mem["memory_type"],
+                "confidence": mem["confidence"],
+                "is_active": mem["is_active"],
+                "source": mem["source"],
+                "created_at": mem["created_at"],
+            }
+            for mem in memories
+        ]
+        click.echo(json.dumps(output, indent=2, default=str))
+    else:
+        if not memories:
+            click.echo("No memories found.")
+            return
+        table_data = []
+        for mem in memories:
+            text = mem["memory_text"]
+            table_data.append(
+                [
+                    mem["id"],
+                    text[:60] + ("..." if len(text) > 60 else ""),
+                    mem["memory_type"],
+                    "active" if mem["is_active"] else "inactive",
+                ]
+            )
+        headers = ["ID", "Text", "Type", "Status"]
+        click.echo(tabulate(table_data, headers=headers, tablefmt="grid"))
+
+
+@memory.command("add")
+@click.option("--text", required=True, help="Memory text")
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def memory_add(ctx: click.Context, text: str, user_id: int) -> None:
+    """Add a new core memory."""
+    storage = ctx.obj["storage"]
+    memory_id = storage.save_core_memory(
+        user_id=user_id,
+        memory_text=text,
+        memory_type="user_stated",
+        source="manual",
+        confidence=1.0,
+    )
+    click.echo(f"Memory {memory_id} created.")
+
+
+@memory.command("edit")
+@click.option("--id", "memory_id", type=int, required=True, help="Memory ID")
+@click.option("--text", default=None, help="New memory text")
+@click.option(
+    "--active/--inactive",
+    "is_active",
+    default=None,
+    help="Set active status (matches web API PUT /api/memories/{id})",
+)
+@click.pass_context
+def memory_edit(
+    ctx: click.Context, memory_id: int, text: str | None, is_active: bool | None
+) -> None:
+    """Edit a core memory's text and/or active status."""
+    if text is None and is_active is None:
+        click.echo("Error: specify --text and/or --active/--inactive.", err=True)
+        raise click.Abort()
+    storage = ctx.obj["storage"]
+    updated = storage.update_core_memory(
+        memory_id=memory_id, memory_text=text, is_active=is_active
+    )
+    if updated:
+        click.echo(f"Memory {memory_id} updated.")
+    else:
+        click.echo(f"Error: Memory {memory_id} not found.", err=True)
+        raise click.Abort()
+
+
+@memory.command("toggle")
+@click.option("--id", "memory_id", type=int, required=True, help="Memory ID")
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def memory_toggle(ctx: click.Context, memory_id: int, user_id: int) -> None:
+    """Toggle a memory between active and inactive."""
+    storage = ctx.obj["storage"]
+    all_memories = storage.get_core_memories(user_id, active_only=False)
+    target = next((m for m in all_memories if m["id"] == memory_id), None)
+    if target is None:
+        click.echo(f"Error: Memory {memory_id} not found.", err=True)
+        raise click.Abort()
+
+    new_active = not target["is_active"]
+    storage.update_core_memory(memory_id=memory_id, is_active=new_active)
+    state = "active" if new_active else "inactive"
+    click.echo(f"Memory {memory_id} is now {state}.")
+
+
+@memory.command("delete")
+@click.option("--id", "memory_id", type=int, required=True, help="Memory ID")
+@click.option("--yes", is_flag=True, help="Skip confirmation")
+@click.pass_context
+def memory_delete(ctx: click.Context, memory_id: int, yes: bool) -> None:
+    """Delete a core memory."""
+    if not yes:
+        if not click.confirm(f"Delete memory {memory_id}?"):
+            click.echo("Aborted.")
+            return
+
+    storage = ctx.obj["storage"]
+    deleted = storage.delete_core_memory(memory_id=memory_id)
+    if deleted:
+        click.echo(f"Memory {memory_id} deleted.")
+    else:
+        click.echo(f"Error: Memory {memory_id} not found.", err=True)
+        raise click.Abort()
+
+
+# ---------------------------------------------------------------------------
+# Profile command group
+# ---------------------------------------------------------------------------
+
+
+@click.group()
+def profile() -> None:
+    """View and manage your preference profile."""
+
+
+@profile.command("show")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    default="table",
+    help="Output format",
+)
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def profile_show(ctx: click.Context, output_format: str, user_id: int) -> None:
+    """Show your preference profile."""
+    storage = ctx.obj["storage"]
+    profile_record = storage.get_preference_profile(user_id)
+
+    if profile_record is None:
+        if output_format == "json":
+            # Emit an empty ProfileResponse (matches web GET /api/profile).
+            click.echo(
+                json.dumps(
+                    {
+                        "user_id": user_id,
+                        "genre_affinities": {},
+                        "theme_preferences": [],
+                        "anti_preferences": [],
+                        "cross_media_patterns": [],
+                        "generated_at": None,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            click.echo(
+                "No profile generated yet. Run 'profile regenerate' to create one."
+            )
+        return
+
+    # StorageManager.get_preference_profile wraps the profile in a record:
+    # {"id", "user_id", "profile": {...actual data...}, "generated_at"}.
+    # Unwrap to match the web API's ProfileResponse shape.
+    profile = profile_record.get("profile", {})
+    generated_at = profile_record.get("generated_at")
+
+    if output_format == "json":
+        # Explicit field extraction matches web ProfileResponse exactly,
+        # immune to any extra keys the stored profile blob may contain.
+        output = {
+            "user_id": profile_record.get("user_id"),
+            "genre_affinities": profile.get("genre_affinities", {}),
+            "theme_preferences": profile.get("theme_preferences", []),
+            "anti_preferences": profile.get("anti_preferences", []),
+            "cross_media_patterns": profile.get("cross_media_patterns", []),
+            "generated_at": generated_at,
+        }
+        click.echo(json.dumps(output, indent=2, default=str))
+    else:
+        affinities = profile.get("genre_affinities", {})
+        if affinities:
+            click.echo("Genre Affinities:")
+            for genre, score in sorted(
+                affinities.items(), key=lambda pair: pair[1], reverse=True
+            ):
+                click.echo(f"  {genre}: {score:.1f}")
+
+        themes = profile.get("theme_preferences", [])
+        if themes:
+            click.echo("\nTheme Preferences:")
+            for theme in themes:
+                click.echo(f"  - {theme}")
+
+        anti_preferences = profile.get("anti_preferences", [])
+        if anti_preferences:
+            click.echo("\nAnti-Preferences:")
+            for preference in anti_preferences:
+                click.echo(f"  - {preference}")
+
+        patterns = profile.get("cross_media_patterns", [])
+        if patterns:
+            click.echo("\nCross-Media Patterns:")
+            for pattern in patterns:
+                click.echo(f"  - {pattern}")
+
+        if generated_at:
+            click.echo(f"\nGenerated: {generated_at}")
+
+
+@profile.command("regenerate")
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def profile_regenerate(ctx: click.Context, user_id: int) -> None:
+    """Regenerate your preference profile from library data."""
+    storage = ctx.obj["storage"]
+
+    click.echo("Analyzing your library...")
+    generator = ProfileGenerator(storage)
+    profile_result = generator.regenerate_and_save(user_id)
+    click.echo(
+        f"Profile regenerated with {len(profile_result.genre_affinities)} genre affinities."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chat command group
+# ---------------------------------------------------------------------------
+
+
+@click.group()
+def chat() -> None:
+    """Chat with the recommendation AI."""
+
+
+def _require_ai(ctx: click.Context) -> None:
+    """Check that AI features are enabled."""
+    if not get_feature_flags(ctx.obj["config"])["ai_enabled"]:
+        click.echo(
+            "Error: AI features are not enabled. "
+            "Set features.ai_enabled: true in config.",
+            err=True,
+        )
+        raise click.Abort()
+
+
+def _create_conversation_engine(ctx: click.Context) -> ConversationEngine:
+    """Create a ConversationEngine from CLI context."""
+    storage = ctx.obj["storage"]
+    ollama_client = ctx.obj["llm_client"]
+    engine = ctx.obj["engine"]
+    return ConversationEngine(
+        storage_manager=storage,
+        ollama_client=ollama_client,
+        recommendation_engine=engine,
+    )
+
+
+@chat.command("start")
+@click.option(
+    "--type",
+    "content_type_str",
+    type=click.Choice(["book", "movie", "tv_show", "video_game"], case_sensitive=False),
+    default=None,
+    help="Filter suggestions to a content type",
+)
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def chat_start(ctx: click.Context, content_type_str: str | None, user_id: int) -> None:
+    """Start an interactive chat session."""
+    _require_ai(ctx)
+    conv_engine = _create_conversation_engine(ctx)
+    content_type = (
+        ContentType.from_string(content_type_str) if content_type_str else None
+    )
+
+    click.echo("Chat session started. Type your message, or Ctrl+D to exit.\n")
+
+    while True:
+        try:
+            click.echo("You> ", nl=False)
+            message = input()
+        except (EOFError, KeyboardInterrupt):
+            click.echo("\nChat session ended.")
+            break
+
+        if not message.strip():
+            continue
+
+        try:
+            response = conv_engine.process_message_sync(
+                user_id=user_id, message=message, content_type=content_type
+            )
+            click.echo(f"\nAssistant: {response}\n")
+        except Exception:
+            logger.error("Chat message processing failed", exc_info=True)
+            click.echo(
+                "\nError: Could not process message. Please try again.\n",
+                err=True,
+            )
+
+
+@chat.command("send")
+@click.option("--message", required=True, help="Message to send")
+@click.option(
+    "--type",
+    "content_type_str",
+    type=click.Choice(["book", "movie", "tv_show", "video_game"], case_sensitive=False),
+    default=None,
+    help="Filter suggestions to a content type",
+)
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def chat_send(
+    ctx: click.Context, message: str, content_type_str: str | None, user_id: int
+) -> None:
+    """Send a single message and get a response."""
+    _require_ai(ctx)
+    conv_engine = _create_conversation_engine(ctx)
+    content_type = (
+        ContentType.from_string(content_type_str) if content_type_str else None
+    )
+
+    try:
+        response = conv_engine.process_message_sync(
+            user_id=user_id, message=message, content_type=content_type
+        )
+        click.echo(response)
+    except Exception:
+        logger.error("Chat send failed", exc_info=True)
+        click.echo("Error: Failed to get a response. Check logs for details.", err=True)
+        raise click.Abort() from None
+
+
+@chat.command("history")
+@click.option(
+    "--limit",
+    type=click.IntRange(min=1, max=200),
+    default=50,
+    help="Number of messages to show (1-200, matches web API)",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format",
+)
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def chat_history(
+    ctx: click.Context, limit: int, output_format: str, user_id: int
+) -> None:
+    """Show recent conversation history."""
+    storage = ctx.obj["storage"]
+    messages = storage.get_conversation_history(user_id, limit=limit)
+
+    if output_format == "json":
+        # JSON output matches web API MessageResponse shape
+        output = [
+            {
+                "id": msg["id"],
+                "role": msg["role"],
+                "content": msg["content"],
+                "tool_calls": msg.get("tool_calls"),
+                "created_at": msg["created_at"],
+            }
+            for msg in messages
+        ]
+        click.echo(json.dumps(output, indent=2, default=str))
+    else:
+        if not messages:
+            click.echo("No conversation history.")
+            return
+        for msg in messages:
+            role = msg["role"].capitalize()
+            content = msg["content"]
+            click.echo(f"{role}: {content}\n")
+
+
+@chat.command("reset")
+@click.option("--user", "user_id", type=int, default=1, help="User ID")
+@click.pass_context
+def chat_reset(ctx: click.Context, user_id: int) -> None:
+    """Clear conversation history (preserves memories)."""
+    storage = ctx.obj["storage"]
+    count = storage.clear_conversation_history(user_id)
+    click.echo(f"Cleared {count} message(s). Core memories preserved.")

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -3,6 +3,7 @@
 import importlib.metadata
 import json
 import time
+from pathlib import Path
 
 import click
 from tabulate import tabulate
@@ -10,7 +11,12 @@ from tabulate import tabulate
 from src.cli.config import get_feature_flags
 from src.enrichment.manager import EnrichmentManager
 from src.ingestion.sync import execute_sync
-from src.models.content import ConsumptionStatus, ContentItem, ContentType
+from src.models.content import (
+    ConsumptionStatus,
+    ContentItem,
+    ContentType,
+    get_enum_value,
+)
 from src.models.user_preferences import UserPreferenceConfig
 from src.recommendations.preference_interpreter import (
     LLMPreferenceInterpreter,
@@ -18,6 +24,7 @@ from src.recommendations.preference_interpreter import (
 )
 from src.recommendations.scorers import SCORER_NAME_MAP
 from src.storage.credential_migration import migrate_config_credentials
+from src.web.export import export_items_csv, export_items_json
 from src.web.sync_sources import resolve_inputs, validate_source_config
 
 
@@ -933,3 +940,359 @@ def enrichment_reset(
     )
 
     click.echo(f"Reset enrichment status for {count} item(s).")
+
+
+# ---------------------------------------------------------------------------
+# Library command group
+# ---------------------------------------------------------------------------
+
+
+@click.group()
+def library() -> None:
+    """Manage your content library."""
+
+
+@library.command("list")
+@click.option(
+    "--type",
+    "content_type_str",
+    type=click.Choice(["book", "movie", "tv_show", "video_game"], case_sensitive=False),
+    default=None,
+    help="Filter by content type",
+)
+@click.option(
+    "--status",
+    "status_str",
+    type=click.Choice(
+        ["unread", "currently_consuming", "completed", "abandoned"],
+        case_sensitive=False,
+    ),
+    default=None,
+    help="Filter by consumption status",
+)
+@click.option(
+    "--sort",
+    "sort_by",
+    type=click.Choice(
+        ["title", "updated_at", "rating", "created_at"], case_sensitive=False
+    ),
+    default="title",
+    help="Sort order (default: title)",
+)
+@click.option(
+    "--show-ignored",
+    is_flag=True,
+    help="Include ignored items",
+)
+@click.option("--limit", type=int, default=None, help="Max items to return")
+@click.option("--offset", type=int, default=0, help="Items to skip")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    default="table",
+    help="Output format",
+)
+@click.option(
+    "--user",
+    "user_id",
+    type=int,
+    default=1,
+    help="User ID",
+)
+@click.pass_context
+def library_list(
+    ctx: click.Context,
+    content_type_str: str | None,
+    status_str: str | None,
+    sort_by: str,
+    show_ignored: bool,
+    limit: int | None,
+    offset: int,
+    output_format: str,
+    user_id: int,
+) -> None:
+    """List library items with filters."""
+    storage = ctx.obj["storage"]
+
+    content_type = (
+        ContentType.from_string(content_type_str) if content_type_str else None
+    )
+    consumption_status = ConsumptionStatus(status_str) if status_str else None
+
+    items: list[ContentItem] = storage.get_content_items(
+        user_id=user_id,
+        content_type=content_type,
+        status=consumption_status,
+        sort_by=sort_by,
+        include_ignored=show_ignored,
+        limit=limit,
+        offset=offset,
+    )
+
+    if not items:
+        click.echo("No items found.")
+        return
+
+    if output_format == "json":
+        output = [
+            {
+                "db_id": item.db_id,
+                "title": item.title,
+                "author": item.author,
+                "content_type": get_enum_value(item.content_type),
+                "status": get_enum_value(item.status),
+                "rating": item.rating,
+                "ignored": bool(item.ignored),
+            }
+            for item in items
+        ]
+        click.echo(json.dumps(output, indent=2))
+    else:
+        table_data = []
+        for item in items:
+            table_data.append(
+                [
+                    item.db_id,
+                    item.title,
+                    item.author or "N/A",
+                    get_enum_value(item.content_type),
+                    get_enum_value(item.status),
+                    item.rating or "N/A",
+                ]
+            )
+        headers = ["ID", "Title", "Author", "Type", "Status", "Rating"]
+        click.echo(tabulate(table_data, headers=headers, tablefmt="grid"))
+
+
+@library.command("show")
+@click.option("--id", "item_id", type=int, required=True, help="Item database ID")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    default="table",
+    help="Output format",
+)
+@click.option(
+    "--user",
+    "user_id",
+    type=int,
+    default=1,
+    help="User ID",
+)
+@click.pass_context
+def library_show(
+    ctx: click.Context, item_id: int, output_format: str, user_id: int
+) -> None:
+    """Show details of a single library item."""
+    storage = ctx.obj["storage"]
+
+    item = storage.get_content_item(item_id, user_id=user_id)
+    if item is None:
+        click.echo(f"Error: Item {item_id} not found.", err=True)
+        raise click.Abort()
+
+    if output_format == "json":
+        output = {
+            "db_id": item.db_id,
+            "title": item.title,
+            "author": item.author,
+            "content_type": get_enum_value(item.content_type),
+            "status": get_enum_value(item.status),
+            "rating": item.rating,
+            "review": item.review,
+            "date_completed": (
+                item.date_completed.isoformat() if item.date_completed else None
+            ),
+            "ignored": bool(item.ignored),
+        }
+        click.echo(json.dumps(output, indent=2))
+    else:
+        table_data = [
+            ["Title", item.title],
+            ["Author", item.author or "N/A"],
+            ["Type", get_enum_value(item.content_type)],
+            ["Status", get_enum_value(item.status)],
+            ["Rating", item.rating or "N/A"],
+            ["Review", item.review or "N/A"],
+            [
+                "Date Completed",
+                item.date_completed.isoformat() if item.date_completed else "N/A",
+            ],
+            ["Ignored", "Yes" if item.ignored else "No"],
+        ]
+        click.echo(tabulate(table_data, tablefmt="grid"))
+
+
+@library.command("edit")
+@click.option("--id", "item_id", type=int, required=True, help="Item database ID")
+@click.option(
+    "--status",
+    "status_str",
+    type=click.Choice(
+        ["unread", "currently_consuming", "completed", "abandoned"],
+        case_sensitive=False,
+    ),
+    default=None,
+    help="New status",
+)
+@click.option(
+    "--rating",
+    type=click.IntRange(min=1, max=5),
+    default=None,
+    help="New rating (1-5)",
+)
+@click.option("--review", default=None, help="New review text")
+@click.option(
+    "--seasons-watched",
+    default=None,
+    help="Comma-separated list of watched season numbers",
+)
+@click.option(
+    "--user",
+    "user_id",
+    type=int,
+    default=1,
+    help="User ID",
+)
+@click.pass_context
+def library_edit(
+    ctx: click.Context,
+    item_id: int,
+    status_str: str | None,
+    rating: int | None,
+    review: str | None,
+    seasons_watched: str | None,
+    user_id: int,
+) -> None:
+    """Edit an item's status, rating, or review."""
+    storage = ctx.obj["storage"]
+
+    # Look up the item to get current status if not provided
+    item = storage.get_content_item(item_id, user_id=user_id)
+    if item is None:
+        click.echo(f"Error: Item {item_id} not found.", err=True)
+        raise click.Abort()
+
+    effective_status = status_str if status_str else get_enum_value(item.status)
+
+    parsed_seasons: list[int] | None = None
+    if seasons_watched is not None:
+        parsed_seasons = [int(s.strip()) for s in seasons_watched.split(",")]
+
+    updated = storage.update_item_from_ui(
+        db_id=item_id,
+        status=effective_status,
+        rating=rating,
+        review=review,
+        seasons_watched=parsed_seasons,
+        user_id=user_id,
+    )
+
+    if updated:
+        click.echo(f"Updated item {item_id} ({item.title}).")
+    else:
+        click.echo(f"Error: Failed to update item {item_id}.", err=True)
+        raise click.Abort()
+
+
+@library.command("ignore")
+@click.option("--id", "item_id", type=int, required=True, help="Item database ID")
+@click.option(
+    "--user",
+    "user_id",
+    type=int,
+    default=1,
+    help="User ID",
+)
+@click.pass_context
+def library_ignore(ctx: click.Context, item_id: int, user_id: int) -> None:
+    """Ignore an item (exclude from recommendations)."""
+    storage = ctx.obj["storage"]
+
+    if storage.set_item_ignored(db_id=item_id, ignored=True, user_id=user_id):
+        click.echo(f"Ignored item {item_id}.")
+    else:
+        click.echo(f"Error: Item {item_id} not found.", err=True)
+        raise click.Abort()
+
+
+@library.command("unignore")
+@click.option("--id", "item_id", type=int, required=True, help="Item database ID")
+@click.option(
+    "--user",
+    "user_id",
+    type=int,
+    default=1,
+    help="User ID",
+)
+@click.pass_context
+def library_unignore(ctx: click.Context, item_id: int, user_id: int) -> None:
+    """Unignore an item (include in recommendations again)."""
+    storage = ctx.obj["storage"]
+
+    if storage.set_item_ignored(db_id=item_id, ignored=False, user_id=user_id):
+        click.echo(f"Unignored item {item_id}.")
+    else:
+        click.echo(f"Error: Item {item_id} not found.", err=True)
+        raise click.Abort()
+
+
+@library.command("export")
+@click.option(
+    "--type",
+    "content_type_str",
+    type=click.Choice(["book", "movie", "tv_show", "video_game"], case_sensitive=False),
+    required=True,
+    help="Content type to export",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    default="csv",
+    help="Export format (default: csv)",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(path_type=Path),  # type: ignore[type-var]
+    default=None,
+    help="Output file path (default: stdout)",
+)
+@click.option(
+    "--user",
+    "user_id",
+    type=int,
+    default=1,
+    help="User ID",
+)
+@click.pass_context
+def library_export(
+    ctx: click.Context,
+    content_type_str: str,
+    output_format: str,
+    output_path: Path | None,
+    user_id: int,
+) -> None:
+    """Export library items as CSV or JSON."""
+    storage = ctx.obj["storage"]
+    content_type = ContentType.from_string(content_type_str)
+
+    items: list[ContentItem] = storage.get_content_items(
+        user_id=user_id,
+        content_type=content_type,
+        include_ignored=True,
+    )
+
+    if output_format == "json":
+        data = export_items_json(items, content_type)
+    else:
+        data = export_items_csv(items, content_type)
+
+    if output_path:
+        output_path.write_text(data, encoding="utf-8")
+        click.echo(f"Exported {len(items)} items to {output_path}")
+    else:
+        click.echo(data, nl=False)

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1,5 +1,6 @@
 """CLI commands."""
 
+import importlib.metadata
 import json
 import time
 
@@ -18,6 +19,59 @@ from src.recommendations.preference_interpreter import (
 from src.recommendations.scorers import SCORER_NAME_MAP
 from src.storage.credential_migration import migrate_config_credentials
 from src.web.sync_sources import resolve_inputs, validate_source_config
+
+
+@click.command()
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    default="table",
+    help="Output format",
+)
+@click.pass_context
+def status(ctx: click.Context, output_format: str) -> None:
+    """Show system health, component readiness, and feature flags."""
+    version = importlib.metadata.version("recommendinator")
+    config = ctx.obj["config"]
+
+    # Component readiness
+    components = {
+        "engine": ctx.obj.get("engine") is not None,
+        "storage": ctx.obj.get("storage") is not None,
+        "embedding_gen": ctx.obj.get("embedding_gen") is not None,
+        "llm_client": ctx.obj.get("llm_client") is not None,
+    }
+
+    # Feature flags
+    flags = get_feature_flags(config)
+
+    # Max recommendation count
+    rec_config = config.get("recommendations", {})
+    max_count = rec_config.get("max_count", 20)
+
+    if output_format == "json":
+        output = {
+            "version": version,
+            "components": components,
+            "features": flags,
+            "recommendations": {"max_count": max_count},
+        }
+        click.echo(json.dumps(output, indent=2))
+    else:
+        click.echo(f"\nRecommendinator v{version}\n")
+
+        click.echo("Components:")
+        for name, ready in components.items():
+            label = "ready" if ready else "not available"
+            click.echo(f"  {name}: {label}")
+
+        click.echo("\nFeatures:")
+        for name, enabled in flags.items():
+            label = "enabled" if enabled else "disabled"
+            click.echo(f"  {name}: {label}")
+
+        click.echo(f"\nMax recommendations: {max_count}")
 
 
 @click.command()

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -6,10 +6,14 @@ from pathlib import Path
 import click
 
 from src.cli.commands import (
+    auth,
+    chat,
     complete,
     enrichment,
     library,
+    memory,
     preferences,
+    profile,
     recommend,
     status,
     update,
@@ -59,6 +63,8 @@ def cli(ctx: click.Context, config: Path | None) -> None:
 
 
 # Register commands
+cli.add_command(auth)
+cli.add_command(chat)
 cli.add_command(status)
 cli.add_command(recommend)
 cli.add_command(update)
@@ -66,6 +72,8 @@ cli.add_command(complete)
 cli.add_command(preferences)
 cli.add_command(enrichment)
 cli.add_command(library)
+cli.add_command(memory)
+cli.add_command(profile)
 
 
 if __name__ == "__main__":

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -5,7 +5,14 @@ from pathlib import Path
 
 import click
 
-from src.cli.commands import complete, enrichment, preferences, recommend, update
+from src.cli.commands import (
+    complete,
+    enrichment,
+    preferences,
+    recommend,
+    status,
+    update,
+)
 from src.cli.config import (
     create_llm_components,
     create_recommendation_engine,
@@ -51,6 +58,7 @@ def cli(ctx: click.Context, config: Path | None) -> None:
 
 
 # Register commands
+cli.add_command(status)
 cli.add_command(recommend)
 cli.add_command(update)
 cli.add_command(complete)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -8,6 +8,7 @@ import click
 from src.cli.commands import (
     complete,
     enrichment,
+    library,
     preferences,
     recommend,
     status,
@@ -64,6 +65,7 @@ cli.add_command(update)
 cli.add_command(complete)
 cli.add_command(preferences)
 cli.add_command(enrichment)
+cli.add_command(library)
 
 
 if __name__ == "__main__":

--- a/src/ingestion/plugin_base.py
+++ b/src/ingestion/plugin_base.py
@@ -1,12 +1,17 @@
 """Abstract base class for source plugins."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from src.models.config_field import ConfigField
 from src.models.content import ContentItem, ContentType
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
 
 # Progress callback: (items_processed, total_items, current_item) -> None
 # - items_processed: Number of items fetched/processed so far
@@ -91,7 +96,12 @@ class SourcePlugin(ABC):
                     ),
                 ]
 
-            def validate_config(self, config: dict[str, Any]) -> list[str]:
+            def validate_config(
+                self,
+                config: dict[str, Any],
+                storage: StorageManager | None = None,
+                user_id: int = 1,
+            ) -> list[str]:
                 errors = []
                 if not config.get("path"):
                     errors.append("'path' is required")
@@ -191,14 +201,26 @@ class SourcePlugin(ABC):
         ...
 
     @abstractmethod
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: StorageManager | None = None,
+        user_id: int = 1,
+    ) -> list[str]:
         """Validate plugin configuration.
 
         Checks that all required fields are present and valid.
         Called before fetch() to catch configuration errors early.
 
+        When *storage* is provided, sensitive fields (e.g. OAuth tokens)
+        that are missing from *config* are looked up in the encrypted
+        credential database.  If the credential exists there, the field
+        is treated as satisfied.
+
         Args:
             config: Plugin-specific configuration dict from inputs.<name>
+            storage: Optional StorageManager for DB credential lookup.
+            user_id: User ID for credential lookup (default 1).
 
         Returns:
             List of validation error messages (empty list if valid)

--- a/src/ingestion/sources/arr_base.py
+++ b/src/ingestion/sources/arr_base.py
@@ -92,7 +92,12 @@ class ArrPlugin(SourcePlugin):
             ),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: Any = None,
+        user_id: int = 1,
+    ) -> list[str]:
         errors = []
         if not config.get("api_key", "").strip():
             errors.append(

--- a/src/ingestion/sources/arr_base.py
+++ b/src/ingestion/sources/arr_base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from abc import abstractmethod
 from collections.abc import Iterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests
 
@@ -17,6 +17,9 @@ from src.ingestion.plugin_base import (
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
 from src.utils.progress import log_progress
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +98,7 @@ class ArrPlugin(SourcePlugin):
     def validate_config(
         self,
         config: dict[str, Any],
-        storage: Any = None,
+        storage: StorageManager | None = None,
         user_id: int = 1,
     ) -> list[str]:
         errors = []

--- a/src/ingestion/sources/epic_games.py
+++ b/src/ingestion/sources/epic_games.py
@@ -26,10 +26,10 @@ from src.ingestion.plugin_base import (
     SourcePlugin,
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
+from src.utils.progress import log_progress
 
 if TYPE_CHECKING:
     from src.storage.manager import StorageManager
-from src.utils.progress import log_progress
 
 logger = logging.getLogger(__name__)
 

--- a/src/ingestion/sources/epic_games.py
+++ b/src/ingestion/sources/epic_games.py
@@ -9,9 +9,11 @@ Limitations:
 - No playtime data (Epic doesn't expose it).
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Iterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from legendary.api.egs import EPCAPI
 from legendary.models.exceptions import InvalidCredentialsError
@@ -24,6 +26,9 @@ from src.ingestion.plugin_base import (
     SourcePlugin,
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
 from src.utils.progress import log_progress
 
 logger = logging.getLogger(__name__)
@@ -239,9 +244,20 @@ class EpicGamesPlugin(SourcePlugin):
             ),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: StorageManager | None = None,
+        user_id: int = 1,
+    ) -> list[str]:
         errors: list[str] = []
         if not (config.get("refresh_token") or "").strip():
+            # Check DB credentials before rejecting
+            source_id = config.get("_source_id", self.name)
+            if storage is not None:
+                db_creds = storage.get_credentials_for_source(user_id, source_id)
+                if (db_creds.get("refresh_token") or "").strip():
+                    return errors
             errors.append(
                 "'refresh_token' is required. "
                 "Connect your Epic Games account via the web UI "

--- a/src/ingestion/sources/generic_csv.py
+++ b/src/ingestion/sources/generic_csv.py
@@ -216,7 +216,12 @@ class CsvImportPlugin(SourcePlugin):
             ),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: Any = None,
+        user_id: int = 1,
+    ) -> list[str]:
         errors = []
 
         path = config.get("path")

--- a/src/ingestion/sources/generic_csv.py
+++ b/src/ingestion/sources/generic_csv.py
@@ -1,11 +1,13 @@
 """Generic CSV import plugin with prescriptive templates per content type."""
 
+from __future__ import annotations
+
 import csv
 import logging
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from src.ingestion.plugin_base import (
     ConfigField,
@@ -14,6 +16,9 @@ from src.ingestion.plugin_base import (
     SourcePlugin,
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
 
 logger = logging.getLogger(__name__)
 
@@ -219,7 +224,7 @@ class CsvImportPlugin(SourcePlugin):
     def validate_config(
         self,
         config: dict[str, Any],
-        storage: Any = None,
+        storage: StorageManager | None = None,
         user_id: int = 1,
     ) -> list[str]:
         errors = []

--- a/src/ingestion/sources/generic_json.py
+++ b/src/ingestion/sources/generic_json.py
@@ -78,7 +78,12 @@ class JsonImportPlugin(SourcePlugin):
             ),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: Any = None,
+        user_id: int = 1,
+    ) -> list[str]:
         errors = []
 
         path = config.get("path")

--- a/src/ingestion/sources/generic_json.py
+++ b/src/ingestion/sources/generic_json.py
@@ -1,11 +1,13 @@
 """Generic JSON/JSONL import plugin with prescriptive templates per content type."""
 
+from __future__ import annotations
+
 import json
 import logging
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from src.ingestion.plugin_base import (
     ConfigField,
@@ -21,6 +23,9 @@ from src.ingestion.sources.generic_csv import (
     parse_seasons_watched,
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +86,7 @@ class JsonImportPlugin(SourcePlugin):
     def validate_config(
         self,
         config: dict[str, Any],
-        storage: Any = None,
+        storage: StorageManager | None = None,
         user_id: int = 1,
     ) -> list[str]:
         errors = []

--- a/src/ingestion/sources/gog.py
+++ b/src/ingestion/sources/gog.py
@@ -17,10 +17,10 @@ from src.ingestion.plugin_base import (
     SourcePlugin,
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
+from src.utils.progress import log_progress
 
 if TYPE_CHECKING:
     from src.storage.manager import StorageManager
-from src.utils.progress import log_progress
 
 logger = logging.getLogger(__name__)
 

--- a/src/ingestion/sources/gog.py
+++ b/src/ingestion/sources/gog.py
@@ -1,9 +1,11 @@
 """GOG.com integration plugin for fetching user game library and wishlist."""
 
+from __future__ import annotations
+
 import logging
 import time
 from collections.abc import Callable, Iterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests
 
@@ -15,6 +17,9 @@ from src.ingestion.plugin_base import (
     SourcePlugin,
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
 from src.utils.progress import log_progress
 
 logger = logging.getLogger(__name__)
@@ -305,9 +310,20 @@ class GogPlugin(SourcePlugin):
             ),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
-        errors = []
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: StorageManager | None = None,
+        user_id: int = 1,
+    ) -> list[str]:
+        errors: list[str] = []
         if not (config.get("refresh_token") or "").strip():
+            # Check DB credentials before rejecting
+            source_id = config.get("_source_id", self.name)
+            if storage is not None:
+                db_creds = storage.get_credentials_for_source(user_id, source_id)
+                if (db_creds.get("refresh_token") or "").strip():
+                    return errors
             errors.append(
                 "'refresh_token' is required. "
                 "Use the web UI (Data tab) to connect your GOG account, "

--- a/src/ingestion/sources/goodreads.py
+++ b/src/ingestion/sources/goodreads.py
@@ -1,11 +1,13 @@
 """Goodreads CSV export plugin."""
 
+from __future__ import annotations
+
 import csv
 import logging
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from src.ingestion.plugin_base import (
     ConfigField,
@@ -14,6 +16,9 @@ from src.ingestion.plugin_base import (
     SourcePlugin,
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +69,7 @@ class GoodreadsPlugin(SourcePlugin):
     def validate_config(
         self,
         config: dict[str, Any],
-        storage: Any = None,
+        storage: StorageManager | None = None,
         user_id: int = 1,
     ) -> list[str]:
         errors = []

--- a/src/ingestion/sources/goodreads.py
+++ b/src/ingestion/sources/goodreads.py
@@ -61,7 +61,12 @@ class GoodreadsPlugin(SourcePlugin):
             ),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: Any = None,
+        user_id: int = 1,
+    ) -> list[str]:
         errors = []
         path = config.get("path")
         if not path:

--- a/src/ingestion/sources/markdown.py
+++ b/src/ingestion/sources/markdown.py
@@ -1,11 +1,13 @@
 """Markdown import plugin using a prescriptive list format per content type."""
 
+from __future__ import annotations
+
 import logging
 import re
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from src.ingestion.plugin_base import (
     ConfigField,
@@ -14,6 +16,9 @@ from src.ingestion.plugin_base import (
     SourcePlugin,
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +116,7 @@ class MarkdownImportPlugin(SourcePlugin):
     def validate_config(
         self,
         config: dict[str, Any],
-        storage: Any = None,
+        storage: StorageManager | None = None,
         user_id: int = 1,
     ) -> list[str]:
         errors = []

--- a/src/ingestion/sources/markdown.py
+++ b/src/ingestion/sources/markdown.py
@@ -108,7 +108,12 @@ class MarkdownImportPlugin(SourcePlugin):
             ),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: Any = None,
+        user_id: int = 1,
+    ) -> list[str]:
         errors = []
 
         path = config.get("path")

--- a/src/ingestion/sources/steam.py
+++ b/src/ingestion/sources/steam.py
@@ -1,9 +1,11 @@
 """Steam Web API integration plugin for fetching user game library."""
 
+from __future__ import annotations
+
 import logging
 import time
 from collections.abc import Callable, Iterator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests
 
@@ -15,6 +17,9 @@ from src.ingestion.plugin_base import (
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
 from src.utils.progress import log_progress
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
 
 logger = logging.getLogger(__name__)
 
@@ -251,7 +256,7 @@ class SteamPlugin(SourcePlugin):
     def validate_config(
         self,
         config: dict[str, Any],
-        storage: Any = None,
+        storage: StorageManager | None = None,
         user_id: int = 1,
     ) -> list[str]:
         errors = []

--- a/src/ingestion/sources/steam.py
+++ b/src/ingestion/sources/steam.py
@@ -248,7 +248,12 @@ class SteamPlugin(SourcePlugin):
             ),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: Any = None,
+        user_id: int = 1,
+    ) -> list[str]:
         errors = []
         if not (config.get("api_key") or "").strip():
             errors.append(

--- a/src/utils/item_serialization.py
+++ b/src/utils/item_serialization.py
@@ -1,0 +1,57 @@
+"""Shared serialization helpers for ContentItem.
+
+Used by both the CLI commands and the web API to guarantee identical
+JSON output shapes between the two interfaces. Any new field on the
+web ContentItemResponse must be added here so the CLI emits it too.
+"""
+
+from src.models.content import ContentItem, get_enum_value
+
+
+def extract_tv_season_fields(
+    item: ContentItem,
+) -> tuple[list[int] | None, int | None]:
+    """Extract seasons_watched and total_seasons from TV show metadata.
+
+    Returns (None, None) for non-TV items or when the metadata does not
+    contain the expected keys.
+    """
+    if get_enum_value(item.content_type) != "tv_show":
+        return None, None
+    metadata = item.metadata
+    seasons_watched = metadata.get("seasons_watched")
+    total_seasons: int | None = None
+    seasons_raw = metadata.get("seasons")
+    if seasons_raw is not None:
+        try:
+            total_seasons = int(seasons_raw)
+        except (ValueError, TypeError):
+            pass
+    return seasons_watched, total_seasons
+
+
+def item_to_dict(item: ContentItem) -> dict[str, object]:
+    """Serialize a ContentItem to the shared CLI/web field set.
+
+    The CLI emits this dict directly as JSON; the web API unpacks it
+    into a ContentItemResponse. Keeping the construction in one place
+    prevents field-set drift between the two interfaces.
+    """
+    seasons_watched, total_seasons = extract_tv_season_fields(item)
+    return {
+        "id": item.id,
+        "db_id": item.db_id,
+        "title": item.title,
+        "author": item.author,
+        "content_type": get_enum_value(item.content_type),
+        "status": get_enum_value(item.status),
+        "rating": item.rating,
+        "review": item.review,
+        "source": item.source,
+        "date_completed": (
+            item.date_completed.isoformat() if item.date_completed else None
+        ),
+        "ignored": bool(item.ignored),
+        "seasons_watched": seasons_watched,
+        "total_seasons": total_seasons,
+    }

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -22,6 +22,7 @@ from src.models.content import (
 )
 from src.models.user_preferences import UserPreferenceConfig
 from src.storage.manager import VALID_SORT_OPTIONS
+from src.utils.item_serialization import item_to_dict
 from src.utils.text import humanize_source_id
 from src.web.enrichment_manager import get_enrichment_manager
 from src.web.epic_auth import (
@@ -112,6 +113,7 @@ class ContentItemResponse(BaseModel):
     rating: int | None
     review: str | None
     source: str | None
+    date_completed: str | None = None
     ignored: bool = False
     seasons_watched: list[int] | None = None
     total_seasons: int | None = None
@@ -628,43 +630,8 @@ async def list_users() -> list[UserResponse]:
 
 
 def _item_to_response(item: "ContentItem") -> ContentItemResponse:
-    """Convert a ContentItem to a ContentItemResponse.
-
-    Extracts seasons_watched and total_seasons from TV show metadata.
-
-    Args:
-        item: ContentItem to convert.
-
-    Returns:
-        ContentItemResponse with all fields populated.
-    """
-    seasons_watched: list[int] | None = None
-    total_seasons: int | None = None
-    metadata = item.metadata
-
-    if get_enum_value(item.content_type) == "tv_show":
-        seasons_watched = metadata.get("seasons_watched")
-        seasons_raw = metadata.get("seasons")
-        if seasons_raw is not None:
-            try:
-                total_seasons = int(seasons_raw)
-            except (ValueError, TypeError):
-                pass
-
-    return ContentItemResponse(
-        id=item.id,
-        db_id=item.db_id,
-        title=item.title,
-        author=item.author,
-        content_type=get_enum_value(item.content_type),
-        status=get_enum_value(item.status),
-        rating=item.rating,
-        review=item.review,
-        source=item.source,
-        ignored=bool(item.ignored),
-        seasons_watched=seasons_watched,
-        total_seasons=total_seasons,
-    )
+    """Convert a ContentItem to a ContentItemResponse via the shared dict."""
+    return ContentItemResponse.model_validate(item_to_dict(item))
 
 
 @router.get("/items", response_model=list[ContentItemResponse])
@@ -1584,6 +1551,23 @@ async def exchange_gog_token(request: GogExchangeRequest) -> dict[str, Any]:
         ) from error
 
 
+@router.delete("/gog/token")
+async def disconnect_gog(user_id: int = Query(1, ge=1)) -> dict[str, Any]:
+    """Disconnect GOG by deleting the stored refresh token.
+
+    Mirrors the CLI `auth disconnect --source gog` command.
+    """
+    storage = get_storage()
+    if not storage:
+        raise HTTPException(status_code=500, detail="Storage not initialized")
+
+    deleted = storage.delete_credential(user_id, "gog", "refresh_token")
+    if not deleted:
+        raise HTTPException(status_code=404, detail="No active GOG connection found")
+    logger.info("Disconnected GOG account for user %s", user_id)
+    return {"success": True, "message": "GOG disconnected."}
+
+
 # ---------------------------------------------------------------------------
 # Epic Games OAuth endpoints
 # ---------------------------------------------------------------------------
@@ -1674,3 +1658,22 @@ async def exchange_epic_token(request: EpicExchangeRequest) -> dict[str, Any]:
             status_code=500,
             detail="Unexpected error during Epic Games authentication",
         ) from error
+
+
+@router.delete("/epic/token")
+async def disconnect_epic(user_id: int = Query(1, ge=1)) -> dict[str, Any]:
+    """Disconnect Epic Games by deleting the stored refresh token.
+
+    Mirrors the CLI `auth disconnect --source epic` command.
+    """
+    storage = get_storage()
+    if not storage:
+        raise HTTPException(status_code=500, detail="Storage not initialized")
+
+    deleted = storage.delete_credential(user_id, "epic_games", "refresh_token")
+    if not deleted:
+        raise HTTPException(
+            status_code=404, detail="No active Epic Games connection found"
+        )
+    logger.info("Disconnected Epic Games account for user %s", user_id)
+    return {"success": True, "message": "Epic Games disconnected."}

--- a/src/web/sync_manager.py
+++ b/src/web/sync_manager.py
@@ -159,17 +159,38 @@ class SyncManager:
         try:
             count = sync_function(job)
             with self._lock:
-                job.status = SyncStatus.COMPLETED
                 job.completed_at = datetime.now()
                 job.items_processed = count
-            logger.info("Sync completed for %s: %d items processed", job.source, count)
+                # A sync that produced zero items but logged errors is a
+                # failure, not a success — plugins like Epic Games catch
+                # their own exceptions and report them via add_error, and
+                # the UI banner branches on the status field.
+                if count == 0 and job.errors:
+                    job.status = SyncStatus.FAILED
+                    job.error_message = job.errors[0]
+                else:
+                    job.status = SyncStatus.COMPLETED
+                final_status = job.status
+                error_count = len(job.errors)
 
-            # Run completion callback if provided
-            if on_complete is not None:
-                try:
-                    on_complete()
-                except Exception as callback_error:
-                    logger.error("Sync on_complete callback failed: %s", callback_error)
+            if final_status == SyncStatus.COMPLETED:
+                logger.info(
+                    "Sync completed for %s: %d items processed", job.source, count
+                )
+                # Run completion callback only on true success
+                if on_complete is not None:
+                    try:
+                        on_complete()
+                    except Exception as callback_error:
+                        logger.error(
+                            "Sync on_complete callback failed: %s", callback_error
+                        )
+            else:
+                logger.warning(
+                    "Sync for %s produced no items; marking failed (%d errors)",
+                    job.source,
+                    error_count,
+                )
         except Exception:
             with self._lock:
                 job.status = SyncStatus.FAILED

--- a/src/web/sync_sources.py
+++ b/src/web/sync_sources.py
@@ -182,6 +182,7 @@ def validate_source_config(
     source_id: str,
     config: dict[str, Any],
     storage: StorageManager | None = None,
+    user_id: int = 1,
 ) -> list[str]:
     """Validate config for a sync source.
 
@@ -189,12 +190,15 @@ def validate_source_config(
         source_id: User-defined source key.
         config: Full application config.
         storage: Optional StorageManager for DB credential injection.
+        user_id: User ID for credential lookup (default 1).
 
     Returns:
         List of error messages (empty if valid).
     """
-    resolved = get_sync_handler(source_id, config, storage=storage)
+    resolved = get_sync_handler(source_id, config, storage=storage, user_id=user_id)
     if resolved is None:
         return [f"Unknown or disabled source: {source_id}"]
 
-    return resolved.plugin.validate_config(resolved.config)
+    return resolved.plugin.validate_config(
+        resolved.config, storage=storage, user_id=user_id
+    )

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,61 @@
+"""Shared fixtures and helpers for CLI tests."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from src.cli.main import cli
+from src.llm.embeddings import EmbeddingGenerator
+from src.llm.recommendations import RecommendationGenerator
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create CLI test runner."""
+    return CliRunner()
+
+
+def _cli_patches():
+    """Context manager stack for CLI patches."""
+    return (
+        patch("src.cli.main.load_config"),
+        patch("src.cli.main.create_storage_manager"),
+        patch("src.cli.main.create_llm_components"),
+        patch("src.cli.main.create_recommendation_engine"),
+    )
+
+
+def _invoke_with_mocks(
+    cli_runner: CliRunner,
+    args: list[str],
+    mock_storage: MagicMock,
+    config: dict | None = None,
+    input_text: str | None = None,
+    llm_client: MagicMock | None = None,
+) -> object:
+    """Invoke CLI with standard mock setup.
+
+    Args:
+        cli_runner: Click test runner
+        args: CLI arguments
+        mock_storage: Pre-configured storage mock
+        config: Config dict (default: empty)
+        input_text: Simulated stdin input
+        llm_client: Optional LLM client mock (default: None/AI disabled)
+    """
+    p_config, p_storage, p_llm, p_engine = _cli_patches()
+    with (
+        p_config as mock_load,
+        p_storage as mock_storage_fn,
+        p_llm as mock_llm,
+        p_engine,
+    ):
+        mock_load.return_value = config or {}
+        mock_storage_fn.return_value = mock_storage
+        mock_llm.return_value = (
+            llm_client,
+            MagicMock(spec=EmbeddingGenerator),
+            MagicMock(spec=RecommendationGenerator),
+        )
+        return cli_runner.invoke(cli, args, input=input_text)

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -1,0 +1,267 @@
+"""Tests for CLI auth commands."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from src.storage.manager import StorageManager
+
+from .conftest import _invoke_with_mocks
+
+
+class TestAuthStatus:
+    """Tests for auth status command."""
+
+    def test_auth_status_no_sources_enabled(self, cli_runner: CliRunner) -> None:
+        """Test auth status when no OAuth sources are enabled."""
+        mock_storage = MagicMock(spec=StorageManager)
+        with (
+            patch("src.cli.commands.is_gog_enabled", return_value=False),
+            patch("src.cli.commands.is_epic_enabled", return_value=False),
+        ):
+            result = _invoke_with_mocks(cli_runner, ["auth", "status"], mock_storage)
+
+        assert result.exit_code == 0
+        assert "No OAuth sources are enabled" in result.output
+
+    def test_auth_status_shows_sources(self, cli_runner: CliRunner) -> None:
+        """Test auth status lists available OAuth sources."""
+        mock_storage = MagicMock(spec=StorageManager)
+        config = {
+            "inputs": [
+                {"source": "gog", "enabled": True},
+                {"source": "epic_games", "enabled": True},
+            ],
+        }
+        with (
+            patch("src.cli.commands.is_gog_enabled", return_value=True),
+            patch("src.cli.commands.has_gog_token", return_value=True),
+            patch("src.cli.commands.is_epic_enabled", return_value=True),
+            patch("src.cli.commands.has_epic_token", return_value=False),
+        ):
+            result = _invoke_with_mocks(
+                cli_runner, ["auth", "status"], mock_storage, config=config
+            )
+
+        assert result.exit_code == 0
+        assert "gog: connected" in result.output
+        assert "epic: not connected" in result.output
+
+
+class TestAuthConnect:
+    """Tests for auth connect command."""
+
+    def test_connect_source_not_enabled(self, cli_runner: CliRunner) -> None:
+        """Test connecting a source that is not enabled in config."""
+        mock_storage = MagicMock(spec=StorageManager)
+        with patch("src.cli.commands.is_gog_enabled", return_value=False):
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["auth", "connect", "--source", "gog"],
+                mock_storage,
+            )
+
+        assert result.exit_code != 0
+        assert "not enabled in config" in result.output
+
+    def test_connect_gog(self, cli_runner: CliRunner) -> None:
+        """Test connecting GOG account."""
+        mock_storage = MagicMock(spec=StorageManager)
+        config = {"inputs": [{"source": "gog", "enabled": True}]}
+        # Auth codes must be >=20 chars to pass extract_code_from_input validation
+        auth_code = "test-auth-code-abc123xyz"
+        with (
+            patch("src.cli.commands.is_gog_enabled", return_value=True),
+            patch(
+                "src.cli.commands.get_gog_auth_url",
+                return_value="https://auth.gog.com/auth?client_id=test",
+            ),
+            patch(
+                "src.cli.commands.exchange_gog_code",
+                return_value={"refresh_token": "test-token"},
+            ),
+            patch("src.cli.commands.save_gog_token") as mock_save,
+            patch("webbrowser.open"),
+        ):
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["auth", "connect", "--source", "gog"],
+                mock_storage,
+                config=config,
+                input_text=f"{auth_code}\n",
+            )
+
+        assert result.exit_code == 0
+        assert "connected successfully" in result.output.lower()
+        mock_save.assert_called_once_with(mock_storage, "test-token", user_id=1)
+
+    def test_connect_gog_no_browser(self, cli_runner: CliRunner) -> None:
+        """Test --no-browser suppresses webbrowser.open."""
+        mock_storage = MagicMock(spec=StorageManager)
+        auth_code = "test-auth-code-abc123xyz"
+        with (
+            patch("src.cli.commands.is_gog_enabled", return_value=True),
+            patch(
+                "src.cli.commands.get_gog_auth_url",
+                return_value="https://auth.gog.com/auth?client_id=test",
+            ),
+            patch(
+                "src.cli.commands.exchange_gog_code",
+                return_value={"refresh_token": "test-token"},
+            ),
+            patch("src.cli.commands.save_gog_token"),
+            patch("webbrowser.open") as mock_open,
+        ):
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["auth", "connect", "--source", "gog", "--no-browser"],
+                mock_storage,
+                input_text=f"{auth_code}\n",
+            )
+
+        assert result.exit_code == 0
+        mock_open.assert_not_called()
+
+    def test_connect_exchange_fails(self, cli_runner: CliRunner) -> None:
+        """Test that connect handles exchange exceptions gracefully."""
+        mock_storage = MagicMock(spec=StorageManager)
+        auth_code = "test-auth-code-abc123xyz"
+        with (
+            patch("src.cli.commands.is_gog_enabled", return_value=True),
+            patch(
+                "src.cli.commands.get_gog_auth_url",
+                return_value="https://auth.gog.com",
+            ),
+            patch(
+                "src.cli.commands.exchange_gog_code",
+                side_effect=RuntimeError("network error"),
+            ),
+            patch("webbrowser.open"),
+        ):
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["auth", "connect", "--source", "gog"],
+                mock_storage,
+                input_text=f"{auth_code}\n",
+            )
+
+        assert result.exit_code != 0
+        assert "Failed to connect gog" in result.output
+
+    def test_connect_epic(self, cli_runner: CliRunner) -> None:
+        """Test connecting Epic account (exercises the Epic branch)."""
+        mock_storage = MagicMock(spec=StorageManager)
+        auth_code = "test-auth-code-abc123xyz"
+        with (
+            patch("src.cli.commands.is_epic_enabled", return_value=True),
+            patch(
+                "src.cli.commands.get_epic_auth_url",
+                return_value="https://www.epicgames.com/id/authorize",
+            ),
+            patch(
+                "src.cli.commands.exchange_epic_code",
+                return_value={"refresh_token": "epic-token"},
+            ),
+            patch("src.cli.commands.save_epic_token") as mock_save,
+            patch("webbrowser.open"),
+        ):
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["auth", "connect", "--source", "epic"],
+                mock_storage,
+                input_text=f"{auth_code}\n",
+            )
+
+        assert result.exit_code == 0
+        mock_save.assert_called_once_with(mock_storage, "epic-token", user_id=1)
+
+    def test_connect_no_refresh_token(self, cli_runner: CliRunner) -> None:
+        """Test that connect aborts when exchange returns no refresh token."""
+        mock_storage = MagicMock(spec=StorageManager)
+        auth_code = "test-auth-code-abc123xyz"
+        with (
+            patch("src.cli.commands.is_gog_enabled", return_value=True),
+            patch(
+                "src.cli.commands.get_gog_auth_url",
+                return_value="https://auth.gog.com",
+            ),
+            patch(
+                "src.cli.commands.exchange_gog_code",
+                return_value={"access_token": "only"},
+            ),
+            patch("webbrowser.open"),
+        ):
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["auth", "connect", "--source", "gog"],
+                mock_storage,
+                input_text=f"{auth_code}\n",
+            )
+
+        assert result.exit_code != 0
+        assert "No refresh token received" in result.output
+
+
+class TestAuthDisconnect:
+    """Tests for auth disconnect command."""
+
+    def test_disconnect_gog(self, cli_runner: CliRunner) -> None:
+        """Test disconnecting GOG account."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.delete_credential.return_value = True
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["auth", "disconnect", "--source", "gog", "--yes"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        assert "disconnected" in result.output.lower()
+        mock_storage.delete_credential.assert_called_once_with(
+            1, "gog", "refresh_token"
+        )
+
+    def test_disconnect_without_yes(self, cli_runner: CliRunner) -> None:
+        """Test aborting disconnect when user declines confirmation."""
+        mock_storage = MagicMock(spec=StorageManager)
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["auth", "disconnect", "--source", "gog"],
+            mock_storage,
+            input_text="n\n",
+        )
+
+        assert "Aborted" in result.output
+        mock_storage.delete_credential.assert_not_called()
+
+    def test_disconnect_epic(self, cli_runner: CliRunner) -> None:
+        """Test disconnecting Epic Games uses source_id 'epic_games'."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.delete_credential.return_value = True
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["auth", "disconnect", "--source", "epic", "--yes"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        mock_storage.delete_credential.assert_called_once_with(
+            1, "epic_games", "refresh_token"
+        )
+
+    def test_disconnect_no_active_connection(self, cli_runner: CliRunner) -> None:
+        """Disconnect exits non-zero when no credential existed to delete.
+
+        Mirrors the web `DELETE /api/{source}/token` 404 response — both
+        interfaces signal "nothing to disconnect" as an error, not success.
+        """
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.delete_credential.return_value = False
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["auth", "disconnect", "--source", "gog", "--yes"],
+            mock_storage,
+        )
+
+        assert result.exit_code != 0
+        assert "No active gog connection" in result.output

--- a/tests/cli/test_cli_chat.py
+++ b/tests/cli/test_cli_chat.py
@@ -1,0 +1,246 @@
+"""Tests for CLI chat commands."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from src.conversation.engine import ConversationEngine
+from src.models.content import ContentType
+from src.storage.manager import StorageManager
+
+from .conftest import _invoke_with_mocks
+
+_AI_CONFIG = {"features": {"ai_enabled": True}, "ollama": {}}
+
+
+class TestChatSend:
+    """Tests for chat send (single-shot) command."""
+
+    def test_send_message(self, cli_runner: CliRunner) -> None:
+        """Test sending a single message."""
+        mock_storage = MagicMock(spec=StorageManager)
+        with patch("src.cli.commands.ConversationEngine") as mock_engine_cls:
+            mock_engine = MagicMock(spec=ConversationEngine)
+            mock_engine.process_message_sync.return_value = (
+                "I recommend Dune by Frank Herbert!"
+            )
+            mock_engine_cls.return_value = mock_engine
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["chat", "send", "--message", "What should I read?"],
+                mock_storage,
+                config=_AI_CONFIG,
+                llm_client=MagicMock(),
+            )
+
+        assert result.exit_code == 0
+        assert "Dune" in result.output
+
+    def test_send_requires_ai(self, cli_runner: CliRunner) -> None:
+        """Test that chat requires AI to be enabled."""
+        mock_storage = MagicMock(spec=StorageManager)
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["chat", "send", "--message", "Hello"],
+            mock_storage,
+            config={"features": {"ai_enabled": False}},
+        )
+
+        assert result.exit_code != 0
+        assert "ai features are not enabled" in result.output.lower()
+
+    def test_send_engine_error(self, cli_runner: CliRunner) -> None:
+        """Test that chat send handles engine exceptions gracefully."""
+        mock_storage = MagicMock(spec=StorageManager)
+        with patch("src.cli.commands.ConversationEngine") as mock_engine_cls:
+            mock_engine = MagicMock(spec=ConversationEngine)
+            mock_engine.process_message_sync.side_effect = RuntimeError(
+                "model unavailable"
+            )
+            mock_engine_cls.return_value = mock_engine
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["chat", "send", "--message", "Hello"],
+                mock_storage,
+                config=_AI_CONFIG,
+                llm_client=MagicMock(),
+            )
+
+        assert result.exit_code != 0
+        assert "Failed to get a response" in result.output
+
+    def test_send_with_type_filter(self, cli_runner: CliRunner) -> None:
+        """Test that --type forwards a ContentType filter to the engine."""
+        mock_storage = MagicMock(spec=StorageManager)
+        with patch("src.cli.commands.ConversationEngine") as mock_engine_cls:
+            mock_engine = MagicMock(spec=ConversationEngine)
+            mock_engine.process_message_sync.return_value = "ok"
+            mock_engine_cls.return_value = mock_engine
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["chat", "send", "--message", "Hi", "--type", "book"],
+                mock_storage,
+                config=_AI_CONFIG,
+                llm_client=MagicMock(),
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_engine.process_message_sync.call_args[1]
+        assert call_kwargs["content_type"] == ContentType.BOOK
+
+
+class TestChatHistory:
+    """Tests for chat history command."""
+
+    def test_history_empty(self, cli_runner: CliRunner) -> None:
+        """Test displaying chat history when no messages exist."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_conversation_history.return_value = []
+        result = _invoke_with_mocks(cli_runner, ["chat", "history"], mock_storage)
+
+        assert result.exit_code == 0
+        assert "No conversation history." in result.output
+
+    def test_show_history(self, cli_runner: CliRunner) -> None:
+        """Test displaying chat history."""
+        history = [
+            {
+                "role": "user",
+                "content": "What should I read?",
+                "created_at": "2026-01-01T00:00:00",
+            },
+            {
+                "role": "assistant",
+                "content": "Try Dune!",
+                "created_at": "2026-01-01T00:00:01",
+            },
+        ]
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_conversation_history.return_value = history
+        result = _invoke_with_mocks(cli_runner, ["chat", "history"], mock_storage)
+
+        assert result.exit_code == 0
+        assert "What should I read?" in result.output
+        assert "Try Dune!" in result.output
+
+    def test_history_forwards_limit(self, cli_runner: CliRunner) -> None:
+        """--limit is forwarded to storage.get_conversation_history."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_conversation_history.return_value = []
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["chat", "history", "--limit", "25"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        mock_storage.get_conversation_history.assert_called_once_with(1, limit=25)
+
+    def test_history_json_empty(self, cli_runner: CliRunner) -> None:
+        """Empty history emits [] in JSON mode (matches web API shape)."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_conversation_history.return_value = []
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["chat", "history", "--format", "json"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == []
+
+    def test_history_json(self, cli_runner: CliRunner) -> None:
+        """Test chat history JSON output matches web API MessageResponse shape."""
+        history = [
+            {
+                "id": 1,
+                "user_id": 1,
+                "role": "user",
+                "content": "Hi",
+                "tool_calls": None,
+                "created_at": "2026-01-01T00:00:00",
+            },
+        ]
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_conversation_history.return_value = history
+        result = _invoke_with_mocks(
+            cli_runner, ["chat", "history", "--format", "json"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        # Field set matches web MessageResponse (no user_id)
+        assert set(parsed[0].keys()) == {
+            "id",
+            "role",
+            "content",
+            "tool_calls",
+            "created_at",
+        }
+        assert parsed[0]["content"] == "Hi"
+        assert parsed[0]["id"] == 1
+
+
+class TestChatReset:
+    """Tests for chat reset command."""
+
+    def test_reset_conversation(self, cli_runner: CliRunner) -> None:
+        """Test resetting conversation history."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.clear_conversation_history.return_value = 10
+        result = _invoke_with_mocks(cli_runner, ["chat", "reset"], mock_storage)
+
+        assert result.exit_code == 0
+        assert "Cleared 10 message(s)." in result.output
+
+
+class TestChatStart:
+    """Tests for chat start (REPL) command."""
+
+    def test_start_requires_ai(self, cli_runner: CliRunner) -> None:
+        """Test that chat start requires AI to be enabled."""
+        mock_storage = MagicMock(spec=StorageManager)
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["chat", "start"],
+            mock_storage,
+            config={"features": {"ai_enabled": False}},
+        )
+
+        assert result.exit_code != 0
+        assert "ai features are not enabled" in result.output.lower()
+
+    def test_start_repl_exit(self, cli_runner: CliRunner) -> None:
+        """Test that REPL exits on empty input (Ctrl+D / EOF)."""
+        mock_storage = MagicMock(spec=StorageManager)
+        with patch("src.cli.commands.ConversationEngine"):
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["chat", "start"],
+                mock_storage,
+                config=_AI_CONFIG,
+                llm_client=MagicMock(),
+                input_text="",
+            )
+
+        assert result.exit_code == 0
+
+    def test_start_repl_message_and_exit(self, cli_runner: CliRunner) -> None:
+        """Test sending a message in REPL then exiting."""
+        mock_storage = MagicMock(spec=StorageManager)
+        with patch("src.cli.commands.ConversationEngine") as mock_engine_cls:
+            mock_engine = MagicMock(spec=ConversationEngine)
+            mock_engine.process_message_sync.return_value = "Great choice!"
+            mock_engine_cls.return_value = mock_engine
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["chat", "start"],
+                mock_storage,
+                config=_AI_CONFIG,
+                llm_client=MagicMock(),
+                input_text="I just finished Dune\n",
+            )
+
+        assert result.exit_code == 0
+        assert "Great choice!" in result.output

--- a/tests/cli/test_cli_enrichment.py
+++ b/tests/cli/test_cli_enrichment.py
@@ -1,40 +1,47 @@
 """Tests for CLI enrichment commands."""
 
+import json
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
-from src.cli.main import cli
 from src.enrichment.manager import EnrichmentJobStatus, EnrichmentManager
-from src.llm.embeddings import EmbeddingGenerator
-from src.llm.recommendations import RecommendationGenerator
+from src.models.content import ContentType
 from src.storage.manager import StorageManager
 
-
-@pytest.fixture
-def cli_runner() -> CliRunner:
-    """Create CLI test runner."""
-    return CliRunner()
+from .conftest import _invoke_with_mocks
 
 
-@pytest.fixture
-def mock_context() -> dict:
-    """Create mock CLI context objects."""
-    mock_storage = MagicMock(spec=StorageManager)
-    mock_config = {
-        "enrichment": {
-            "enabled": True,
-            "batch_size": 50,
-            "providers": {
-                "tmdb": {"enabled": True, "api_key": "test-key"},
-            },
-        },
-    }
-    return {
-        "storage": mock_storage,
-        "config": mock_config,
-    }
+def _invoke_with_enrichment_manager(
+    cli_runner: CliRunner,
+    args: list[str],
+    mock_storage: MagicMock,
+    mock_manager: MagicMock,
+    config: dict | None = None,
+) -> object:
+    """Invoke CLI with the standard mocks plus a mocked EnrichmentManager."""
+    with patch("src.cli.commands.EnrichmentManager", return_value=mock_manager):
+        return _invoke_with_mocks(cli_runner, args, mock_storage, config=config)
+
+
+def _make_status(
+    completed: bool = True,
+    items_processed: int = 10,
+    items_enriched: int = 8,
+) -> MagicMock:
+    """Build an EnrichmentJobStatus mock with sensible defaults."""
+    mock_status = MagicMock(spec=EnrichmentJobStatus)
+    mock_status.running = False
+    mock_status.completed = completed
+    mock_status.cancelled = False
+    mock_status.items_processed = items_processed
+    mock_status.items_enriched = items_enriched
+    mock_status.items_not_found = max(0, items_processed - items_enriched)
+    mock_status.items_failed = 0
+    mock_status.elapsed_seconds = 5.0
+    mock_status.progress_percent = 100.0
+    mock_status.errors = []
+    return mock_status
 
 
 class TestEnrichmentStart:
@@ -42,124 +49,101 @@ class TestEnrichmentStart:
 
     def test_enrichment_disabled_error(self, cli_runner: CliRunner) -> None:
         """Test error when enrichment is disabled."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {"enrichment": {"enabled": False}}
-            with patch("src.cli.main.create_storage_manager"):
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine"):
-                        result = cli_runner.invoke(cli, ["enrichment", "start"])
+        mock_storage = MagicMock(spec=StorageManager)
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["enrichment", "start"],
+            mock_storage,
+            config={"enrichment": {"enabled": False}},
+        )
 
         assert result.exit_code != 0
         assert "disabled" in result.output.lower()
 
     def test_enrichment_start_success(self, cli_runner: CliRunner) -> None:
-        """Test successful enrichment start."""
-        mock_status = MagicMock(spec=EnrichmentJobStatus)
-        mock_status.running = False
-        mock_status.completed = True
-        mock_status.cancelled = False
-        mock_status.items_processed = 10
-        mock_status.items_enriched = 8
-        mock_status.items_not_found = 2
-        mock_status.items_failed = 0
-        mock_status.elapsed_seconds = 5.0
-        mock_status.progress_percent = 100.0
-        mock_status.errors = []
+        """Test successful enrichment start forwards correct args to the manager."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_manager = MagicMock(spec=EnrichmentManager)
+        mock_manager.start_enrichment.return_value = True
+        mock_manager.get_status.return_value = _make_status()
 
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {
-                "enrichment": {"enabled": True, "batch_size": 50},
-            }
-            with patch("src.cli.main.create_storage_manager"):
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine"):
-                        with patch(
-                            "src.cli.commands.EnrichmentManager"
-                        ) as mock_manager_cls:
-                            mock_manager = MagicMock(spec=EnrichmentManager)
-                            mock_manager.start_enrichment.return_value = True
-                            mock_manager.get_status.return_value = mock_status
-                            mock_manager_cls.return_value = mock_manager
-
-                            result = cli_runner.invoke(cli, ["enrichment", "start"])
+        result = _invoke_with_enrichment_manager(
+            cli_runner,
+            ["enrichment", "start"],
+            mock_storage,
+            mock_manager,
+            config={"enrichment": {"enabled": True, "batch_size": 50}},
+        )
 
         assert result.exit_code == 0
         assert "completed" in result.output.lower()
         assert "Items processed: 10" in result.output
+        mock_manager.start_enrichment.assert_called_once_with(
+            content_type=None, user_id=1, include_not_found=False
+        )
 
     def test_enrichment_start_with_type(self, cli_runner: CliRunner) -> None:
-        """Test enrichment start with content type filter."""
-        mock_status = MagicMock(spec=EnrichmentJobStatus)
-        mock_status.running = False
-        mock_status.completed = True
-        mock_status.cancelled = False
-        mock_status.items_processed = 5
-        mock_status.items_enriched = 5
-        mock_status.items_not_found = 0
-        mock_status.items_failed = 0
-        mock_status.elapsed_seconds = 2.0
-        mock_status.progress_percent = 100.0
-        mock_status.errors = []
+        """Test enrichment start with content type filter forwards the enum."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_manager = MagicMock(spec=EnrichmentManager)
+        mock_manager.start_enrichment.return_value = True
+        mock_manager.get_status.return_value = _make_status(
+            items_processed=5, items_enriched=5
+        )
 
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {
-                "enrichment": {"enabled": True, "batch_size": 50},
-            }
-            with patch("src.cli.main.create_storage_manager"):
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine"):
-                        with patch(
-                            "src.cli.commands.EnrichmentManager"
-                        ) as mock_manager_cls:
-                            mock_manager = MagicMock(spec=EnrichmentManager)
-                            mock_manager.start_enrichment.return_value = True
-                            mock_manager.get_status.return_value = mock_status
-                            mock_manager_cls.return_value = mock_manager
-
-                            result = cli_runner.invoke(
-                                cli, ["enrichment", "start", "--type", "movie"]
-                            )
+        result = _invoke_with_enrichment_manager(
+            cli_runner,
+            ["enrichment", "start", "--type", "movie"],
+            mock_storage,
+            mock_manager,
+            config={"enrichment": {"enabled": True, "batch_size": 50}},
+        )
 
         assert result.exit_code == 0
         assert "movie" in result.output.lower()
+        mock_manager.start_enrichment.assert_called_once_with(
+            content_type=ContentType.MOVIE, user_id=1, include_not_found=False
+        )
+
+    def test_enrichment_start_retry_not_found(self, cli_runner: CliRunner) -> None:
+        """--retry-not-found forwards include_not_found=True to the manager.
+
+        Bug: earlier revisions silently dropped the flag because the CLI did
+        not forward it through to EnrichmentManager.start_enrichment. The web
+        API's /api/enrichment/start accepts retry_not_found, so parity
+        requires the CLI to do the same.
+        """
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_manager = MagicMock(spec=EnrichmentManager)
+        mock_manager.start_enrichment.return_value = True
+        mock_manager.get_status.return_value = _make_status()
+
+        result = _invoke_with_enrichment_manager(
+            cli_runner,
+            ["enrichment", "start", "--retry-not-found"],
+            mock_storage,
+            mock_manager,
+            config={"enrichment": {"enabled": True, "batch_size": 50}},
+        )
+
+        assert result.exit_code == 0
+        mock_manager.start_enrichment.assert_called_once_with(
+            content_type=None, user_id=1, include_not_found=True
+        )
 
     def test_enrichment_already_running(self, cli_runner: CliRunner) -> None:
         """Test error when enrichment is already running."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {
-                "enrichment": {"enabled": True, "batch_size": 50},
-            }
-            with patch("src.cli.main.create_storage_manager"):
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine"):
-                        with patch(
-                            "src.cli.commands.EnrichmentManager"
-                        ) as mock_manager_cls:
-                            mock_manager = MagicMock(spec=EnrichmentManager)
-                            mock_manager.start_enrichment.return_value = False
-                            mock_manager_cls.return_value = mock_manager
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_manager = MagicMock(spec=EnrichmentManager)
+        mock_manager.start_enrichment.return_value = False
 
-                            result = cli_runner.invoke(cli, ["enrichment", "start"])
+        result = _invoke_with_enrichment_manager(
+            cli_runner,
+            ["enrichment", "start"],
+            mock_storage,
+            mock_manager,
+            config={"enrichment": {"enabled": True, "batch_size": 50}},
+        )
 
         assert result.exit_code != 0
         assert "already running" in result.output.lower()
@@ -170,7 +154,8 @@ class TestEnrichmentStatus:
 
     def test_enrichment_status_table(self, cli_runner: CliRunner) -> None:
         """Test status command with table output."""
-        mock_stats = {
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_enrichment_stats.return_value = {
             "total": 100,
             "enriched": 80,
             "pending": 15,
@@ -180,30 +165,23 @@ class TestEnrichmentStatus:
             "by_quality": {"high": 60, "medium": 20},
         }
 
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {}
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage.get_enrichment_stats.return_value = mock_stats
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine"):
-                        result = cli_runner.invoke(cli, ["enrichment", "status"])
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["enrichment", "status"],
+            mock_storage,
+        )
 
         assert result.exit_code == 0
         assert "Total items: 100" in result.output
         assert "Enriched: 80" in result.output
         assert "Pending: 15" in result.output
         assert "tmdb: 50" in result.output
+        mock_storage.get_enrichment_stats.assert_called_once_with(user_id=1)
 
     def test_enrichment_status_json(self, cli_runner: CliRunner) -> None:
-        """Test status command with JSON output."""
-        mock_stats = {
+        """Test status JSON output matches web API EnrichmentStatsResponse shape."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_enrichment_stats.return_value = {
             "total": 100,
             "enriched": 80,
             "pending": 15,
@@ -213,49 +191,43 @@ class TestEnrichmentStatus:
             "by_quality": {"high": 60},
         }
 
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {}
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage.get_enrichment_stats.return_value = mock_stats
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine"):
-                        result = cli_runner.invoke(
-                            cli, ["enrichment", "status", "--format", "json"]
-                        )
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["enrichment", "status", "--format", "json"],
+            mock_storage,
+        )
 
         assert result.exit_code == 0
-        assert '"total": 100' in result.output
-        assert '"enriched": 80' in result.output
+        parsed = json.loads(result.output)
+        # Field set matches web API EnrichmentStatsResponse (includes `enabled`)
+        assert set(parsed.keys()) >= {
+            "enabled",
+            "total",
+            "enriched",
+            "pending",
+            "not_found",
+            "failed",
+            "by_provider",
+            "by_quality",
+        }
+        assert parsed["total"] == 100
+        assert parsed["enriched"] == 80
+        assert parsed["enabled"] is False
 
 
 class TestEnrichmentReset:
     """Tests for enrichment reset command."""
 
     def test_enrichment_reset_all(self, cli_runner: CliRunner) -> None:
-        """Test reset command for all items."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {}
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage.reset_enrichment_status.return_value = 50
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine"):
-                        result = cli_runner.invoke(
-                            cli, ["enrichment", "reset", "--yes"]
-                        )
+        """Test reset command for all items forwards correct filters."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.reset_enrichment_status.return_value = 50
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["enrichment", "reset", "--yes"],
+            mock_storage,
+        )
 
         assert result.exit_code == 0
         assert "Reset enrichment status for 50 item(s)" in result.output
@@ -264,71 +236,51 @@ class TestEnrichmentReset:
         )
 
     def test_enrichment_reset_by_provider(self, cli_runner: CliRunner) -> None:
-        """Test reset command filtered by provider."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {}
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage.reset_enrichment_status.return_value = 20
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine"):
-                        result = cli_runner.invoke(
-                            cli,
-                            ["enrichment", "reset", "--provider", "tmdb", "--yes"],
-                        )
+        """Test reset filtered by provider forwards provider=tmdb to storage."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.reset_enrichment_status.return_value = 20
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["enrichment", "reset", "--provider", "tmdb", "--yes"],
+            mock_storage,
+        )
 
         assert result.exit_code == 0
         assert "Reset enrichment status for 20 item(s)" in result.output
+        mock_storage.reset_enrichment_status.assert_called_once_with(
+            provider="tmdb", content_type=None, user_id=1
+        )
 
     def test_enrichment_reset_by_type(self, cli_runner: CliRunner) -> None:
-        """Test reset command filtered by content type."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {}
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage.reset_enrichment_status.return_value = 15
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine"):
-                        result = cli_runner.invoke(
-                            cli,
-                            ["enrichment", "reset", "--type", "book", "--yes"],
-                        )
+        """Test reset filtered by content type forwards content_type=book."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.reset_enrichment_status.return_value = 15
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["enrichment", "reset", "--type", "book", "--yes"],
+            mock_storage,
+        )
 
         assert result.exit_code == 0
         assert "Reset enrichment status for 15 item(s)" in result.output
+        mock_storage.reset_enrichment_status.assert_called_once_with(
+            provider=None, content_type=ContentType.BOOK, user_id=1
+        )
 
     def test_enrichment_reset_requires_confirmation(
         self, cli_runner: CliRunner
     ) -> None:
         """Test that reset requires confirmation without --yes."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {}
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine"):
-                        # Input 'n' to decline
-                        result = cli_runner.invoke(
-                            cli, ["enrichment", "reset"], input="n\n"
-                        )
+        mock_storage = MagicMock(spec=StorageManager)
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["enrichment", "reset"],
+            mock_storage,
+            input_text="n\n",
+        )
 
         assert result.exit_code == 0
         assert "Aborted" in result.output

--- a/tests/cli/test_cli_library.py
+++ b/tests/cli/test_cli_library.py
@@ -1,21 +1,16 @@
 """Tests for CLI library commands."""
 
+import json
+from datetime import date
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
-from src.cli.main import cli
-from src.llm.embeddings import EmbeddingGenerator
-from src.llm.recommendations import RecommendationGenerator
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
 from src.storage.manager import StorageManager
 
-
-@pytest.fixture
-def cli_runner() -> CliRunner:
-    """Create CLI test runner."""
-    return CliRunner()
+from .conftest import _invoke_with_mocks
 
 
 def _make_item(
@@ -43,41 +38,6 @@ def _make_item(
     return item
 
 
-def _cli_patches():
-    """Context manager stack for CLI patches."""
-    return (
-        patch("src.cli.main.load_config"),
-        patch("src.cli.main.create_storage_manager"),
-        patch("src.cli.main.create_llm_components"),
-        patch("src.cli.main.create_recommendation_engine"),
-    )
-
-
-def _invoke_with_mocks(
-    cli_runner: CliRunner,
-    args: list[str],
-    mock_storage: MagicMock,
-    config: dict | None = None,
-    input_text: str | None = None,
-) -> object:
-    """Invoke CLI with standard mock setup."""
-    p_config, p_storage, p_llm, p_engine = _cli_patches()
-    with (
-        p_config as mock_load,
-        p_storage as mock_storage_fn,
-        p_llm as mock_llm,
-        p_engine,
-    ):
-        mock_load.return_value = config or {}
-        mock_storage_fn.return_value = mock_storage
-        mock_llm.return_value = (
-            None,
-            MagicMock(spec=EmbeddingGenerator),
-            MagicMock(spec=RecommendationGenerator),
-        )
-        return cli_runner.invoke(cli, args, input=input_text)
-
-
 class TestLibraryList:
     """Tests for library list command."""
 
@@ -98,9 +58,9 @@ class TestLibraryList:
         assert "Author A" in result.output
 
     def test_list_json_output(self, cli_runner: CliRunner) -> None:
-        """Test listing items with JSON output."""
+        """Test listing items with JSON output matches web ContentItemResponse shape."""
         items = [
-            _make_item(db_id=1, title="Book One", rating=5),
+            _make_item(db_id=1, title="Book One", rating=5, review="Loved it"),
         ]
         mock_storage = MagicMock(spec=StorageManager)
         mock_storage.get_content_items.return_value = items
@@ -110,8 +70,34 @@ class TestLibraryList:
         )
 
         assert result.exit_code == 0
-        assert '"title": "Book One"' in result.output
-        assert '"db_id": 1' in result.output
+        parsed = json.loads(result.output)
+        item = parsed[0]
+        # Full field set matches web API ContentItemResponse
+        assert set(item.keys()) == {
+            "id",
+            "db_id",
+            "title",
+            "author",
+            "content_type",
+            "status",
+            "rating",
+            "review",
+            "source",
+            "date_completed",
+            "ignored",
+            "seasons_watched",
+            "total_seasons",
+        }
+        assert item["title"] == "Book One"
+        assert item["db_id"] == 1
+        assert item["rating"] == 5
+        assert item["review"] == "Loved it"
+        assert item["author"] == "Test Author"
+        assert item["content_type"] == "book"
+        assert item["status"] == "completed"
+        assert item["ignored"] is False
+        assert item["seasons_watched"] is None
+        assert item["total_seasons"] is None
 
     def test_list_type_filter(self, cli_runner: CliRunner) -> None:
         """Test listing items filtered by type."""
@@ -150,6 +136,34 @@ class TestLibraryList:
         assert result.exit_code == 0
         assert "No items found" in result.output
 
+    def test_list_forwards_sort_limit_offset(self, cli_runner: CliRunner) -> None:
+        """Test that --sort, --limit, --offset, --show-ignored reach storage."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            [
+                "library",
+                "list",
+                "--sort",
+                "rating",
+                "--limit",
+                "5",
+                "--offset",
+                "10",
+                "--show-ignored",
+            ],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["sort_by"] == "rating"
+        assert call_kwargs["limit"] == 5
+        assert call_kwargs["offset"] == 10
+        assert call_kwargs["include_ignored"] is True
+
 
 class TestLibraryShow:
     """Tests for library show command."""
@@ -185,11 +199,13 @@ class TestLibraryShow:
         )
 
         assert result.exit_code != 0
-        assert "not found" in result.output.lower()
+        assert "Error: Item 999 not found." in result.output
 
     def test_show_json_output(self, cli_runner: CliRunner) -> None:
-        """Test showing item with JSON output."""
-        item = _make_item(db_id=42, title="The Great Book", rating=5)
+        """Test showing item with JSON output matches web ContentItemResponse shape."""
+        item = _make_item(
+            db_id=42, title="The Great Book", rating=5, review="Masterpiece"
+        )
         mock_storage = MagicMock(spec=StorageManager)
         mock_storage.get_content_item.return_value = item
 
@@ -200,8 +216,89 @@ class TestLibraryShow:
         )
 
         assert result.exit_code == 0
-        assert '"title": "The Great Book"' in result.output
-        assert '"rating": 5' in result.output
+        parsed = json.loads(result.output)
+        # Full field set matches web API ContentItemResponse
+        assert set(parsed.keys()) == {
+            "id",
+            "db_id",
+            "title",
+            "author",
+            "content_type",
+            "status",
+            "rating",
+            "review",
+            "source",
+            "date_completed",
+            "ignored",
+            "seasons_watched",
+            "total_seasons",
+        }
+        assert parsed["title"] == "The Great Book"
+        assert parsed["rating"] == 5
+        assert parsed["db_id"] == 42
+        assert parsed["author"] == "Test Author"
+        assert parsed["content_type"] == "book"
+        assert parsed["status"] == "completed"
+        assert parsed["ignored"] is False
+        assert parsed["review"] == "Masterpiece"
+        assert parsed["date_completed"] is None
+
+    def test_show_json_with_date_completed(self, cli_runner: CliRunner) -> None:
+        """Test that a non-None date_completed is serialized as ISO string."""
+        item = _make_item(db_id=42, title="Finished Book")
+        item.date_completed = date(2025, 12, 31)
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "show", "--id", "42", "--format", "json"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["date_completed"] == "2025-12-31"
+
+    def test_show_json_tv_show_with_seasons(self, cli_runner: CliRunner) -> None:
+        """Test that TV show metadata populates seasons_watched and total_seasons."""
+        item = _make_item(
+            db_id=1, title="Breaking Bad", content_type=ContentType.TV_SHOW
+        )
+        item.metadata = {"seasons_watched": [1, 2, 3], "seasons": "5"}
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "show", "--id", "1", "--format", "json"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["seasons_watched"] == [1, 2, 3]
+        assert parsed["total_seasons"] == 5
+
+    def test_show_json_tv_show_with_unparseable_seasons(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Test graceful handling when seasons metadata is not an integer."""
+        item = _make_item(db_id=1, title="Show", content_type=ContentType.TV_SHOW)
+        item.metadata = {"seasons": "unknown"}
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "show", "--id", "1", "--format", "json"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["total_seasons"] is None
+        assert parsed["seasons_watched"] is None
 
 
 class TestLibraryEdit:
@@ -244,6 +341,23 @@ class TestLibraryEdit:
         call_kwargs = mock_storage.update_item_from_ui.call_args[1]
         assert call_kwargs["status"] == "completed"
 
+    def test_edit_review(self, cli_runner: CliRunner) -> None:
+        """Test editing an item's review (review-only update)."""
+        item = _make_item(db_id=1, title="Book One")
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+        mock_storage.update_item_from_ui.return_value = True
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "1", "--review", "A revelation"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.update_item_from_ui.call_args[1]
+        assert call_kwargs["review"] == "A revelation"
+
     def test_edit_item_not_found(self, cli_runner: CliRunner) -> None:
         """Test editing a non-existent item."""
         mock_storage = MagicMock(spec=StorageManager)
@@ -256,7 +370,71 @@ class TestLibraryEdit:
         )
 
         assert result.exit_code != 0
-        assert "not found" in result.output.lower()
+        assert "Error: Item 999 not found." in result.output
+
+    def test_edit_no_fields(self, cli_runner: CliRunner) -> None:
+        """Test that edit aborts when no fields are provided (before storage call)."""
+        mock_storage = MagicMock(spec=StorageManager)
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "edit", "--id", "1"], mock_storage
+        )
+
+        assert result.exit_code != 0
+        assert (
+            "Provide at least one of --status, --rating, --review, --seasons-watched."
+            in result.output
+        )
+        # Guard fires before any storage access.
+        mock_storage.get_content_item.assert_not_called()
+        mock_storage.update_item_from_ui.assert_not_called()
+
+    def test_edit_invalid_seasons_watched(self, cli_runner: CliRunner) -> None:
+        """Test that non-integer seasons-watched input is rejected."""
+        mock_storage = MagicMock(spec=StorageManager)
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "1", "--seasons-watched", "1,two,3"],
+            mock_storage,
+        )
+
+        assert result.exit_code != 0
+        assert "comma-separated integers" in result.output.lower()
+        mock_storage.update_item_from_ui.assert_not_called()
+
+    def test_edit_seasons_watched(self, cli_runner: CliRunner) -> None:
+        """Test parsing valid seasons-watched input to a list of ints."""
+        item = _make_item(db_id=1, title="Show", content_type=ContentType.TV_SHOW)
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+        mock_storage.update_item_from_ui.return_value = True
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "1", "--seasons-watched", "1, 2 ,3"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.update_item_from_ui.call_args[1]
+        assert call_kwargs["seasons_watched"] == [1, 2, 3]
+
+    def test_edit_update_fails(self, cli_runner: CliRunner) -> None:
+        """Test edit when storage update returns False."""
+        item = _make_item(db_id=1, title="Book One")
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+        mock_storage.update_item_from_ui.return_value = False
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "1", "--rating", "3"],
+            mock_storage,
+        )
+
+        assert result.exit_code != 0
+        assert "failed to update" in result.output.lower()
 
 
 class TestLibraryIgnore:
@@ -272,7 +450,7 @@ class TestLibraryIgnore:
         )
 
         assert result.exit_code == 0
-        assert "Ignored" in result.output or "ignored" in result.output
+        assert "Ignored item 1." in result.output
         mock_storage.set_item_ignored.assert_called_once_with(
             db_id=1, ignored=True, user_id=1
         )
@@ -303,10 +481,22 @@ class TestLibraryUnignore:
         )
 
         assert result.exit_code == 0
-        assert "unignored" in result.output.lower() or "Unignored" in result.output
+        assert "Unignored item 1." in result.output
         mock_storage.set_item_ignored.assert_called_once_with(
             db_id=1, ignored=False, user_id=1
         )
+
+    def test_unignore_item_not_found(self, cli_runner: CliRunner) -> None:
+        """Test unignoring a non-existent item."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.set_item_ignored.return_value = False
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "unignore", "--id", "999"], mock_storage
+        )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
 
 
 class TestLibraryExport:
@@ -328,7 +518,7 @@ class TestLibraryExport:
 
         assert result.exit_code == 0
         assert "Book One" in result.output
-        mock_csv.assert_called_once()
+        mock_csv.assert_called_once_with(items, ContentType.BOOK)
 
     def test_export_json(self, cli_runner: CliRunner) -> None:
         """Test JSON export."""
@@ -346,4 +536,35 @@ class TestLibraryExport:
 
         assert result.exit_code == 0
         assert "Book One" in result.output
-        mock_json.assert_called_once()
+        mock_json.assert_called_once_with(items, ContentType.BOOK)
+
+    def test_export_to_file(self, cli_runner: CliRunner, tmp_path: Path) -> None:
+        """Test exporting to a file (--output)."""
+        items = [_make_item(db_id=1, title="Book One")]
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = items
+        output_path = tmp_path / "books.csv"
+
+        with patch("src.cli.commands.export_items_csv") as mock_csv:
+            mock_csv.return_value = "title\nBook One\n"
+            result = _invoke_with_mocks(
+                cli_runner,
+                [
+                    "library",
+                    "export",
+                    "--type",
+                    "book",
+                    "--format",
+                    "csv",
+                    "--output",
+                    str(output_path),
+                ],
+                mock_storage,
+            )
+
+        assert result.exit_code == 0
+        assert output_path.read_text() == "title\nBook One\n"
+        assert f"Exported 1 items to {output_path}" in result.output
+        mock_storage.get_content_items.assert_called_once()
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["include_ignored"] is True

--- a/tests/cli/test_cli_library.py
+++ b/tests/cli/test_cli_library.py
@@ -1,0 +1,349 @@
+"""Tests for CLI library commands."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from src.cli.main import cli
+from src.llm.embeddings import EmbeddingGenerator
+from src.llm.recommendations import RecommendationGenerator
+from src.models.content import ConsumptionStatus, ContentItem, ContentType
+from src.storage.manager import StorageManager
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create CLI test runner."""
+    return CliRunner()
+
+
+def _make_item(
+    db_id: int = 1,
+    title: str = "Test Book",
+    author: str | None = "Test Author",
+    content_type: ContentType = ContentType.BOOK,
+    status: ConsumptionStatus = ConsumptionStatus.COMPLETED,
+    rating: int | None = 4,
+    review: str | None = None,
+    ignored: bool | None = False,
+) -> ContentItem:
+    """Create a ContentItem for testing."""
+    item = ContentItem(
+        id=f"ext-{db_id}",
+        title=title,
+        author=author,
+        content_type=content_type,
+        status=status,
+        rating=rating,
+        review=review,
+        ignored=ignored,
+    )
+    item.db_id = db_id
+    return item
+
+
+def _cli_patches():
+    """Context manager stack for CLI patches."""
+    return (
+        patch("src.cli.main.load_config"),
+        patch("src.cli.main.create_storage_manager"),
+        patch("src.cli.main.create_llm_components"),
+        patch("src.cli.main.create_recommendation_engine"),
+    )
+
+
+def _invoke_with_mocks(
+    cli_runner: CliRunner,
+    args: list[str],
+    mock_storage: MagicMock,
+    config: dict | None = None,
+    input_text: str | None = None,
+) -> object:
+    """Invoke CLI with standard mock setup."""
+    p_config, p_storage, p_llm, p_engine = _cli_patches()
+    with (
+        p_config as mock_load,
+        p_storage as mock_storage_fn,
+        p_llm as mock_llm,
+        p_engine,
+    ):
+        mock_load.return_value = config or {}
+        mock_storage_fn.return_value = mock_storage
+        mock_llm.return_value = (
+            None,
+            MagicMock(spec=EmbeddingGenerator),
+            MagicMock(spec=RecommendationGenerator),
+        )
+        return cli_runner.invoke(cli, args, input=input_text)
+
+
+class TestLibraryList:
+    """Tests for library list command."""
+
+    def test_list_table_output(self, cli_runner: CliRunner) -> None:
+        """Test listing items with table output."""
+        items = [
+            _make_item(db_id=1, title="Book One", author="Author A", rating=5),
+            _make_item(db_id=2, title="Book Two", author="Author B", rating=3),
+        ]
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = items
+
+        result = _invoke_with_mocks(cli_runner, ["library", "list"], mock_storage)
+
+        assert result.exit_code == 0
+        assert "Book One" in result.output
+        assert "Book Two" in result.output
+        assert "Author A" in result.output
+
+    def test_list_json_output(self, cli_runner: CliRunner) -> None:
+        """Test listing items with JSON output."""
+        items = [
+            _make_item(db_id=1, title="Book One", rating=5),
+        ]
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = items
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "list", "--format", "json"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        assert '"title": "Book One"' in result.output
+        assert '"db_id": 1' in result.output
+
+    def test_list_type_filter(self, cli_runner: CliRunner) -> None:
+        """Test listing items filtered by type."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "list", "--type", "movie"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        mock_storage.get_content_items.assert_called_once()
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["content_type"] == ContentType.MOVIE
+
+    def test_list_status_filter(self, cli_runner: CliRunner) -> None:
+        """Test listing items filtered by status."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "list", "--status", "completed"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["status"] == ConsumptionStatus.COMPLETED
+
+    def test_list_empty_results(self, cli_runner: CliRunner) -> None:
+        """Test listing when no items match."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(cli_runner, ["library", "list"], mock_storage)
+
+        assert result.exit_code == 0
+        assert "No items found" in result.output
+
+
+class TestLibraryShow:
+    """Tests for library show command."""
+
+    def test_show_item(self, cli_runner: CliRunner) -> None:
+        """Test showing a single item."""
+        item = _make_item(
+            db_id=42,
+            title="The Great Book",
+            author="Famous Author",
+            rating=5,
+            review="Excellent!",
+        )
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "show", "--id", "42"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        assert "The Great Book" in result.output
+        assert "Famous Author" in result.output
+        assert "Excellent!" in result.output
+
+    def test_show_item_not_found(self, cli_runner: CliRunner) -> None:
+        """Test showing a non-existent item."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = None
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "show", "--id", "999"], mock_storage
+        )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_show_json_output(self, cli_runner: CliRunner) -> None:
+        """Test showing item with JSON output."""
+        item = _make_item(db_id=42, title="The Great Book", rating=5)
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "show", "--id", "42", "--format", "json"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        assert '"title": "The Great Book"' in result.output
+        assert '"rating": 5' in result.output
+
+
+class TestLibraryEdit:
+    """Tests for library edit command."""
+
+    def test_edit_rating(self, cli_runner: CliRunner) -> None:
+        """Test editing an item's rating."""
+        item = _make_item(db_id=1, title="Book One")
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+        mock_storage.update_item_from_ui.return_value = True
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "1", "--rating", "5"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        assert "Updated" in result.output
+        mock_storage.update_item_from_ui.assert_called_once()
+        call_kwargs = mock_storage.update_item_from_ui.call_args[1]
+        assert call_kwargs["rating"] == 5
+
+    def test_edit_status(self, cli_runner: CliRunner) -> None:
+        """Test editing an item's status."""
+        item = _make_item(db_id=1, title="Book One")
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+        mock_storage.update_item_from_ui.return_value = True
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "1", "--status", "completed"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        assert "Updated" in result.output
+        call_kwargs = mock_storage.update_item_from_ui.call_args[1]
+        assert call_kwargs["status"] == "completed"
+
+    def test_edit_item_not_found(self, cli_runner: CliRunner) -> None:
+        """Test editing a non-existent item."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = None
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "999", "--rating", "3"],
+            mock_storage,
+        )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+
+class TestLibraryIgnore:
+    """Tests for library ignore command."""
+
+    def test_ignore_item(self, cli_runner: CliRunner) -> None:
+        """Test ignoring an item."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.set_item_ignored.return_value = True
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "ignore", "--id", "1"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        assert "Ignored" in result.output or "ignored" in result.output
+        mock_storage.set_item_ignored.assert_called_once_with(
+            db_id=1, ignored=True, user_id=1
+        )
+
+    def test_ignore_item_not_found(self, cli_runner: CliRunner) -> None:
+        """Test ignoring a non-existent item."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.set_item_ignored.return_value = False
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "ignore", "--id", "999"], mock_storage
+        )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+
+class TestLibraryUnignore:
+    """Tests for library unignore command."""
+
+    def test_unignore_item(self, cli_runner: CliRunner) -> None:
+        """Test unignoring an item."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.set_item_ignored.return_value = True
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "unignore", "--id", "1"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        assert "unignored" in result.output.lower() or "Unignored" in result.output
+        mock_storage.set_item_ignored.assert_called_once_with(
+            db_id=1, ignored=False, user_id=1
+        )
+
+
+class TestLibraryExport:
+    """Tests for library export command."""
+
+    def test_export_csv(self, cli_runner: CliRunner) -> None:
+        """Test CSV export."""
+        items = [_make_item(db_id=1, title="Book One")]
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = items
+
+        with patch("src.cli.commands.export_items_csv") as mock_csv:
+            mock_csv.return_value = "title,author\nBook One,Test Author\n"
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["library", "export", "--type", "book"],
+                mock_storage,
+            )
+
+        assert result.exit_code == 0
+        assert "Book One" in result.output
+        mock_csv.assert_called_once()
+
+    def test_export_json(self, cli_runner: CliRunner) -> None:
+        """Test JSON export."""
+        items = [_make_item(db_id=1, title="Book One")]
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = items
+
+        with patch("src.cli.commands.export_items_json") as mock_json:
+            mock_json.return_value = '[{"title": "Book One"}]'
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["library", "export", "--type", "book", "--format", "json"],
+                mock_storage,
+            )
+
+        assert result.exit_code == 0
+        assert "Book One" in result.output
+        mock_json.assert_called_once()

--- a/tests/cli/test_cli_memory.py
+++ b/tests/cli/test_cli_memory.py
@@ -1,0 +1,306 @@
+"""Tests for CLI memory commands."""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+from src.storage.manager import StorageManager
+
+from .conftest import _invoke_with_mocks
+
+
+def _make_memory_dict(
+    memory_id: int = 1,
+    memory_text: str = "Prefers sci-fi",
+    memory_type: str = "user_stated",
+    is_active: bool = True,
+) -> dict[str, Any]:
+    return {
+        "id": memory_id,
+        "user_id": 1,
+        "memory_text": memory_text,
+        "memory_type": memory_type,
+        "source": "manual",
+        "confidence": 1.0,
+        "is_active": is_active,
+        "created_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+    }
+
+
+class TestMemoryList:
+    """Tests for memory list command."""
+
+    def test_list_empty(self, cli_runner: CliRunner) -> None:
+        """Test listing memories when none exist."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_core_memories.return_value = []
+        result = _invoke_with_mocks(cli_runner, ["memory", "list"], mock_storage)
+
+        assert result.exit_code == 0
+        assert "No memories found." in result.output
+
+    def test_list_memories(self, cli_runner: CliRunner) -> None:
+        """Test listing memories."""
+        memories = [
+            _make_memory_dict(1, "Prefers sci-fi"),
+            _make_memory_dict(2, "Dislikes horror"),
+        ]
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_core_memories.return_value = memories
+        result = _invoke_with_mocks(cli_runner, ["memory", "list"], mock_storage)
+
+        assert result.exit_code == 0
+        assert "Prefers sci-fi" in result.output
+        assert "Dislikes horror" in result.output
+
+    def test_list_json(self, cli_runner: CliRunner) -> None:
+        """Test listing memories JSON output matches web API MemoryResponse shape."""
+        memories = [_make_memory_dict(1, "Prefers sci-fi")]
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_core_memories.return_value = memories
+        result = _invoke_with_mocks(
+            cli_runner, ["memory", "list", "--format", "json"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        # Field set matches web MemoryResponse (no user_id, no updated_at)
+        assert set(parsed[0].keys()) == {
+            "id",
+            "memory_text",
+            "memory_type",
+            "confidence",
+            "is_active",
+            "source",
+            "created_at",
+        }
+        assert parsed[0]["memory_text"] == "Prefers sci-fi"
+        assert parsed[0]["is_active"] is True
+
+    def test_list_defaults_to_active_only(self, cli_runner: CliRunner) -> None:
+        """Test that memory list defaults to active-only (matches web API)."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_core_memories.return_value = []
+        result = _invoke_with_mocks(cli_runner, ["memory", "list"], mock_storage)
+
+        assert result.exit_code == 0
+        mock_storage.get_core_memories.assert_called_once_with(1, active_only=True)
+
+    def test_list_include_inactive(self, cli_runner: CliRunner) -> None:
+        """Test that --include-inactive flag returns all memories."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_core_memories.return_value = []
+        result = _invoke_with_mocks(
+            cli_runner, ["memory", "list", "--include-inactive"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        mock_storage.get_core_memories.assert_called_once_with(1, active_only=False)
+
+
+class TestMemoryAdd:
+    """Tests for memory add command."""
+
+    def test_add_memory(self, cli_runner: CliRunner) -> None:
+        """Test adding a new memory."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.save_core_memory.return_value = 1
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["memory", "add", "--text", "Loves dystopian fiction"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        assert "Memory 1 created." in result.output
+        mock_storage.save_core_memory.assert_called_once_with(
+            user_id=1,
+            memory_text="Loves dystopian fiction",
+            memory_type="user_stated",
+            source="manual",
+            confidence=1.0,
+        )
+
+
+class TestMemoryEdit:
+    """Tests for memory edit command."""
+
+    def test_edit_not_found(self, cli_runner: CliRunner) -> None:
+        """Test editing a memory that does not exist."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.update_core_memory.return_value = False
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["memory", "edit", "--id", "999", "--text", "New text"],
+            mock_storage,
+        )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_edit_memory(self, cli_runner: CliRunner) -> None:
+        """Test editing a memory."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.update_core_memory.return_value = True
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["memory", "edit", "--id", "1", "--text", "Updated text"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        mock_storage.update_core_memory.assert_called_once_with(
+            memory_id=1, memory_text="Updated text", is_active=None
+        )
+
+    def test_edit_text_and_active(self, cli_runner: CliRunner) -> None:
+        """--text and --active can be set in one call (matches web PUT).
+
+        Bug: earlier the CLI required two separate commands (memory edit + memory
+        toggle) to change text and active state, while the web PUT /api/memories
+        accepts both in one request. The CLI now accepts --active/--inactive on
+        edit so a single call mirrors the web contract.
+        """
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.update_core_memory.return_value = True
+        result = _invoke_with_mocks(
+            cli_runner,
+            [
+                "memory",
+                "edit",
+                "--id",
+                "1",
+                "--text",
+                "New text",
+                "--inactive",
+            ],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        mock_storage.update_core_memory.assert_called_once_with(
+            memory_id=1, memory_text="New text", is_active=False
+        )
+
+    def test_edit_active_only(self, cli_runner: CliRunner) -> None:
+        """--active without --text only changes active state."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.update_core_memory.return_value = True
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["memory", "edit", "--id", "1", "--active"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        mock_storage.update_core_memory.assert_called_once_with(
+            memory_id=1, memory_text=None, is_active=True
+        )
+
+    def test_edit_no_fields(self, cli_runner: CliRunner) -> None:
+        """No --text and no --active/--inactive aborts without touching storage."""
+        mock_storage = MagicMock(spec=StorageManager)
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["memory", "edit", "--id", "1"],
+            mock_storage,
+        )
+
+        assert result.exit_code != 0
+        assert "specify --text and/or --active/--inactive" in result.output
+        mock_storage.update_core_memory.assert_not_called()
+
+
+class TestMemoryToggle:
+    """Tests for memory toggle command."""
+
+    def test_toggle_not_found(self, cli_runner: CliRunner) -> None:
+        """Test toggling a memory that does not exist."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_core_memories.return_value = []
+        result = _invoke_with_mocks(
+            cli_runner, ["memory", "toggle", "--id", "999"], mock_storage
+        )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_toggle_memory_active_to_inactive(self, cli_runner: CliRunner) -> None:
+        """Test toggling an active memory flips it to inactive."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_core_memories.return_value = [
+            _make_memory_dict(1, "Test", is_active=True)
+        ]
+        mock_storage.update_core_memory.return_value = True
+        result = _invoke_with_mocks(
+            cli_runner, ["memory", "toggle", "--id", "1"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        assert "Memory 1 is now inactive." in result.output
+        mock_storage.update_core_memory.assert_called_once_with(
+            memory_id=1, is_active=False
+        )
+
+    def test_toggle_memory_inactive_to_active(self, cli_runner: CliRunner) -> None:
+        """Test toggling an inactive memory flips it to active."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_core_memories.return_value = [
+            _make_memory_dict(1, "Test", is_active=False)
+        ]
+        mock_storage.update_core_memory.return_value = True
+        result = _invoke_with_mocks(
+            cli_runner, ["memory", "toggle", "--id", "1"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        assert "Memory 1 is now active." in result.output
+        mock_storage.update_core_memory.assert_called_once_with(
+            memory_id=1, is_active=True
+        )
+
+
+class TestMemoryDelete:
+    """Tests for memory delete command."""
+
+    def test_delete_not_found(self, cli_runner: CliRunner) -> None:
+        """Test deleting a memory that does not exist."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.delete_core_memory.return_value = False
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["memory", "delete", "--id", "999", "--yes"],
+            mock_storage,
+        )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_delete_memory(self, cli_runner: CliRunner) -> None:
+        """Test deleting a memory."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.delete_core_memory.return_value = True
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["memory", "delete", "--id", "1", "--yes"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        mock_storage.delete_core_memory.assert_called_once_with(memory_id=1)
+
+    def test_delete_memory_aborted(self, cli_runner: CliRunner) -> None:
+        """Test aborting memory deletion."""
+        mock_storage = MagicMock(spec=StorageManager)
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["memory", "delete", "--id", "1"],
+            mock_storage,
+            input_text="n\n",
+        )
+
+        assert "Aborted" in result.output
+        mock_storage.delete_core_memory.assert_not_called()

--- a/tests/cli/test_cli_profile.py
+++ b/tests/cli/test_cli_profile.py
@@ -1,0 +1,130 @@
+"""Tests for CLI profile commands."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from src.conversation.profile import ProfileGenerator
+from src.storage.manager import StorageManager
+
+from .conftest import _invoke_with_mocks
+
+
+class TestProfileShow:
+    """Tests for profile show command."""
+
+    def test_show_profile_table(self, cli_runner: CliRunner) -> None:
+        """Test showing profile in table format."""
+        # Storage returns a wrapper dict with the profile under a "profile" key.
+        profile_record = {
+            "id": 1,
+            "user_id": 1,
+            "profile": {
+                "genre_affinities": {"sci-fi": 4.5, "fantasy": 3.2},
+                "theme_preferences": ["space exploration", "time travel"],
+                "anti_preferences": ["gore", "romance"],
+                "cross_media_patterns": ["Enjoys adaptations"],
+            },
+            "generated_at": "2026-01-01T00:00:00",
+        }
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_preference_profile.return_value = profile_record
+        result = _invoke_with_mocks(cli_runner, ["profile", "show"], mock_storage)
+
+        assert result.exit_code == 0
+        assert "sci-fi" in result.output
+        assert "fantasy" in result.output
+        assert "space exploration" in result.output
+        assert "Generated: 2026-01-01T00:00:00" in result.output
+
+    def test_show_profile_json(self, cli_runner: CliRunner) -> None:
+        """Test showing profile in JSON format."""
+        profile_record = {
+            "id": 1,
+            "user_id": 1,
+            "profile": {
+                "genre_affinities": {"sci-fi": 4.5, "fantasy": 3.2},
+                "theme_preferences": ["space exploration", "time travel"],
+                "anti_preferences": ["gore"],
+                "cross_media_patterns": [],
+            },
+            "generated_at": "2026-01-01T00:00:00",
+        }
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_preference_profile.return_value = profile_record
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["profile", "show", "--format", "json"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["genre_affinities"]["sci-fi"] == 4.5
+        assert "space exploration" in parsed["theme_preferences"]
+        assert parsed["user_id"] == 1
+        assert parsed["generated_at"] == "2026-01-01T00:00:00"
+
+    def test_show_profile_no_profile(self, cli_runner: CliRunner) -> None:
+        """Test showing profile when none exists."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_preference_profile.return_value = None
+        result = _invoke_with_mocks(cli_runner, ["profile", "show"], mock_storage)
+
+        assert result.exit_code == 0
+        assert "no profile" in result.output.lower()
+
+    def test_show_profile_no_profile_json(self, cli_runner: CliRunner) -> None:
+        """Empty profile in JSON mode emits the full ProfileResponse shape.
+
+        Bug: the CLI used to print "No profile generated yet" on stdout even
+        for --format json, which broke parity with the web API's empty-state
+        response. The JSON path now emits an empty ProfileResponse so parsers
+        on the web side see a consistent shape.
+        """
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_preference_profile.return_value = None
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["profile", "show", "--format", "json"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert set(parsed.keys()) == {
+            "user_id",
+            "genre_affinities",
+            "theme_preferences",
+            "anti_preferences",
+            "cross_media_patterns",
+            "generated_at",
+        }
+        assert parsed["user_id"] == 1
+        assert parsed["genre_affinities"] == {}
+        assert parsed["theme_preferences"] == []
+        assert parsed["generated_at"] is None
+
+
+class TestProfileRegenerate:
+    """Tests for profile regenerate command."""
+
+    def test_regenerate_profile(self, cli_runner: CliRunner) -> None:
+        """Test regenerating profile."""
+        mock_storage = MagicMock(spec=StorageManager)
+        with patch("src.cli.commands.ProfileGenerator") as mock_pg_cls:
+            mock_pg = MagicMock(spec=ProfileGenerator)
+            mock_profile = MagicMock()
+            mock_profile.genre_affinities = {"sci-fi": 4.5}
+            mock_profile.theme_preferences = ["space"]
+            mock_profile.anti_preferences = []
+            mock_profile.cross_media_patterns = []
+            mock_pg.regenerate_and_save.return_value = mock_profile
+            mock_pg_cls.return_value = mock_pg
+            result = _invoke_with_mocks(
+                cli_runner, ["profile", "regenerate"], mock_storage
+            )
+
+        assert result.exit_code == 0
+        assert "Profile regenerated with 1 genre affinities." in result.output

--- a/tests/cli/test_cli_recommend.py
+++ b/tests/cli/test_cli_recommend.py
@@ -1,5 +1,6 @@
 """Tests for CLI recommend command."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -7,14 +8,19 @@ from click.testing import CliRunner
 from src.cli.main import cli
 from src.llm.embeddings import EmbeddingGenerator
 from src.llm.recommendations import RecommendationGenerator
+from src.models.content import ConsumptionStatus, ContentItem, ContentType
 from src.recommendations.engine import RecommendationEngine
 from src.storage.manager import StorageManager
+
+from .conftest import _invoke_with_mocks
 
 
 class TestRecommendEmptyResultsRegression:
     """Regression tests for the recommend command empty-results messaging."""
 
-    def test_empty_recommendations_shows_unconsumed_guidance_regression(self) -> None:
+    def test_empty_recommendations_shows_unconsumed_guidance_regression(
+        self, cli_runner: CliRunner
+    ) -> None:
         """CLI explains that recommendations come from unconsumed items.
 
         Bug: the old message said 'add more consumed content' which was
@@ -22,28 +28,181 @@ class TestRecommendEmptyResultsRegression:
         consumed yet. If all items are completed, there is nothing to
         recommend. The message now explains this.
         """
-        runner = CliRunner()
         mock_engine = MagicMock(spec=RecommendationEngine)
         mock_engine.generate_recommendations.return_value = []
 
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {}
-            with patch("src.cli.main.create_storage_manager") as mock_storage:
-                mock_storage.return_value = MagicMock(spec=StorageManager)
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch(
-                        "src.cli.main.create_recommendation_engine"
-                    ) as mock_create_engine:
-                        mock_create_engine.return_value = mock_engine
-                        result = runner.invoke(
-                            cli, ["recommend", "--type", "video_game"]
-                        )
+        result = _invoke_recommend_with_engine(
+            cli_runner,
+            ["recommend", "--type", "video_game"],
+            mock_engine,
+        )
 
         assert result.exit_code == 0
         assert "haven't consumed yet" in result.output
         assert "add more consumed content" not in result.output
+
+
+class TestRecommendCountMaxEnforcement:
+    """Tests for config-driven --count max enforcement (matches web API)."""
+
+    def test_count_exceeds_max_count_aborts(self, cli_runner: CliRunner) -> None:
+        """--count greater than configured max_count aborts."""
+        mock_storage = MagicMock(spec=StorageManager)
+        config = {"recommendations": {"max_count": 5}}
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["recommend", "--type", "video_game", "--count", "10"],
+            mock_storage,
+            config=config,
+        )
+
+        assert result.exit_code != 0
+        assert "exceeds configured max_count=5" in result.output
+
+    def test_count_equal_to_max_count_is_accepted(self, cli_runner: CliRunner) -> None:
+        """--count exactly equal to max_count is the boundary and is accepted."""
+        mock_engine = MagicMock(spec=RecommendationEngine)
+        mock_engine.generate_recommendations.return_value = []
+
+        result = _invoke_recommend_with_engine(
+            cli_runner,
+            ["recommend", "--type", "video_game", "--count", "5"],
+            mock_engine,
+            config={"recommendations": {"max_count": 5}},
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_engine.generate_recommendations.call_args[1]
+        assert call_kwargs["count"] == 5
+
+    def test_default_max_count_of_20_applies_when_no_config(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """With no recommendations section in config, default max is 20."""
+        mock_storage = MagicMock(spec=StorageManager)
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["recommend", "--type", "video_game", "--count", "21"],
+            mock_storage,
+            config={},
+        )
+
+        assert result.exit_code != 0
+        assert "exceeds configured max_count=20" in result.output
+
+
+def _invoke_recommend_with_engine(
+    cli_runner: CliRunner,
+    args: list[str],
+    mock_engine: MagicMock,
+    config: dict | None = None,
+) -> object:
+    """Invoke the recommend CLI with a pre-configured engine mock.
+
+    Can't use _invoke_with_mocks because we need to control the engine's
+    return value, not just its existence.
+    """
+    with (
+        patch("src.cli.main.load_config") as mock_load,
+        patch("src.cli.main.create_storage_manager") as mock_storage_fn,
+        patch("src.cli.main.create_llm_components") as mock_llm,
+        patch("src.cli.main.create_recommendation_engine", return_value=mock_engine),
+    ):
+        mock_load.return_value = config or {}
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_user_preference_config.return_value = MagicMock()
+        mock_storage_fn.return_value = mock_storage
+        mock_llm.return_value = (
+            None,
+            MagicMock(spec=EmbeddingGenerator),
+            MagicMock(spec=RecommendationGenerator),
+        )
+        return cli_runner.invoke(cli, args)
+
+
+class TestRecommendJsonOutput:
+    """Tests for recommend --format json matching web RecommendationResponse."""
+
+    def test_json_output_matches_web_shape(self, cli_runner: CliRunner) -> None:
+        """Test JSON output includes all RecommendationResponse fields."""
+        item = ContentItem(
+            id="ext-1",
+            title="Book One",
+            author="Author A",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.UNREAD,
+        )
+        item.db_id = 42
+        mock_engine = MagicMock(spec=RecommendationEngine)
+        mock_engine.generate_recommendations.return_value = [
+            {
+                "item": item,
+                "score": 0.9,
+                "similarity_score": 0.7,
+                "preference_score": 0.8,
+                "reasoning": "Great match",
+                "llm_reasoning": "LLM says so",
+                "score_breakdown": {"genre": 0.5, "theme": 0.4},
+            }
+        ]
+
+        result = _invoke_recommend_with_engine(
+            cli_runner,
+            ["recommend", "--type", "book", "--format", "json"],
+            mock_engine,
+        )
+
+        assert result.exit_code == 0
+        # Strip the "Generating..." preamble to parse JSON
+        json_start = result.output.find("[")
+        parsed = json.loads(result.output[json_start:])
+        rec = parsed[0]
+        # Field set matches web RecommendationResponse
+        assert set(rec.keys()) == {
+            "db_id",
+            "title",
+            "author",
+            "score",
+            "similarity_score",
+            "preference_score",
+            "reasoning",
+            "llm_reasoning",
+            "score_breakdown",
+        }
+        assert rec["db_id"] == 42
+        assert rec["llm_reasoning"] == "LLM says so"
+        assert rec["score_breakdown"] == {"genre": 0.5, "theme": 0.4}
+
+
+class TestRecommendLlmFlag:
+    """Tests for --use-llm/--no-use-llm flag behavior."""
+
+    def test_no_use_llm_disables_llm(self, cli_runner: CliRunner) -> None:
+        """--no-use-llm forwards use_llm=False to the engine."""
+        mock_engine = MagicMock(spec=RecommendationEngine)
+        mock_engine.generate_recommendations.return_value = []
+
+        result = _invoke_recommend_with_engine(
+            cli_runner,
+            ["recommend", "--type", "video_game", "--no-use-llm"],
+            mock_engine,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_engine.generate_recommendations.call_args[1]
+        assert call_kwargs["use_llm"] is False
+
+    def test_default_uses_llm(self, cli_runner: CliRunner) -> None:
+        """With no flag specified, use_llm defaults to True (matches web API)."""
+        mock_engine = MagicMock(spec=RecommendationEngine)
+        mock_engine.generate_recommendations.return_value = []
+
+        result = _invoke_recommend_with_engine(
+            cli_runner,
+            ["recommend", "--type", "video_game"],
+            mock_engine,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_engine.generate_recommendations.call_args[1]
+        assert call_kwargs["use_llm"] is True

--- a/tests/cli/test_cli_status.py
+++ b/tests/cli/test_cli_status.py
@@ -1,0 +1,244 @@
+"""Tests for CLI status command."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from src.cli.main import cli
+from src.llm.embeddings import EmbeddingGenerator
+from src.llm.recommendations import RecommendationGenerator
+from src.recommendations.engine import RecommendationEngine
+from src.storage.manager import StorageManager
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create CLI test runner."""
+    return CliRunner()
+
+
+class TestStatusTable:
+    """Tests for status command with table output."""
+
+    def test_status_table_shows_version(self, cli_runner: CliRunner) -> None:
+        """Test that status command displays version."""
+        with patch("src.cli.main.load_config") as mock_load:
+            mock_load.return_value = {
+                "recommendations": {"max_count": 20},
+            }
+            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
+                mock_storage = MagicMock(spec=StorageManager)
+                mock_storage_fn.return_value = mock_storage
+                with patch("src.cli.main.create_llm_components") as mock_llm:
+                    mock_llm.return_value = (
+                        None,
+                        MagicMock(spec=EmbeddingGenerator),
+                        MagicMock(spec=RecommendationGenerator),
+                    )
+                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
+                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
+                        with patch(
+                            "src.cli.commands.importlib.metadata.version",
+                            return_value="0.6.0",
+                        ):
+                            result = cli_runner.invoke(cli, ["status"])
+
+        assert result.exit_code == 0
+        assert "Recommendinator v0.6.0" in result.output
+
+    def test_status_table_shows_components(self, cli_runner: CliRunner) -> None:
+        """Test that status command displays component readiness."""
+        with patch("src.cli.main.load_config") as mock_load:
+            mock_load.return_value = {
+                "recommendations": {"max_count": 20},
+            }
+            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
+                mock_storage = MagicMock(spec=StorageManager)
+                mock_storage_fn.return_value = mock_storage
+                with patch("src.cli.main.create_llm_components") as mock_llm:
+                    mock_llm.return_value = (
+                        None,
+                        None,
+                        MagicMock(spec=RecommendationGenerator),
+                    )
+                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
+                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
+                        with patch(
+                            "src.cli.commands.importlib.metadata.version",
+                            return_value="0.6.0",
+                        ):
+                            result = cli_runner.invoke(cli, ["status"])
+
+        assert result.exit_code == 0
+        assert "Components:" in result.output
+        assert "engine: ready" in result.output
+        assert "storage: ready" in result.output
+        assert "embedding_gen: not available" in result.output
+        assert "llm_client: not available" in result.output
+
+    def test_status_table_shows_features(self, cli_runner: CliRunner) -> None:
+        """Test that status command displays feature flags."""
+        with patch("src.cli.main.load_config") as mock_load:
+            mock_load.return_value = {
+                "features": {
+                    "ai_enabled": True,
+                    "embeddings_enabled": True,
+                    "llm_reasoning_enabled": False,
+                },
+                "recommendations": {"max_count": 20},
+            }
+            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
+                mock_storage = MagicMock(spec=StorageManager)
+                mock_storage_fn.return_value = mock_storage
+                with patch("src.cli.main.create_llm_components") as mock_llm:
+                    mock_llm.return_value = (
+                        None,
+                        MagicMock(spec=EmbeddingGenerator),
+                        MagicMock(spec=RecommendationGenerator),
+                    )
+                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
+                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
+                        with patch(
+                            "src.cli.commands.importlib.metadata.version",
+                            return_value="0.6.0",
+                        ):
+                            result = cli_runner.invoke(cli, ["status"])
+
+        assert result.exit_code == 0
+        assert "Features:" in result.output
+        assert "ai_enabled: enabled" in result.output
+        assert "embeddings_enabled: enabled" in result.output
+        assert "llm_reasoning_enabled: disabled" in result.output
+        assert "use_embeddings: enabled" in result.output
+
+    def test_status_table_shows_max_recommendations(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Test that status command displays max recommendation count."""
+        with patch("src.cli.main.load_config") as mock_load:
+            mock_load.return_value = {
+                "recommendations": {"max_count": 15},
+            }
+            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
+                mock_storage = MagicMock(spec=StorageManager)
+                mock_storage_fn.return_value = mock_storage
+                with patch("src.cli.main.create_llm_components") as mock_llm:
+                    mock_llm.return_value = (
+                        None,
+                        MagicMock(spec=EmbeddingGenerator),
+                        MagicMock(spec=RecommendationGenerator),
+                    )
+                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
+                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
+                        with patch(
+                            "src.cli.commands.importlib.metadata.version",
+                            return_value="0.6.0",
+                        ):
+                            result = cli_runner.invoke(cli, ["status"])
+
+        assert result.exit_code == 0
+        assert "Max recommendations: 15" in result.output
+
+    def test_status_table_default_max_count(self, cli_runner: CliRunner) -> None:
+        """Test that status uses default max_count of 20 when not configured."""
+        with patch("src.cli.main.load_config") as mock_load:
+            mock_load.return_value = {}
+            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
+                mock_storage = MagicMock(spec=StorageManager)
+                mock_storage_fn.return_value = mock_storage
+                with patch("src.cli.main.create_llm_components") as mock_llm:
+                    mock_llm.return_value = (
+                        None,
+                        MagicMock(spec=EmbeddingGenerator),
+                        MagicMock(spec=RecommendationGenerator),
+                    )
+                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
+                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
+                        with patch(
+                            "src.cli.commands.importlib.metadata.version",
+                            return_value="0.6.0",
+                        ):
+                            result = cli_runner.invoke(cli, ["status"])
+
+        assert result.exit_code == 0
+        assert "Max recommendations: 20" in result.output
+
+
+class TestStatusJson:
+    """Tests for status command with JSON output."""
+
+    def test_status_json_output(self, cli_runner: CliRunner) -> None:
+        """Test that status command produces valid JSON output."""
+        with patch("src.cli.main.load_config") as mock_load:
+            mock_load.return_value = {
+                "features": {
+                    "ai_enabled": True,
+                    "embeddings_enabled": False,
+                    "llm_reasoning_enabled": False,
+                },
+                "recommendations": {"max_count": 10},
+            }
+            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
+                mock_storage = MagicMock(spec=StorageManager)
+                mock_storage_fn.return_value = mock_storage
+                with patch("src.cli.main.create_llm_components") as mock_llm:
+                    mock_llm.return_value = (
+                        MagicMock(),
+                        None,
+                        MagicMock(spec=RecommendationGenerator),
+                    )
+                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
+                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
+                        with patch(
+                            "src.cli.commands.importlib.metadata.version",
+                            return_value="0.6.0",
+                        ):
+                            result = cli_runner.invoke(
+                                cli, ["status", "--format", "json"]
+                            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["version"] == "0.6.0"
+        assert data["components"]["engine"] is True
+        assert data["components"]["storage"] is True
+        assert data["components"]["embedding_gen"] is False
+        assert data["components"]["llm_client"] is True
+        assert data["features"]["ai_enabled"] is True
+        assert data["features"]["embeddings_enabled"] is False
+        assert data["features"]["use_embeddings"] is False
+        assert data["recommendations"]["max_count"] == 10
+
+    def test_status_json_all_components_unavailable(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Test JSON output when no optional components are available."""
+        with patch("src.cli.main.load_config") as mock_load:
+            mock_load.return_value = {}
+            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
+                mock_storage = MagicMock(spec=StorageManager)
+                mock_storage_fn.return_value = mock_storage
+                with patch("src.cli.main.create_llm_components") as mock_llm:
+                    mock_llm.return_value = (
+                        None,
+                        None,
+                        None,
+                    )
+                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
+                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
+                        with patch(
+                            "src.cli.commands.importlib.metadata.version",
+                            return_value="0.6.0",
+                        ):
+                            result = cli_runner.invoke(
+                                cli, ["status", "--format", "json"]
+                            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["components"]["llm_client"] is False
+        assert data["components"]["embedding_gen"] is False
+        assert data["features"]["ai_enabled"] is False
+        assert data["features"]["use_embeddings"] is False

--- a/tests/cli/test_cli_status.py
+++ b/tests/cli/test_cli_status.py
@@ -3,7 +3,6 @@
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
 from src.cli.main import cli
@@ -12,11 +11,46 @@ from src.llm.recommendations import RecommendationGenerator
 from src.recommendations.engine import RecommendationEngine
 from src.storage.manager import StorageManager
 
+from .conftest import _cli_patches
 
-@pytest.fixture
-def cli_runner() -> CliRunner:
-    """Create CLI test runner."""
-    return CliRunner()
+_SENTINEL = object()
+
+
+def _status_invoke(
+    cli_runner: CliRunner,
+    config: dict | None = None,
+    llm_client: MagicMock | None = None,
+    embedding_gen: MagicMock | None | object = _SENTINEL,
+    rec_gen: MagicMock | None | object = _SENTINEL,
+    args: list[str] | None = None,
+    version: str = "0.6.0",
+) -> object:
+    """Invoke the status command with version patch and full LLM control."""
+    p_config, p_storage, p_llm, p_engine = _cli_patches()
+    mock_storage = MagicMock(spec=StorageManager)
+    with (
+        p_config as mock_load,
+        p_storage as mock_storage_fn,
+        p_llm as mock_llm,
+        p_engine as mock_eng,
+        patch(
+            "src.cli.commands.importlib.metadata.version",
+            return_value=version,
+        ),
+    ):
+        mock_load.return_value = config or {}
+        mock_storage_fn.return_value = mock_storage
+        effective_embed = (
+            MagicMock(spec=EmbeddingGenerator)
+            if embedding_gen is _SENTINEL
+            else embedding_gen
+        )
+        effective_rec = (
+            MagicMock(spec=RecommendationGenerator) if rec_gen is _SENTINEL else rec_gen
+        )
+        mock_llm.return_value = (llm_client, effective_embed, effective_rec)
+        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
+        return cli_runner.invoke(cli, args or ["status"])
 
 
 class TestStatusTable:
@@ -24,221 +58,136 @@ class TestStatusTable:
 
     def test_status_table_shows_version(self, cli_runner: CliRunner) -> None:
         """Test that status command displays version."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {
-                "recommendations": {"max_count": 20},
-            }
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
-                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
-                        with patch(
-                            "src.cli.commands.importlib.metadata.version",
-                            return_value="0.6.0",
-                        ):
-                            result = cli_runner.invoke(cli, ["status"])
-
+        result = _status_invoke(
+            cli_runner,
+            config={"recommendations": {"max_count": 20}},
+        )
         assert result.exit_code == 0
         assert "Recommendinator v0.6.0" in result.output
 
     def test_status_table_shows_components(self, cli_runner: CliRunner) -> None:
-        """Test that status command displays component readiness."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {
-                "recommendations": {"max_count": 20},
-            }
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        None,
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
-                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
-                        with patch(
-                            "src.cli.commands.importlib.metadata.version",
-                            return_value="0.6.0",
-                        ):
-                            result = cli_runner.invoke(cli, ["status"])
+        """Test that status command displays component readiness.
 
+        With AI disabled, embedding_generator is reported as ready
+        (matches web API behavior — component is not required without AI).
+        """
+        result = _status_invoke(
+            cli_runner,
+            config={
+                "features": {"ai_enabled": True},
+                "recommendations": {"max_count": 20},
+            },
+            embedding_gen=None,
+        )
         assert result.exit_code == 0
         assert "Components:" in result.output
         assert "engine: ready" in result.output
         assert "storage: ready" in result.output
-        assert "embedding_gen: not available" in result.output
-        assert "llm_client: not available" in result.output
+        assert "embedding_generator: not available" in result.output
 
     def test_status_table_shows_features(self, cli_runner: CliRunner) -> None:
         """Test that status command displays feature flags."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {
+        result = _status_invoke(
+            cli_runner,
+            config={
                 "features": {
                     "ai_enabled": True,
                     "embeddings_enabled": True,
                     "llm_reasoning_enabled": False,
                 },
                 "recommendations": {"max_count": 20},
-            }
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
-                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
-                        with patch(
-                            "src.cli.commands.importlib.metadata.version",
-                            return_value="0.6.0",
-                        ):
-                            result = cli_runner.invoke(cli, ["status"])
-
+            },
+        )
         assert result.exit_code == 0
         assert "Features:" in result.output
         assert "ai_enabled: enabled" in result.output
         assert "embeddings_enabled: enabled" in result.output
         assert "llm_reasoning_enabled: disabled" in result.output
-        assert "use_embeddings: enabled" in result.output
 
     def test_status_table_shows_max_recommendations(
         self, cli_runner: CliRunner
     ) -> None:
         """Test that status command displays max recommendation count."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {
-                "recommendations": {"max_count": 15},
-            }
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
-                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
-                        with patch(
-                            "src.cli.commands.importlib.metadata.version",
-                            return_value="0.6.0",
-                        ):
-                            result = cli_runner.invoke(cli, ["status"])
-
+        result = _status_invoke(
+            cli_runner,
+            config={"recommendations": {"max_count": 15, "default_count": 3}},
+        )
         assert result.exit_code == 0
-        assert "Max recommendations: 15" in result.output
+        assert "max=15" in result.output
+        assert "default=3" in result.output
 
     def test_status_table_default_max_count(self, cli_runner: CliRunner) -> None:
         """Test that status uses default max_count of 20 when not configured."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {}
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        MagicMock(spec=EmbeddingGenerator),
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
-                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
-                        with patch(
-                            "src.cli.commands.importlib.metadata.version",
-                            return_value="0.6.0",
-                        ):
-                            result = cli_runner.invoke(cli, ["status"])
-
+        result = _status_invoke(cli_runner)
         assert result.exit_code == 0
-        assert "Max recommendations: 20" in result.output
+        assert "max=20" in result.output
+        assert "default=5" in result.output
 
 
 class TestStatusJson:
     """Tests for status command with JSON output."""
 
     def test_status_json_output(self, cli_runner: CliRunner) -> None:
-        """Test that status command produces valid JSON output."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {
+        """Test that status command JSON matches web API StatusResponse shape."""
+        result = _status_invoke(
+            cli_runner,
+            config={
                 "features": {
                     "ai_enabled": True,
                     "embeddings_enabled": False,
                     "llm_reasoning_enabled": False,
                 },
-                "recommendations": {"max_count": 10},
-            }
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        MagicMock(),
-                        None,
-                        MagicMock(spec=RecommendationGenerator),
-                    )
-                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
-                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
-                        with patch(
-                            "src.cli.commands.importlib.metadata.version",
-                            return_value="0.6.0",
-                        ):
-                            result = cli_runner.invoke(
-                                cli, ["status", "--format", "json"]
-                            )
-
+                "recommendations": {"max_count": 10, "default_count": 3},
+            },
+            llm_client=MagicMock(),
+            embedding_gen=None,
+            args=["status", "--format", "json"],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
+        # Top-level keys match StatusResponse
+        assert set(data.keys()) == {
+            "status",
+            "version",
+            "components",
+            "features",
+            "recommendations_config",
+        }
+        assert data["status"] == "initializing"
         assert data["version"] == "0.6.0"
+        # Component keys match (no llm_client)
+        assert set(data["components"].keys()) == {
+            "engine",
+            "storage",
+            "embedding_generator",
+        }
         assert data["components"]["engine"] is True
         assert data["components"]["storage"] is True
-        assert data["components"]["embedding_gen"] is False
-        assert data["components"]["llm_client"] is True
+        assert data["components"]["embedding_generator"] is False
+        # Feature keys match FeaturesStatus (no derived use_embeddings)
+        assert set(data["features"].keys()) == {
+            "ai_enabled",
+            "embeddings_enabled",
+            "llm_reasoning_enabled",
+        }
         assert data["features"]["ai_enabled"] is True
         assert data["features"]["embeddings_enabled"] is False
-        assert data["features"]["use_embeddings"] is False
-        assert data["recommendations"]["max_count"] == 10
+        # Recommendations config includes both max_count and default_count
+        assert data["recommendations_config"]["max_count"] == 10
+        assert data["recommendations_config"]["default_count"] == 3
 
-    def test_status_json_all_components_unavailable(
-        self, cli_runner: CliRunner
-    ) -> None:
-        """Test JSON output when no optional components are available."""
-        with patch("src.cli.main.load_config") as mock_load:
-            mock_load.return_value = {}
-            with patch("src.cli.main.create_storage_manager") as mock_storage_fn:
-                mock_storage = MagicMock(spec=StorageManager)
-                mock_storage_fn.return_value = mock_storage
-                with patch("src.cli.main.create_llm_components") as mock_llm:
-                    mock_llm.return_value = (
-                        None,
-                        None,
-                        None,
-                    )
-                    with patch("src.cli.main.create_recommendation_engine") as mock_eng:
-                        mock_eng.return_value = MagicMock(spec=RecommendationEngine)
-                        with patch(
-                            "src.cli.commands.importlib.metadata.version",
-                            return_value="0.6.0",
-                        ):
-                            result = cli_runner.invoke(
-                                cli, ["status", "--format", "json"]
-                            )
-
+    def test_status_json_all_components_ready(self, cli_runner: CliRunner) -> None:
+        """Test JSON output when all components are ready (AI disabled)."""
+        result = _status_invoke(
+            cli_runner,
+            embedding_gen=None,
+            rec_gen=None,
+            args=["status", "--format", "json"],
+        )
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["components"]["llm_client"] is False
-        assert data["components"]["embedding_gen"] is False
+        # With ai_enabled=False, embedding_generator is reported as ready
+        assert data["components"]["engine"] is True
+        assert data["components"]["embedding_generator"] is True
+        assert data["status"] == "ready"
         assert data["features"]["ai_enabled"] is False
-        assert data["features"]["use_embeddings"] is False

--- a/tests/test_epic_games.py
+++ b/tests/test_epic_games.py
@@ -392,6 +392,59 @@ class TestEpicGamesPluginValidation:
         assert len(errors) == 1
         assert "'refresh_token' is required" in errors[0]
 
+    def test_validate_missing_token_passes_when_in_db(self) -> None:
+        """Regression: CLI sync fails when refresh_token is in DB but not config.
+
+        Bug: validate_config() checked for refresh_token in the config dict
+        without considering that the token might be stored in the encrypted
+        credential database (used by the web UI's OAuth flow). This caused
+        CLI sync to fail with "'refresh_token' is required" even though
+        resolve_inputs() would inject the DB credential before fetch().
+
+        Root cause: validate_config() had no awareness of DB-stored
+        credentials, so it rejected configs where sensitive fields were
+        absent from the YAML but present in the credential store.
+
+        Fix: validate_config() now accepts optional storage and user_id
+        parameters. When a required sensitive field is missing from config
+        but a credential exists in DB for that source, validation passes.
+        """
+        plugin = EpicGamesPlugin()
+        mock_storage = Mock()
+        mock_storage.get_credentials_for_source.return_value = {
+            "refresh_token": "db_stored_token"
+        }
+
+        # Config has no refresh_token, but DB does — should pass
+        errors = plugin.validate_config(
+            {"_source_id": "my_epic"},
+            storage=mock_storage,
+            user_id=1,
+        )
+        assert errors == []
+        mock_storage.get_credentials_for_source.assert_called_once_with(1, "my_epic")
+
+    def test_validate_missing_token_fails_when_not_in_db(self) -> None:
+        """Validation still fails when token is absent from both config and DB."""
+        plugin = EpicGamesPlugin()
+        mock_storage = Mock()
+        mock_storage.get_credentials_for_source.return_value = {}
+
+        errors = plugin.validate_config(
+            {"_source_id": "my_epic"},
+            storage=mock_storage,
+            user_id=1,
+        )
+        assert len(errors) == 1
+        assert "'refresh_token' is required" in errors[0]
+
+    def test_validate_missing_token_fails_without_storage(self) -> None:
+        """Validation fails when no storage is provided and token is missing."""
+        plugin = EpicGamesPlugin()
+        errors = plugin.validate_config({})
+        assert len(errors) == 1
+        assert "'refresh_token' is required" in errors[0]
+
 
 # ===========================================================================
 # EpicGamesPlugin — transform_config

--- a/tests/test_gog.py
+++ b/tests/test_gog.py
@@ -392,6 +392,59 @@ class TestGogPluginValidation:
         assert len(errors) == 1
         assert "'refresh_token' is required" in errors[0]
 
+    def test_validate_missing_token_passes_when_in_db(self) -> None:
+        """Regression: CLI sync fails when refresh_token is in DB but not config.
+
+        Bug: validate_config() checked for refresh_token in the config dict
+        without considering that the token might be stored in the encrypted
+        credential database (used by the web UI's OAuth flow). This caused
+        CLI sync to fail with "'refresh_token' is required" even though
+        resolve_inputs() would inject the DB credential before fetch().
+
+        Root cause: validate_config() had no awareness of DB-stored
+        credentials, so it rejected configs where sensitive fields were
+        absent from the YAML but present in the credential store.
+
+        Fix: validate_config() now accepts optional storage and user_id
+        parameters. When a required sensitive field is missing from config
+        but a credential exists in DB for that source, validation passes.
+        """
+        plugin = GogPlugin()
+        mock_storage = Mock()
+        mock_storage.get_credentials_for_source.return_value = {
+            "refresh_token": "db_stored_token"
+        }
+
+        # Config has no refresh_token, but DB does — should pass
+        errors = plugin.validate_config(
+            {"_source_id": "my_gog"},
+            storage=mock_storage,
+            user_id=1,
+        )
+        assert errors == []
+        mock_storage.get_credentials_for_source.assert_called_once_with(1, "my_gog")
+
+    def test_validate_missing_token_fails_when_not_in_db(self) -> None:
+        """Validation still fails when token is absent from both config and DB."""
+        plugin = GogPlugin()
+        mock_storage = Mock()
+        mock_storage.get_credentials_for_source.return_value = {}
+
+        errors = plugin.validate_config(
+            {"_source_id": "my_gog"},
+            storage=mock_storage,
+            user_id=1,
+        )
+        assert len(errors) == 1
+        assert "'refresh_token' is required" in errors[0]
+
+    def test_validate_missing_token_fails_without_storage(self) -> None:
+        """Validation fails when no storage is provided and token is missing."""
+        plugin = GogPlugin()
+        errors = plugin.validate_config({})
+        assert len(errors) == 1
+        assert "'refresh_token' is required" in errors[0]
+
 
 class TestGogPluginTransformConfig:
     """Tests for GogPlugin.transform_config."""

--- a/tests/test_plugin_base.py
+++ b/tests/test_plugin_base.py
@@ -51,7 +51,7 @@ class MockPlugin(SourcePlugin):
             ),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(self, config: dict[str, Any], **kwargs: Any) -> list[str]:
         errors = []
         if not config.get("path"):
             errors.append("'path' is required")
@@ -100,7 +100,7 @@ class MockAPIPlugin(SourcePlugin):
             ),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(self, config: dict[str, Any], **kwargs: Any) -> list[str]:
         errors = []
         if not config.get("api_key"):
             errors.append("'api_key' is required")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -37,7 +37,7 @@ class FakeBookPlugin(SourcePlugin):
             ConfigField(name="path", field_type=str, required=True),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(self, config: dict[str, Any], **kwargs: Any) -> list[str]:
         errors = []
         if not config.get("path"):
             errors.append("'path' is required")
@@ -77,7 +77,7 @@ class FakeGamePlugin(SourcePlugin):
             ConfigField(name="api_key", field_type=str, required=True, sensitive=True),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(self, config: dict[str, Any], **kwargs: Any) -> list[str]:
         errors = []
         if not config.get("api_key"):
             errors.append("'api_key' is required")

--- a/tests/test_sync_sources.py
+++ b/tests/test_sync_sources.py
@@ -42,7 +42,7 @@ class FakeBookPlugin(SourcePlugin):
             ConfigField(name="path", field_type=str, required=True),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(self, config: dict[str, Any], **kwargs: Any) -> list[str]:
         errors = []
         if not config.get("path"):
             errors.append("'path' is required")
@@ -82,7 +82,7 @@ class FakeGamePlugin(SourcePlugin):
             ConfigField(name="api_key", field_type=str, required=True, sensitive=True),
         ]
 
-    def validate_config(self, config: dict[str, Any]) -> list[str]:
+    def validate_config(self, config: dict[str, Any], **kwargs: Any) -> list[str]:
         errors = []
         if not config.get("api_key"):
             errors.append("'api_key' is required")

--- a/tests/test_sync_sources.py
+++ b/tests/test_sync_sources.py
@@ -98,6 +98,72 @@ class FakeGamePlugin(SourcePlugin):
         )
 
 
+class FakeCredentialPlugin(SourcePlugin):
+    """Fake plugin that performs DB credential lookup in validate_config.
+
+    Mimics the pattern used by Epic Games and GOG plugins: when a required
+    sensitive field is missing from config, the plugin checks the DB for
+    stored credentials before reporting an error.
+    """
+
+    @property
+    def name(self) -> str:
+        return "fake_credential"
+
+    @property
+    def display_name(self) -> str:
+        return "Fake Credential"
+
+    @property
+    def content_types(self) -> list[ContentType]:
+        return [ContentType.VIDEO_GAME]
+
+    @property
+    def requires_api_key(self) -> bool:
+        return True
+
+    def get_config_schema(self) -> list[ConfigField]:
+        return [
+            ConfigField(
+                name="refresh_token",
+                field_type=str,
+                required=True,
+                sensitive=True,
+            ),
+        ]
+
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: StorageManager | None = None,
+        user_id: int = 1,
+    ) -> list[str]:
+        errors: list[str] = []
+        if not (config.get("refresh_token") or "").strip():
+            source_id = config.get("_source_id", self.name)
+            if storage is not None:
+                db_creds = storage.get_credentials_for_source(user_id, source_id)
+                if (db_creds.get("refresh_token") or "").strip():
+                    return errors
+            errors.append("'refresh_token' is required")
+        return errors
+
+    @classmethod
+    def transform_config(cls, raw_config: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "refresh_token": raw_config.get("refresh_token", "").strip(),
+        }
+
+    def fetch(self, config: dict[str, Any]) -> Iterator[ContentItem]:
+        yield ContentItem(
+            id="cred_1",
+            title="Fake Credential Game",
+            content_type=ContentType.VIDEO_GAME,
+            status=ConsumptionStatus.UNREAD,
+            source=self.get_source_identifier(config),
+        )
+
+
 @pytest.fixture()
 def _registry_with_fakes() -> Iterator[None]:
     """Set up a registry with fake plugins for testing."""
@@ -106,6 +172,7 @@ def _registry_with_fakes() -> Iterator[None]:
     registry._plugins.clear()
     registry.register(FakeBookPlugin())
     registry.register(FakeGamePlugin())
+    registry.register(FakeCredentialPlugin())
     yield
     PluginRegistry.reset_instance()
 
@@ -532,3 +599,73 @@ class TestResolveInputsWithStorage:
         resolved = resolve_inputs(config, storage=storage)
 
         assert resolved[0].config["api_key"] == "config_key"
+
+
+@pytest.mark.usefixtures("_registry_with_fakes")
+class TestValidateSourceConfigWithStorage:
+    """Integration tests: validate_source_config forwards storage to plugins.
+
+    Regression test for a bug where validate_source_config did not pass
+    storage and user_id through to plugin.validate_config(), preventing
+    DB credential lookup from being reached through the normal code path.
+    """
+
+    @pytest.fixture()
+    def storage(self, tmp_path: Path) -> StorageManager:
+        """Create a StorageManager with a temp DB."""
+        return StorageManager(sqlite_path=tmp_path / "test.db")
+
+    def test_db_credential_satisfies_validation(self, storage: StorageManager) -> None:
+        """validate_source_config returns no errors when credential is in DB.
+
+        The plugin's config has no refresh_token, but the DB has one stored.
+        validate_source_config must forward storage and user_id so the plugin
+        can find the credential and pass validation.
+        """
+        config = {
+            "inputs": {
+                "my_epic": {
+                    "plugin": "fake_credential",
+                    "enabled": True,
+                    # No refresh_token in config
+                },
+            }
+        }
+        storage.save_credential(1, "my_epic", "refresh_token", "db_token_value")
+
+        errors = validate_source_config("my_epic", config, storage=storage, user_id=1)
+
+        assert errors == []
+
+    def test_missing_credential_everywhere_fails(self, storage: StorageManager) -> None:
+        """validate_source_config returns errors when credential is missing from both."""
+        config = {
+            "inputs": {
+                "my_epic": {
+                    "plugin": "fake_credential",
+                    "enabled": True,
+                },
+            }
+        }
+        # No credential in DB either
+
+        errors = validate_source_config("my_epic", config, storage=storage, user_id=1)
+
+        assert len(errors) == 1
+        assert "'refresh_token' is required" in errors[0]
+
+    def test_config_credential_still_validates(self, storage: StorageManager) -> None:
+        """validate_source_config passes when credential is in config (not DB)."""
+        config = {
+            "inputs": {
+                "my_epic": {
+                    "plugin": "fake_credential",
+                    "enabled": True,
+                    "refresh_token": "config_token",
+                },
+            }
+        }
+
+        errors = validate_source_config("my_epic", config, storage=storage, user_id=1)
+
+        assert errors == []

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -2159,3 +2159,60 @@ class TestItemToResponseInvalidSeasons:
         )
         result = _item_to_response(item)
         assert result.total_seasons is None
+
+
+class TestAuthDisconnectEndpoints:
+    """Tests for DELETE /api/gog/token and /api/epic/token (matches CLI auth disconnect)."""
+
+    def test_gog_disconnect_success(self, client, mock_components):
+        """DELETE /api/gog/token removes stored refresh token."""
+        storage = mock_components["storage"]
+        storage.delete_credential.return_value = True
+
+        response = client.delete("/api/gog/token")
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True, "message": "GOG disconnected."}
+        storage.delete_credential.assert_called_once_with(1, "gog", "refresh_token")
+
+    def test_gog_disconnect_not_connected(self, client, mock_components):
+        """DELETE /api/gog/token returns 404 when no credential exists."""
+        mock_components["storage"].delete_credential.return_value = False
+
+        response = client.delete("/api/gog/token")
+
+        assert response.status_code == 404
+
+    def test_gog_disconnect_custom_user_id(self, client, mock_components):
+        """user_id query parameter is forwarded to storage."""
+        storage = mock_components["storage"]
+        storage.delete_credential.return_value = True
+
+        response = client.delete("/api/gog/token?user_id=5")
+
+        assert response.status_code == 200
+        storage.delete_credential.assert_called_once_with(5, "gog", "refresh_token")
+
+    def test_epic_disconnect_success(self, client, mock_components):
+        """DELETE /api/epic/token removes stored Epic refresh token."""
+        storage = mock_components["storage"]
+        storage.delete_credential.return_value = True
+
+        response = client.delete("/api/epic/token")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "success": True,
+            "message": "Epic Games disconnected.",
+        }
+        storage.delete_credential.assert_called_once_with(
+            1, "epic_games", "refresh_token"
+        )
+
+    def test_epic_disconnect_not_connected(self, client, mock_components):
+        """DELETE /api/epic/token returns 404 when no credential exists."""
+        mock_components["storage"].delete_credential.return_value = False
+
+        response = client.delete("/api/epic/token")
+
+        assert response.status_code == 404

--- a/tests/web/test_sync_manager.py
+++ b/tests/web/test_sync_manager.py
@@ -769,3 +769,83 @@ class TestSyncJobDefaults:
         assert job.current_item is None
         assert job.current_source is None
         assert job.error_message is None
+
+
+class TestSyncManagerZeroItemsWithErrorsRegression:
+    """Regression tests for sync status when a plugin catches all errors.
+
+    Bug: plugins like the Epic Games source catch their own exceptions and
+    report them via the sync manager's add_error callback, then return 0.
+    _run_sync used to mark the job COMPLETED, so the UI rendered a green
+    "Completed: 0 items synced (1 errors)" banner for what was clearly a
+    failed sync. Fix: when zero items were produced and errors
+    accumulated, surface the sync as FAILED so the UI renders the correct
+    error banner, seed error_message from the first recorded error, and
+    skip the on_complete callback so downstream enrichment isn't kicked
+    off for a failed sync.
+    """
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_zero_items_with_errors_marks_failed(
+        self, mock_thread_class: MagicMock
+    ) -> None:
+        manager = SyncManager()
+
+        def sync_function(job: SyncJob) -> int:
+            manager.add_error("Epic Games API returned 401")
+            return 0
+
+        manager.start_sync(source="Epic Games", sync_function=sync_function)
+        manager._run_sync(sync_function)
+
+        status = manager.get_status()
+        assert status["status"] == "failed"
+        assert status["job"]["items_processed"] == 0
+        assert status["job"]["error_count"] == 1
+        assert status["job"]["error_message"] == "Epic Games API returned 401"
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_partial_success_with_errors_stays_completed(
+        self, mock_thread_class: MagicMock
+    ) -> None:
+        """Partial success keeps COMPLETED — the banner honestly reports errors."""
+        manager = SyncManager()
+
+        def sync_function(job: SyncJob) -> int:
+            manager.add_error("Item 3 failed to parse")
+            return 5
+
+        manager.start_sync(source="steam", sync_function=sync_function)
+        manager._run_sync(sync_function)
+
+        status = manager.get_status()
+        assert status["status"] == "completed"
+        assert status["job"]["items_processed"] == 5
+        assert status["job"]["error_count"] == 1
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_on_complete_not_called_when_zero_items_with_errors(
+        self, mock_thread_class: MagicMock
+    ) -> None:
+        """The on_complete callback must be skipped for the FAILED path.
+
+        Downstream work like enrichment triggering should not fire when a
+        sync produced nothing and reported errors — otherwise the UI shows
+        a failure banner while side effects still run as if it succeeded.
+        """
+        manager = SyncManager()
+        on_complete = MagicMock()
+
+        def sync_function(job: SyncJob) -> int:
+            manager.add_error("Epic Games API returned 401")
+            return 0
+
+        manager.start_sync(
+            source="Epic Games",
+            sync_function=sync_function,
+            on_complete=on_complete,
+        )
+        manager._run_sync(sync_function, on_complete=on_complete)
+
+        assert manager.get_status()["status"] == "failed"
+        on_complete.assert_not_called()


### PR DESCRIPTION
Closes #27.

## Summary

- **Achieves full CLI/UI parity.** The CLI and web UI now expose the same capabilities through matching commands and endpoints — every web API action has a CLI equivalent, every CLI subcommand has a web counterpart, and JSON shapes match exactly by construction.
- **New CLI surface:** `status`, `library` (list/show/edit/ignore/export), `auth` (status/connect/disconnect), `memory` (list/add/edit/toggle/delete), `profile` (show/regenerate), `chat` (send/start/history/reset), plus `enrichment start --retry-not-found` and config-driven `recommend --count` max enforcement.
- **New web endpoints:** `DELETE /api/gog/token` and `DELETE /api/epic/token` to mirror the CLI auth disconnect, plus a UI "Disconnect" button on connected OAuth source cards so the web user can recover from an expired refresh token without dropping to the CLI.
- **Shared JSON serialization** via `src/utils/item_serialization.py::item_to_dict` — the CLI emits it as `dict` and the web API feeds it into `ContentItemResponse.model_validate()` so fields stay in lockstep.
- **Bug fixes found during the work:**
  - Sync jobs that processed zero items but accumulated errors (e.g., expired Epic token) were incorrectly marked COMPLETED, showing a green success banner for what was clearly a failed sync. Now correctly marked FAILED with the first recorded error surfaced as `error_message`, and the `on_complete` callback is skipped.
  - `.btn-danger` had ~1.8:1 contrast globally (failing WCAG AA). Fixed to a solid dark-red with light text at 7.77:1 — also fixes the existing Remove button in `CustomRules.vue`.
- **New tooling:** a `parity-review` subagent that blocks any CLI/UI drift during code review (missing commands, missing flags, shape mismatches, different empty-result behavior). Plus an "Anti-Churn Checklist" section in `CLAUDE.md` capturing the recurring review-round issues so future work can avoid them up front.

## Test plan

- [x] `command make check` — 2525 pytest + 264 vitest + mypy + ruff + black all green
- [x] `npm run type-check` — clean
- [x] All six review agents approved (security, code, test, docs, accessibility, parity)
- [ ] Manual smoke test: fresh sync on each enabled source succeeds
- [ ] Manual smoke test: trigger Epic sync with expired token → red FAILED banner with reason string visible → click Disconnect → reconnect via OAuth flow → sync succeeds
- [ ] Manual smoke test: every new CLI command group (`auth`, `chat`, `memory`, `profile`, `library`, `status`) exercised once each
- [ ] Manual smoke test: every new CLI `--format json` output matches the corresponding web API response shape
- [ ] Tab through the Data page to confirm keyboard reachability of the new Disconnect button
- [ ] Screen reader announces "Disconnect GOG" / "Disconnect Epic Games" via aria-label despite the shortened visible text

🤖 Generated with [Claude Code](https://claude.com/claude-code)