### PR TITLE
feat(docker): ship official multi-arch container images for AI and non-AI variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           python-version: "3.11"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: "pnpm"
@@ -57,3 +57,24 @@ jobs:
 
       - name: Test (frontend)
         run: pnpm vitest run
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
+        with:
+          dockerfile: Dockerfile
+
+      - name: Lint Dockerfile (ollama sidecar)
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
+        with:
+          dockerfile: docker/Dockerfile.ollama
+
+      - name: Lint shell scripts
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
+        with:
+          scandir: docker
+
+      - name: Validate docker-compose.yml
+        run: docker compose -f docker-compose.yml config --quiet
+
+      - name: Validate docker-compose.yml + dev override
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,173 @@
+name: Docker
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    tags: ["v*"]
+
+concurrency:
+  group: docker-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # On PRs: build each image (amd64 only, no push) so a broken Dockerfile
+  # fails before merge. Smoke-test the default variant by hitting /api/status.
+  build-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            dockerfile: Dockerfile
+            target: default
+            context: .
+            smoke_test: true
+          - name: ai
+            dockerfile: Dockerfile
+            target: ai
+            context: .
+            smoke_test: false
+          - name: ollama
+            dockerfile: docker/Dockerfile.ollama
+            target: ""
+            context: docker
+            smoke_test: false
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Build ${{ matrix.name }}
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: recommendinator-${{ matrix.name }}:pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,scope=${{ matrix.name }},mode=max
+
+      - name: Smoke test (default variant only)
+        if: matrix.smoke_test
+        env:
+          IMAGE: recommendinator-${{ matrix.name }}:pr-${{ github.event.pull_request.number }}
+        run: |
+          docker run -d --name smoke -p 8000:8000 "$IMAGE"
+          for i in $(seq 1 30); do
+            if curl -fsS --max-time 3 http://localhost:8000/api/status > /dev/null; then
+              echo "App started after ${i}s"
+              docker rm -f smoke
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "App failed to start within 30s"
+          docker logs smoke
+          docker rm -f smoke
+          exit 1
+
+  # On version tags: build each image multi-arch and push to GHCR with semver
+  # tags (X.Y.Z, X.Y, X, latest) plus the AI variant suffix where applicable.
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            image: ghcr.io/${{ github.repository_owner }}/recommendinator
+            dockerfile: Dockerfile
+            target: default
+            context: .
+            tag_suffix: ""
+          - name: ai
+            image: ghcr.io/${{ github.repository_owner }}/recommendinator
+            dockerfile: Dockerfile
+            target: ai
+            context: .
+            tag_suffix: "-ai"
+          - name: ollama
+            image: ghcr.io/${{ github.repository_owner }}/recommendinator-ollama
+            dockerfile: docker/Dockerfile.ollama
+            target: ""
+            context: docker
+            tag_suffix: ""
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Defence-in-depth: even though the workflow's `on.push.tags` filter is `v*`,
+      # accept only proper semver tags here so a stray `vtest` tag can never push
+      # to GHCR or move `latest` to a garbage build.
+      - name: Validate semver tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || {
+            echo "Tag '$TAG' is not a semver release tag (vMAJOR.MINOR.PATCH); aborting publish."
+            exit 1
+          }
+
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ matrix.image }}
+          flavor: |
+            suffix=${{ matrix.tag_suffix }},onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push ${{ matrix.name }}
+        id: build
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}-publish
+          cache-to: type=gha,scope=${{ matrix.name }}-publish,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Verify multi-arch manifest
+        env:
+          IMAGE: ${{ matrix.image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          docker buildx imagetools inspect "${IMAGE}@${DIGEST}" \
+            | grep -E 'linux/(amd64|arm64)' \
+            | tee /tmp/platforms.txt
+          grep -q 'linux/amd64' /tmp/platforms.txt
+          grep -q 'linux/arm64' /tmp/platforms.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: uv run python -m semantic_release version --push --commit --tag --vcs-release
+
+      - name: Attach docker-compose.yml to release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          # Only upload to a real semver tag (defense-in-depth: ignores any
+          # non-version tags that may exist at HEAD, and validates the tag
+          # name before passing it to gh).
+          TAGS=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)
+          TAG_COUNT=$(printf '%s\n' "$TAGS" | grep -c .)
+          if [ -z "$TAGS" ]; then
+            echo "No semver tag at HEAD; skipping asset upload."
+            exit 0
+          fi
+          if [ "$TAG_COUNT" -gt 1 ]; then
+            echo "WARNING: multiple semver tags at HEAD: $TAGS — uploading to the first."
+          fi
+          NEW_TAG=$(printf '%s\n' "$TAGS" | head -1)
+          gh release upload "$NEW_TAG" docker-compose.yml --clobber
+          echo "Uploaded docker-compose.yml to release $NEW_TAG"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -271,6 +271,60 @@ inputs:
 
 Plugin configuration: `.claude/settings.json` | Agent definitions: `.claude/agents/`
 
+## Container Artifacts
+
+Recommendinator publishes Docker images for end-user deployment. The full
+deployment guide is [docs/DOCKER.md](docs/DOCKER.md); this section captures
+the architecture-level shape.
+
+### Variants
+
+| Variant | Image | Contents |
+|---------|-------|----------|
+| Default | `ghcr.io/therealahall/recommendinator:VERSION` | Application, frontend build, base Python deps. Smaller image. |
+| AI | `ghcr.io/therealahall/recommendinator:VERSION-ai` | Default + `ai` extras (`ollama` and `chromadb` Python clients). |
+| Ollama sidecar | `ghcr.io/therealahall/recommendinator-ollama:VERSION` | Thin layer on `ollama/ollama` that bakes in the model-pull entrypoint script. Required by the AI variant; not used by the default variant. |
+
+All three images publish multi-arch manifests for `linux/amd64` and `linux/arm64`.
+`linux/arm/v7` is intentionally unsupported because the Python 3.11 wheel
+ecosystem (notably ChromaDB) is too thin there.
+
+### Image structure
+
+The application images are built by `Dockerfile` (multi-stage, two targets):
+
+1. **frontend-builder** — `node:20-slim` running `pnpm build` to produce the
+   Vue 3 / Vite output in `src/web/static/dist/`.
+2. **builder-base** → **builder-default** / **builder-ai** — `python:3.11-slim`
+   running `uv sync --locked` (with `--extra ai` for the AI variant) into a
+   `/app/.venv` virtualenv.
+3. **runtime-base** — `python:3.11-slim` with the `appuser` non-root account,
+   application source, frontend dist, and the entrypoint script.
+4. **default** / **ai** — copy the appropriate venv, set `ENTRYPOINT` to
+   `/app/docker/entrypoint.sh` (which bootstraps `config.yaml` from `example.yaml`
+   on first run), and start uvicorn via the `CMD`.
+
+The Ollama sidecar is built by `docker/Dockerfile.ollama`, which is a four-line
+extension of `ollama/ollama` adding the model-pull entrypoint.
+
+### Publish pipeline
+
+`.github/workflows/docker.yml` has two jobs:
+
+- **PR build** — on `pull_request`, builds all three images on `linux/amd64`
+  only (no push) so a broken Dockerfile fails before merge. The default variant
+  is smoke-tested by hitting `/api/status` after `docker run`.
+- **Tag publish** — on `push` to a `v*` tag, builds all three images
+  multi-arch with `docker/build-push-action`, generates semver tags
+  (`X.Y.Z`, `X.Y`, `X`, `latest`) via `docker/metadata-action`, attaches
+  build provenance and SBOM attestations, and pushes to GHCR.
+
+The tag is created automatically by `.github/workflows/release.yml` (which
+runs python-semantic-release on every push to `main`), so `feat:` and `fix:`
+commits flow through to a published image without manual intervention. The
+release workflow also uploads `docker-compose.yml` as a release asset, enabling
+the `curl -L .../latest/download/docker-compose.yml` flow for end users.
+
 ## Security & Privacy
 
 - All processing happens locally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,13 @@ index.html            # Vite SPA entry point
 vite.config.ts        # Vite build configuration
 tests/                # Mirrors src/ structure
 config/               # Configuration files (example.yaml for tests)
+docker/               # Container helpers
+├── entrypoint.sh         # First-run config.yaml bootstrap (recommendinator image)
+├── ollama-entrypoint.sh  # Ollama model-pull entrypoint (recommendinator-ollama image)
+└── Dockerfile.ollama     # Sidecar image with the entrypoint baked in
+docker-compose.yml         # Production: pulls from GHCR
+docker-compose.dev.yml     # Dev override: bind-mount + --reload (committed)
+docker-compose.override.yml  # Personal mounts (gitignored)
 private/              # Gitignored — private plugins NOT in the open source repo
 └── plugins/          # Private source plugins (personal_site_games.py, etc.)
 ```
@@ -129,6 +136,7 @@ config = load_config(Path("config/config.yaml"))
 - **CLI**: Click
 - **Testing**: pytest (Python), Vitest (frontend)
 - **Quality**: Black, MyPy (strict), Ruff, vue-tsc
+- **Container**: Docker — production deployment pulls from GHCR via `docker-compose.yml`; local dev layers `docker-compose.dev.yml` for hot reload (bind-mount `src/` + uvicorn `--reload`). Both `recommendinator` (default + `-ai`) and `recommendinator-ollama` images are published multi-arch (`linux/amd64`, `linux/arm64`). See [docs/DOCKER.md](docs/DOCKER.md).
 
 ## Versioning & Releases
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,36 @@ Thank you for your interest in contributing to Recommendinator! This document co
 3. Ensure all checks pass (see [Quality Checks](#quality-checks))
 4. Submit a pull request
 
+### Local development with Docker (hot reload)
+
+If you'd rather not maintain a local Python + Node toolchain, you can run the
+full stack in containers with hot reload by layering `docker-compose.dev.yml`
+on top of the production compose file:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
+What the override does:
+- **Builds locally** instead of pulling from GHCR, so changes to `Dockerfile`,
+  `pyproject.toml`, or the frontend build are reflected.
+- **Bind-mounts `./src` and `./templates`** into the container so Python edits
+  are visible immediately without a rebuild.
+- **Starts uvicorn with `--reload`**, watching `src/` and `templates/` — backend
+  changes restart in ~1 second.
+
+Frontend hot reload runs on the host (Vite's HMR works best natively):
+
+```bash
+pnpm dev
+```
+
+Vite serves on port 5173 and proxies API calls to the container on port 18473.
+
+Your gitignored `docker-compose.override.yml` (for personal mounts like private
+plugin directories) merges automatically alongside both files, so all three
+compose cleanly with one command.
+
 **Automated code review:** When using Claude Code, six review agents run before commits:
 - **code-review** — Reviews code quality, design, naming, DRY compliance, and adherence to project standards.
 - **security-review** — Audits for vulnerabilities, credential leaks, and unsafe patterns. See [docs/SECURITY.md](docs/SECURITY.md) for details.

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,10 @@ COPY --chown=appuser:appuser src/ ./src/
 COPY --chown=appuser:appuser templates/ ./templates/
 COPY --chown=appuser:appuser config/example.yaml ./config/example.yaml
 
+# Copy entrypoint that bootstraps config.yaml on first run
+COPY --chown=appuser:appuser docker/entrypoint.sh /app/docker/entrypoint.sh
+RUN chmod +x /app/docker/entrypoint.sh
+
 # Copy built frontend assets from frontend builder
 COPY --from=frontend-builder --chown=appuser:appuser /app/src/web/static/dist/ ./src/web/static/dist/
 
@@ -98,6 +102,7 @@ USER appuser
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/status')" || exit 1
+ENTRYPOINT ["/app/docker/entrypoint.sh"]
 CMD ["python", "-m", "src.web", "--host", "0.0.0.0", "--port", "8000"]
 
 # =============================================================================
@@ -112,4 +117,5 @@ USER appuser
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/status')" || exit 1
+ENTRYPOINT ["/app/docker/entrypoint.sh"]
 CMD ["python", "-m", "src.web", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,10 @@ COPY --from=ghcr.io/astral-sh/uv:0.10.7 /uv /bin/uv
 
 WORKDIR /app
 
-# Install build dependencies
+# Install build dependencies. build-essential is intentionally unpinned —
+# pinning apt package versions across Debian base image patch updates is
+# fragile and forces a Dockerfile change every minor base-image bump.
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -36,8 +36,11 @@ For AI features (Ollama sidecar with auto model download), use Docker Compose:
 ```bash
 curl -L https://github.com/therealahall/recommendinator/releases/latest/download/docker-compose.yml \
   -o docker-compose.yml
-COMPOSE_PROFILES=ai docker compose up -d
+docker compose --profile ai up -d app-ai
 ```
+
+Naming `app-ai` is required — the default `app` service has no profile and
+would otherwise start alongside the AI variant, colliding on the same host port.
 
 See [docs/DOCKER.md](docs/DOCKER.md) for parameters, GPU setup, reverse proxy
 notes, and troubleshooting.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,14 +4,47 @@ Get up and running with Recommendinator in under 5 minutes.
 
 ## Prerequisites
 
-- **Python 3.11** installed (see [docs/PYTHON_VERSION.md](docs/PYTHON_VERSION.md) for details)
+- **Docker** (recommended) — or Python 3.11 if you'd rather run from source
 - Your data (Goodreads export, Steam account, etc.)
 
 That's it. No AI, no external services required.
 
 ## Installation
 
-### Option 1: Local Installation
+### Option 1: Docker (recommended)
+
+No git clone needed. Pull a published image and mount your data directories:
+
+```bash
+mkdir -p recommendinator/{config,data,inputs} && cd recommendinator
+
+docker run -d \
+  --name recommendinator \
+  -p 18473:8000 \
+  -v "$(pwd)/config:/app/config" \
+  -v "$(pwd)/data:/app/data" \
+  -v "$(pwd)/inputs:/app/inputs:ro" \
+  --restart unless-stopped \
+  ghcr.io/therealahall/recommendinator:latest
+```
+
+The container generates a starter `config/config.yaml` from the bundled example
+on first run — edit it on the host with your API keys and run `docker restart recommendinator`.
+
+For AI features (Ollama sidecar with auto model download), use Docker Compose:
+
+```bash
+curl -L https://github.com/therealahall/recommendinator/releases/latest/download/docker-compose.yml \
+  -o docker-compose.yml
+COMPOSE_PROFILES=ai docker compose up -d
+```
+
+See [docs/DOCKER.md](docs/DOCKER.md) for parameters, GPU setup, reverse proxy
+notes, and troubleshooting.
+
+### Option 2: Local Installation (for contributors)
+
+If you're contributing to Recommendinator or prefer running from source:
 
 ```bash
 # Clone the repository
@@ -37,16 +70,6 @@ cp config/example.yaml config/config.yaml
 ```
 
 > **Note:** The web UI requires Node.js 18+ to build. If you only use the CLI, Node.js is not required.
-
-### Option 2: Docker
-
-```bash
-# Without AI (default)
-docker compose up
-
-# With AI (Ollama sidecar)
-docker compose --profile ai up app-ai
-```
 
 Access the web interface at http://localhost:18473.
 

--- a/README.md
+++ b/README.md
@@ -45,17 +45,42 @@ If you change the host to `0.0.0.0` to allow LAN access, **anyone on your networ
 
 ### Option 1: Docker (Recommended)
 
-```bash
-# Without AI (default) — runs the app only
-docker compose up
+No git clone required. Pull a published image, mount your config and data
+directories, and run.
 
-# With AI — starts the app + Ollama + model auto-pull
-docker compose --profile ai up app-ai
+```bash
+mkdir -p recommendinator/{config,data,inputs} && cd recommendinator
+
+docker run -d \
+  --name recommendinator \
+  -p 18473:8000 \
+  -v "$(pwd)/config:/app/config" \
+  -v "$(pwd)/data:/app/data" \
+  -v "$(pwd)/inputs:/app/inputs:ro" \
+  --restart unless-stopped \
+  ghcr.io/therealahall/recommendinator:latest
 ```
 
-The `--profile ai` flag adds an Ollama sidecar container that automatically pulls the configured models on first start. Set `features.ai_enabled: true` in your config to use AI features.
+The container generates a starter `config/config.yaml` from the bundled example
+on first run. Edit it with your API keys and run `docker restart recommendinator`.
 
-### Option 2: Local Installation
+For the AI variant (with semantic search and LLM-powered explanations) and the
+required Ollama sidecar, use Docker Compose:
+
+```bash
+curl -L https://github.com/therealahall/recommendinator/releases/latest/download/docker-compose.yml \
+  -o docker-compose.yml
+COMPOSE_PROFILES=ai docker compose up -d
+```
+
+Both variants are published as multi-arch images for `linux/amd64` and
+`linux/arm64`, so they run on x86 servers, Apple Silicon, and modern NAS
+hardware. See **[docs/DOCKER.md](docs/DOCKER.md)** for the full deployment
+guide — parameter reference, AI mode, GPU support, reverse proxy, troubleshooting.
+
+### Option 2: Local Installation (for contributors)
+
+If you're developing Recommendinator or prefer to run it from source:
 
 ```bash
 # Clone and install
@@ -82,7 +107,9 @@ python3.11 -m src.cli recommend --type book --count 5
 python3.11 -m src.web
 ```
 
-Access the web interface at `http://localhost:18473`
+Access the web interface at `http://localhost:18473`. See [CONTRIBUTING.md](CONTRIBUTING.md)
+for the full development workflow including the Docker dev override that gives
+you hot reload without rebuilding.
 
 **Important:** [Set up metadata enrichment](docs/ENRICHMENT_SETUP.md) **before importing your data** and enable `auto_enrich_on_sync: true` so items are enriched automatically on every sync. Enrichment is disabled by default but is essential for recommendation quality — without it, many items will lack the genres, tags, and descriptions that the scoring pipeline depends on.
 
@@ -447,7 +474,7 @@ If you want AI-enhanced recommendations:
 
 ### Docker Users
 
-Use `docker compose --profile ai up app-ai` — Ollama and models are set up automatically.
+Run `COMPOSE_PROFILES=ai docker compose up -d` — Ollama and models are set up automatically.
 
 ### Local Installation Users
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ required Ollama sidecar, use Docker Compose:
 ```bash
 curl -L https://github.com/therealahall/recommendinator/releases/latest/download/docker-compose.yml \
   -o docker-compose.yml
-COMPOSE_PROFILES=ai docker compose up -d
+docker compose --profile ai up -d app-ai
 ```
+
+The `app-ai` service name is required so the default `app` service (no profile,
+always-on) is skipped — otherwise both variants race for the same host port.
 
 Both variants are published as multi-arch images for `linux/amd64` and
 `linux/arm64`, so they run on x86 servers, Apple Silicon, and modern NAS
@@ -474,7 +477,7 @@ If you want AI-enhanced recommendations:
 
 ### Docker Users
 
-Run `COMPOSE_PROFILES=ai docker compose up -d` — Ollama and models are set up automatically.
+Run `docker compose --profile ai up -d app-ai` — Ollama and models are set up automatically. The `app-ai` service name keeps the default no-AI service from starting on the same port.
 
 ### Local Installation Users
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -1,5 +1,9 @@
-# Example configuration file
-# Copy this to config.yaml and modify as needed
+# Example configuration file.
+#
+# Copy this to config.yaml and modify as needed. When running via Docker
+# (docker compose up), the container's entrypoint copies this file to
+# config.yaml automatically on first run if config.yaml is missing — so
+# edit ./config/config.yaml on the host directly, not example.yaml.
 
 # Feature flags - control optional functionality
 features:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,57 @@
+# Recommendinator — Local development override.
+#
+# Layer this on top of docker-compose.yml when iterating on app code:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# What it does (vs. the production compose):
+#   - Builds the image locally instead of pulling from GHCR (so your changes
+#     to dependencies, the Dockerfile, or the frontend build are reflected).
+#   - Bind-mounts ./src and ./templates into the container so Python edits
+#     are visible immediately. Combined with --reload, uvicorn restarts in
+#     ~1s on file save — no rebuild needed.
+#   - Renames the local images so they don't shadow the GHCR cache when you
+#     switch back to the production compose.
+#
+# Frontend hot reload is run on the host with `pnpm dev` (port 5173) — see
+# CONTRIBUTING.md.
+#
+# Your gitignored docker-compose.override.yml (private plugin mounts, etc.)
+# still merges automatically, so all three files compose cleanly.
+
+x-dev-common: &dev-common
+  volumes:
+    - ./src:/app/src
+    - ./templates:/app/templates
+  command:
+    - python
+    - -m
+    - src.web
+    - --host
+    - "0.0.0.0"
+    - --port
+    - "8000"
+    - --reload
+  environment:
+    - PYTHONUNBUFFERED=1
+
+services:
+  app:
+    <<: *dev-common
+    build:
+      context: .
+      target: default
+    image: recommendinator:dev
+
+  app-ai:
+    <<: *dev-common
+    build:
+      context: .
+      target: ai
+    image: recommendinator-ai:dev
+
+  ollama:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.ollama
+    image: recommendinator-ollama:dev

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,11 @@
 #
 # Layer this on top of docker-compose.yml when iterating on app code:
 #
-#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile ai up -d app-ai
+#
+# As with the production compose, the AI invocation must name `app-ai`
+# explicitly so the default `app` service (no profile, always-on) is skipped.
 #
 # What it does (vs. the production compose):
 #   - Builds the image locally instead of pulling from GHCR (so your changes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,69 +1,73 @@
-# Recommendinator - Docker Compose
+# Recommendinator — Docker Compose
+#
+# This file pulls pre-built images from GitHub Container Registry and is the
+# same compose file used by maintainers locally. For end users it is the
+# canonical deployment manifest; download it via:
+#
+#   curl -L https://github.com/therealahall/recommendinator/releases/latest/download/docker-compose.yml \
+#     -o docker-compose.yml
 #
 # Usage:
-#   docker compose up                        # App only (no AI features)
-#   docker compose --profile ai up app-ai    # App + Ollama (AI features enabled)
+#   docker compose up -d                    # default variant (no AI)
+#   COMPOSE_PROFILES=ai docker compose up   # with Ollama sidecar (AI features)
 #
-# Note: Set features.ai_enabled: true in config/config.yaml when using --profile ai
+# Environment overrides (set in your shell or a .env file next to this file):
+#   IMAGE_TAG  — image tag to pull (default: latest)
+#   APP_PORT   — host port to expose the web UI on (default: 18473)
+#
+# For local development with hot reload, layer docker-compose.dev.yml on top:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 
 x-app-common: &app-common
   ports:
-    - "18473:8000"  # External:Internal - external port avoids collisions
+    - "${APP_PORT:-18473}:8000"
   volumes:
-    # Persist data between restarts
+    # config is mounted read-write so the entrypoint can copy example.yaml
+    # to config.yaml on first run. Edit ./config/config.yaml on the host.
+    # Once config.yaml exists, you can switch this to `./config:/app/config:ro`
+    # for a tighter security posture (the app never needs to write to it
+    # at steady state).
+    - ./config:/app/config
+    # persistent application data (SQLite DB, ChromaDB, credential keys)
     - ./data:/app/data
-    # Mount config file (copy example.yaml to config.yaml first)
-    - ./config:/app/config:ro
-    # Mount input files
+    # input files for ingestion sources
     - ./inputs:/app/inputs:ro
-    # Mount private plugins (user-specific, gitignored)
+    # optional private plugin directory; leave empty if you don't have any
     - ./private:/app/private:ro
-    # For additional mounts, use docker-compose.override.yml (gitignored)
   restart: unless-stopped
   networks:
     - recommendinator-net
 
 services:
-  # Main application (no AI dependencies)
-  # Use app-ai (--profile ai) for AI features including Ollama connectivity.
+  # Default variant — no AI dependencies. Smallest image.
   app:
     <<: *app-common
-    build:
-      context: .
-      target: default
+    image: ghcr.io/therealahall/recommendinator:${IMAGE_TAG:-latest}
     container_name: recommendinator
 
-  # Main application with AI dependencies (only starts with --profile ai)
+  # AI variant — includes Ollama client and ChromaDB. Requires the ollama
+  # sidecar below; only starts under the `ai` profile.
   app-ai:
     <<: *app-common
-    build:
-      context: .
-      target: ai
+    image: ghcr.io/therealahall/recommendinator:${IMAGE_TAG:-latest}-ai
     container_name: recommendinator-ai
     profiles: ["ai"]
     environment:
-      # Ollama URL - only used when ai.enabled: true in config
-      # Points to sidecar when using --profile ai
       - OLLAMA_BASE_URL=http://ollama:11434
     depends_on:
       ollama:
         condition: service_healthy
 
-  # Ollama LLM sidecar (only starts with --profile ai)
+  # Ollama LLM sidecar (only starts with --profile ai).
   # Models are auto-pulled on first start from config/config.yaml (ollama.model
   # and ollama.embedding_model). Falls back to mistral:7b and nomic-embed-text.
   ollama:
-    image: ollama/ollama:latest
+    image: ghcr.io/therealahall/recommendinator-ollama:${IMAGE_TAG:-latest}
     container_name: recommendinator-ollama
     profiles: ["ai"]
-    entrypoint: ["/entrypoint.sh"]
     volumes:
-      # Persist downloaded models
       - ollama-data:/root/.ollama
-      # Config for reading model names
       - ./config:/config:ro
-      # Custom entrypoint that pulls models on first start
-      - ./docker/ollama-entrypoint.sh:/entrypoint.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "ollama list > /dev/null 2>&1 && test -f /tmp/models-ready"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,15 +8,20 @@
 #     -o docker-compose.yml
 #
 # Usage:
-#   docker compose up -d                    # default variant (no AI)
-#   COMPOSE_PROFILES=ai docker compose up   # with Ollama sidecar (AI features)
+#   docker compose up -d                            # default variant (no AI)
+#   docker compose --profile ai up -d app-ai        # AI variant + Ollama sidecar
+#
+# The AI invocation must name `app-ai` explicitly. The default `app` service
+# has no profile so it always starts unless excluded by service-name selection;
+# omitting `app-ai` leaves both variants competing for the same host port.
 #
 # Environment overrides (set in your shell or a .env file next to this file):
 #   IMAGE_TAG  — image tag to pull (default: latest)
 #   APP_PORT   — host port to expose the web UI on (default: 18473)
 #
 # For local development with hot reload, layer docker-compose.dev.yml on top:
-#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile ai up -d app-ai
 
 x-app-common: &app-common
   ports:

--- a/docker/Dockerfile.ollama
+++ b/docker/Dockerfile.ollama
@@ -1,0 +1,13 @@
+# Recommendinator — Ollama sidecar image.
+#
+# Thin layer on top of ollama/ollama that bakes in the entrypoint script
+# responsible for pulling the configured generation and embedding models on
+# first start. Published so end-users don't need to download a second file
+# alongside docker-compose.yml.
+
+FROM ollama/ollama:0.22.0
+
+COPY ollama-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Recommendinator container entrypoint.
+#
+# On first run, copies the bundled example.yaml to config.yaml inside the
+# mounted /app/config volume so the application has a working starting point.
+# Idempotent — does not overwrite an existing config.yaml.
+#
+# This is a temporary affordance: once configuration moves into the application
+# itself, this script (and the example.yaml it copies) goes away.
+
+set -eu
+
+: "${CONFIG_DIR:=/app/config}"
+
+# Defense-in-depth: refuse CONFIG_DIR values outside the application tree.
+# Inside Docker this is always /app/config; the env override exists only for
+# unit tests, which run against pytest's tmp_path. Anything else is a misuse.
+case "$CONFIG_DIR" in
+    /app/* | /tmp/*) ;;
+    *)
+        echo "[entrypoint] FATAL: CONFIG_DIR must be under /app or /tmp; got: $CONFIG_DIR" >&2
+        exit 1
+        ;;
+esac
+
+CONFIG_PATH="$CONFIG_DIR/config.yaml"
+EXAMPLE_PATH="$CONFIG_DIR/example.yaml"
+
+if [ ! -f "$CONFIG_PATH" ]; then
+    if [ -f "$EXAMPLE_PATH" ]; then
+        cp "$EXAMPLE_PATH" "$CONFIG_PATH"
+        echo "[entrypoint] No config.yaml found; copied example.yaml as a starting point."
+        echo "[entrypoint] Edit ./config/config.yaml on the host with your settings, then restart."
+    else
+        echo "[entrypoint] WARNING: neither config.yaml nor example.yaml present in $CONFIG_DIR." >&2
+        echo "[entrypoint] The application may fail to start. Mount a config directory or rebuild the image." >&2
+    fi
+fi
+
+exec "$@"

--- a/docker/ollama-entrypoint.sh
+++ b/docker/ollama-entrypoint.sh
@@ -109,9 +109,14 @@ EMBEDDING_MODEL=$(parse_config_value "embedding_model" "$DEFAULT_EMBEDDING_MODEL
 log "Generation model: $MODEL"
 log "Embedding model:  $EMBEDDING_MODEL"
 
-# Pull models if not already present
+# Pull models if not already present.
+# Escape the only regex metacharacter that appears in real model names ('.')
+# so "llama3.2" doesn't false-match "llama3a2", while still anchoring to the
+# start of the line — `ollama list` prints the model name as the first column,
+# so anchoring prevents short names from substring-matching longer ones
+# (e.g., MODEL=text incorrectly matching "nomic-embed-text").
 for model_name in "$MODEL" "$EMBEDDING_MODEL"; do
-    if ollama list | grep -q "^${model_name}"; then
+    if ollama list | grep -q "^${model_name//./\\.}"; then
         log "Model $model_name is already downloaded."
     else
         pull_model "$model_name"

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -59,8 +59,13 @@ docker compose up -d
 For the AI variant:
 
 ```bash
-COMPOSE_PROFILES=ai docker compose up -d
+docker compose --profile ai up -d app-ai
 ```
+
+Naming `app-ai` explicitly is required: the default `app` service has no profile
+and would otherwise start alongside `app-ai`, with both fighting for the same
+host port. Specifying the service name limits the up command to `app-ai` and its
+declared dependencies (the Ollama sidecar).
 
 To switch to a pinned version instead of `latest`, set `IMAGE_TAG` in your shell or in a
 `.env` file next to the compose file:
@@ -117,7 +122,7 @@ exposed to the host by default — only `app-ai` talks to it.
 |----------|---------|--------|
 | `IMAGE_TAG` | `latest` | Which image tag the compose file pulls. Set to a semver like `0.7.0` for pinned deployments. The `-ai` suffix is appended automatically for the AI service. |
 | `APP_PORT` | `18473` | Host-side port for the web UI. |
-| `COMPOSE_PROFILES` | (unset) | Set to `ai` to enable the AI variant and the Ollama sidecar. |
+| `COMPOSE_PROFILES` | (unset) | Optional fallback for `--profile ai`. If you set this instead of using the flag, you still need to name `app-ai` on the up command (`docker compose up -d app-ai`) to skip the default `app` service. |
 | `OLLAMA_BASE_URL` | `http://ollama:11434` | Set inside the AI service automatically. Override only if you're pointing at a remote Ollama instance. |
 
 ## First run
@@ -148,11 +153,13 @@ The entrypoint never overwrites an existing `config.yaml`, so restarts are safe.
 ## AI mode
 
 ```bash
-COMPOSE_PROFILES=ai docker compose up -d
+docker compose --profile ai up -d app-ai
 ```
 
-This starts two extra containers: `recommendinator-ai` (the app with AI extras) and
-`recommendinator-ollama` (the LLM server). The Ollama sidecar pulls the models named
+This starts two containers: `recommendinator-ai` (the app with AI extras) and
+`recommendinator-ollama` (the LLM server, pulled in via `depends_on`).
+Naming `app-ai` explicitly is required so the default `app` service does not
+also start and grab the host port. The Ollama sidecar pulls the models named
 in your `config.yaml` (`ollama.model` and `ollama.embedding_model`) on first start —
 this can take 5–15 minutes for a 4 GB model on a typical home connection.
 
@@ -298,7 +305,11 @@ If you're contributing to Recommendinator and want hot reload instead of rebuild
 the image on every change, layer the dev override on top of the production compose:
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+# default variant
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+
+# AI variant — name app-ai so the default app service is skipped
+docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile ai up -d app-ai
 ```
 
 This builds the image locally instead of pulling, bind-mounts `./src` and `./templates`

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,308 @@
+# Docker Deployment
+
+Recommendinator ships official Docker images for both `linux/amd64` and `linux/arm64`,
+so it runs on x86 servers, Apple Silicon, modern NAS hardware (Synology DSM 7+, QNAP),
+and Raspberry Pi 4/5.
+
+The images live in [GitHub Container Registry](https://github.com/therealahall/recommendinator/pkgs/container/recommendinator).
+Two variants are published:
+
+| Variant | Image | When to use |
+|---------|-------|-------------|
+| Default | `ghcr.io/therealahall/recommendinator:latest` | Recommendation engine without AI features. Smaller image; no Ollama / ChromaDB. |
+| AI | `ghcr.io/therealahall/recommendinator:latest-ai` | Adds Ollama client and ChromaDB. Use when you want semantic search and LLM-powered explanations. |
+
+The AI variant pairs with a published Ollama sidecar:
+
+| Image | Purpose |
+|-------|---------|
+| `ghcr.io/therealahall/recommendinator-ollama:latest` | Ollama LLM server pre-configured to pull the models defined in your `config.yaml` on first start. |
+
+## Quick start (CLI)
+
+For a fast, no-AI try-out — single container, host-mounted data:
+
+```bash
+mkdir -p recommendinator/{config,data,inputs}
+cd recommendinator
+
+docker run -d \
+  --name recommendinator \
+  -p 18473:8000 \
+  -v "$(pwd)/config:/app/config" \
+  -v "$(pwd)/data:/app/data" \
+  -v "$(pwd)/inputs:/app/inputs:ro" \
+  --restart unless-stopped \
+  ghcr.io/therealahall/recommendinator:latest
+```
+
+Then open <http://localhost:18473>. The container generates a starter `config/config.yaml`
+on first run from the bundled `example.yaml` — edit it on the host with your API keys
+and `docker restart recommendinator`.
+
+## Docker Compose (recommended)
+
+Compose is the only sensible way to run the AI variant (it needs the Ollama sidecar
+and a private network). It's also the cleanest path for the default variant if you're
+running multiple services on the same host.
+
+Download the canonical compose file from the latest release:
+
+```bash
+mkdir -p recommendinator/{config,data,inputs}
+cd recommendinator
+curl -L https://github.com/therealahall/recommendinator/releases/latest/download/docker-compose.yml \
+  -o docker-compose.yml
+docker compose up -d
+```
+
+For the AI variant:
+
+```bash
+COMPOSE_PROFILES=ai docker compose up -d
+```
+
+To switch to a pinned version instead of `latest`, set `IMAGE_TAG` in your shell or in a
+`.env` file next to the compose file:
+
+```bash
+IMAGE_TAG=0.7.0 docker compose up -d
+```
+
+### Adapt the compose file to your setup
+
+Most users edit a few things — port, volume paths, restart policy. The file is a normal
+Docker Compose document; no helper tooling required. The fields you'll typically touch:
+
+```yaml
+services:
+  app:
+    image: ghcr.io/therealahall/recommendinator:${IMAGE_TAG:-latest}
+    ports:
+      - "${APP_PORT:-18473}:8000"   # change 18473 if it collides
+    volumes:
+      - ./config:/app/config        # rw — entrypoint writes config.yaml on first run
+      - ./data:/app/data            # persistent SQLite + ChromaDB
+      - ./inputs:/app/inputs:ro     # mount your Goodreads exports etc. here
+      - ./private:/app/private:ro   # optional; private plugin directory
+    restart: unless-stopped
+```
+
+If you don't have private plugins, leave the `private/` directory empty or remove that
+volume entry — the application is happy without it.
+
+## Parameters
+
+### Volume mounts
+
+| Container path | Mode | Purpose |
+|----------------|------|---------|
+| `/app/config` | `rw` | Configuration. Container creates `config.yaml` from `example.yaml` on first run if missing; never overwrites an existing file. **Edit `./config/config.yaml` on the host.** |
+| `/app/data` | `rw` | SQLite database, ChromaDB vectors (AI variant), credential keys, cache. Backed by your host filesystem so it survives container restarts and updates. |
+| `/app/inputs` | `ro` | Source files for ingestion plugins (e.g., `goodreads_library_export.csv`). Read-only because the app shouldn't be modifying your exports. |
+| `/app/private` | `ro` | Optional. Private/personal plugin code (gitignored from the repo). Leave the host directory empty if you don't have any. |
+
+### Ports
+
+| Container port | Default host port | Purpose |
+|----------------|-------------------|---------|
+| `8000` | `18473` | Web UI and HTTP API. Change the host side via `APP_PORT` env var or by editing the `ports:` mapping. |
+
+The Ollama sidecar (AI variant only) runs on `11434` inside the network but is not
+exposed to the host by default — only `app-ai` talks to it.
+
+### Environment variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `IMAGE_TAG` | `latest` | Which image tag the compose file pulls. Set to a semver like `0.7.0` for pinned deployments. The `-ai` suffix is appended automatically for the AI service. |
+| `APP_PORT` | `18473` | Host-side port for the web UI. |
+| `COMPOSE_PROFILES` | (unset) | Set to `ai` to enable the AI variant and the Ollama sidecar. |
+| `OLLAMA_BASE_URL` | `http://ollama:11434` | Set inside the AI service automatically. Override only if you're pointing at a remote Ollama instance. |
+
+## First run
+
+The first `docker compose up` does three things:
+
+1. Pulls the image from GHCR (or builds locally if you've layered the dev override).
+2. Starts the container, which runs `docker/entrypoint.sh` before the application.
+3. The entrypoint sees `/app/config/config.yaml` is missing and copies the bundled
+   `example.yaml` into the mounted volume. It logs:
+
+   ```
+   [entrypoint] No config.yaml found; copied example.yaml as a starting point.
+   [entrypoint] Edit ./config/config.yaml on the host with your settings, then restart.
+   ```
+
+4. The application starts and serves the UI, but most ingestion sources will be
+   inert until you fill in API keys.
+
+After editing `./config/config.yaml`:
+
+```bash
+docker compose restart
+```
+
+The entrypoint never overwrites an existing `config.yaml`, so restarts are safe.
+
+## AI mode
+
+```bash
+COMPOSE_PROFILES=ai docker compose up -d
+```
+
+This starts two extra containers: `recommendinator-ai` (the app with AI extras) and
+`recommendinator-ollama` (the LLM server). The Ollama sidecar pulls the models named
+in your `config.yaml` (`ollama.model` and `ollama.embedding_model`) on first start —
+this can take 5–15 minutes for a 4 GB model on a typical home connection.
+
+You can monitor model downloads with:
+
+```bash
+docker compose logs -f ollama
+```
+
+The `app-ai` service's `depends_on: ollama: condition: service_healthy` ensures the
+recommendation server doesn't start until the models are ready.
+
+### GPU support (NVIDIA)
+
+For GPU-accelerated inference, uncomment the `deploy.resources.reservations.devices`
+block in the `ollama` service of `docker-compose.yml`:
+
+```yaml
+ollama:
+  # ...
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - driver: nvidia
+            count: all
+            capabilities: [gpu]
+```
+
+This requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+on the host.
+
+### Model storage
+
+Downloaded models are persisted in a named Docker volume (`recommendinator-ollama-data`)
+so they survive container restarts and updates. To inspect or relocate:
+
+```bash
+docker volume inspect recommendinator-ollama-data
+```
+
+## Updates
+
+```bash
+docker compose pull        # fetch the latest images
+docker compose up -d       # recreate containers with the new image
+```
+
+To pin to a specific version, set `IMAGE_TAG=X.Y.Z` (in your shell or `.env`) and run
+the same commands.
+
+## Reverse proxy
+
+Recommendinator exposes plain HTTP and assumes you'll terminate TLS in front of it.
+For a typical NAS deployment with [Caddy](https://caddyserver.com/), an entry like:
+
+```caddyfile
+recommendinator.example.com {
+  reverse_proxy localhost:18473
+}
+```
+
+…is sufficient. nginx and Traefik configurations are conventional `proxy_pass` to
+the same host:port.
+
+The application is a single-user tool with **no authentication**, so any reverse
+proxy in front of it must enforce its own access controls (basic auth, OAuth
+forward-auth, IP allowlists, or a VPN). The application does not currently
+trust `X-Forwarded-*` headers for URL generation — links it emits use the host
+and port the request reached it on, which is correct for typical deployments
+where the proxy preserves `Host`.
+
+## Architectures
+
+Both images are published as multi-arch manifests covering `linux/amd64` and `linux/arm64`.
+`docker pull` automatically selects the right architecture for your host. To force a
+specific architecture (e.g., to test arm64 on an x86 dev box with QEMU):
+
+```bash
+docker pull --platform linux/arm64 ghcr.io/therealahall/recommendinator:latest
+```
+
+`linux/arm/v7` (32-bit ARM, older Pi 2/3) is intentionally **not** supported — the
+Python 3.11 wheel ecosystem for ChromaDB is too thin there.
+
+## Troubleshooting
+
+### Config changes don't take effect
+
+The entrypoint only writes `config.yaml` on first run. After that, edit the file on
+the host and run `docker compose restart` (or `docker restart recommendinator`).
+Hot-reload of config is not supported.
+
+### Port 18473 collides with another service
+
+Set `APP_PORT` to a different host port:
+
+```bash
+APP_PORT=8080 docker compose up -d
+```
+
+The container always listens on `8000` internally — only the host-side mapping changes.
+
+### Ollama models never download
+
+Check the sidecar logs:
+
+```bash
+docker compose logs -f ollama
+```
+
+If you see `pull manifest unauthorized` or `connection reset`, the model name in your
+`config.yaml` is likely wrong (typo, missing tag suffix). Run `ollama pull <model>`
+manually inside the sidecar to confirm:
+
+```bash
+docker compose exec ollama ollama pull mistral:7b
+```
+
+### `permission denied` writing to `/app/data`
+
+The container runs as a non-root user (UID derived from the image's `appuser`).
+On hosts with restrictive umasks or SELinux, you may need to chown the host data
+directory:
+
+```bash
+chown -R 1000:1000 ./data ./config
+```
+
+Adjust `1000:1000` to match your appuser's UID/GID inside the image — `docker exec`
+into a running container and run `id appuser` to confirm.
+
+### My private plugins aren't loading
+
+Confirm the host `./private/` directory exists and contains your plugin files. The
+volume mount is `:ro` so the container can read your plugins but not modify them.
+If the directory doesn't exist on the host, Docker may auto-create it as `root`,
+which the appuser can't read — `chown` it as above.
+
+## Local development
+
+If you're contributing to Recommendinator and want hot reload instead of rebuilding
+the image on every change, layer the dev override on top of the production compose:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
+This builds the image locally instead of pulling, bind-mounts `./src` and `./templates`
+into the container, and runs uvicorn with `--reload` so Python changes trigger a
+~1s restart. For frontend hot reload, run `pnpm dev` on the host (Vite serves on
+port 5173 and proxies API calls to the container). See [CONTRIBUTING.md](../CONTRIBUTING.md)
+for the full developer workflow.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -227,7 +227,7 @@ python3.11 -m src.cli preferences --help
 **Solutions:**
 1. Check logs for warnings about missing packages (`chromadb is not installed` or `ollama is not installed`)
 2. Install AI packages: `pip install recommendinator[ai]`
-3. For Docker: use `docker compose --profile ai up app-ai` instead of `docker compose up`
+3. For Docker: set `COMPOSE_PROFILES=ai` and run `docker compose up -d` instead of `docker compose up`
 
 The application gracefully degrades when AI packages are missing — it logs a warning and continues with AI features disabled rather than crashing.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -227,7 +227,7 @@ python3.11 -m src.cli preferences --help
 **Solutions:**
 1. Check logs for warnings about missing packages (`chromadb is not installed` or `ollama is not installed`)
 2. Install AI packages: `pip install recommendinator[ai]`
-3. For Docker: set `COMPOSE_PROFILES=ai` and run `docker compose up -d` instead of `docker compose up`
+3. For Docker: run the AI variant with `docker compose --profile ai up -d app-ai` (the explicit `app-ai` service name is required so the default no-AI `app` service does not also start)
 
 The application gracefully degrades when AI packages are missing — it logs a warning and continues with AI features disabled rather than crashing.
 

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -68,6 +68,11 @@ def main() -> None:
         default=None,
         help="Port to bind to (overrides config)",
     )
+    parser.add_argument(
+        "--reload",
+        action="store_true",
+        help="Enable uvicorn auto-reload (watches src/ and templates/); for development only",
+    )
 
     args = parser.parse_args()
 
@@ -104,25 +109,25 @@ def main() -> None:
         port,
     )
 
-    # Start server
-    # Enable auto-reload in debug mode (watches for file changes)
-    debug_mode = web_config.get("debug", False)
+    # Reload is enabled either by the explicit --reload flag (dev compose) or by web.debug
+    # in config. uvicorn requires an import string when reload is enabled.
+    reload_enabled = args.reload or web_config.get("debug", False)
 
-    # When reload is enabled, uvicorn requires an import string instead of app object
-    if debug_mode:
-        # Set config path in environment for the imported app to use
+    if reload_enabled:
         if config_path:
             os.environ["CONFIG_PATH"] = str(config_path.resolve())
-        # Use import string format for reload support
+        # Resolve reload_dirs relative to the project root so --reload works
+        # from any cwd (uvicorn would otherwise resolve them against $PWD).
+        project_root = Path(__file__).resolve().parents[2]
         uvicorn.run(
-            "src.web.app:app",  # Import string format
+            "src.web.app:app",
             host=host,
             port=port,
             log_level="info",
             reload=True,
+            reload_dirs=[str(project_root / "src"), str(project_root / "templates")],
         )
     else:
-        # When reload is disabled, we can pass the app object directly
         uvicorn.run(
             app,
             host=host,

--- a/tests/docker/test_entrypoint.py
+++ b/tests/docker/test_entrypoint.py
@@ -1,0 +1,220 @@
+"""Behavioural tests for docker/entrypoint.sh.
+
+Exercises the script as a subprocess against a temp directory; no Docker
+daemon is required. The entrypoint reads CONFIG_DIR from the environment
+(defaulting to /app/config), so we redirect it to tmp_path for isolation.
+
+The default value (/app/config) is intentionally not tested here — that path
+only exists inside the container, and verifying the default would require a
+Docker daemon. The runtime behavior is exercised end-to-end by the docker.yml
+PR build's smoke test.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# parents[2] resolves /tests/docker/test_entrypoint.py -> repo root.
+# If this test file is ever moved, this constant must be updated.
+ENTRYPOINT = Path(__file__).resolve().parents[2] / "docker" / "entrypoint.sh"
+
+
+def _run(config_dir: Path, *cmd: str) -> subprocess.CompletedProcess[str]:
+    """Invoke the entrypoint with CONFIG_DIR overridden to ``config_dir``.
+
+    The entrypoint exec's ``cmd`` after handling config bootstrap, so passing
+    a benign command like ``echo`` lets us verify the exec path completed.
+    HOME is set to /tmp to keep /bin/sh from sourcing developer-specific
+    profile files on hosts with exotic shell configs.
+    """
+    return subprocess.run(
+        [str(ENTRYPOINT), *cmd],
+        env={
+            "CONFIG_DIR": str(config_dir),
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/tmp",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture()
+def config_dir(tmp_path: Path) -> Path:
+    """Provide an empty config directory for each test.
+
+    The path lives under pytest's tmp_path which resolves to /tmp on Linux,
+    so it satisfies the entrypoint's CONFIG_DIR bounds check (/app/* | /tmp/*).
+    """
+    target = tmp_path / "config"
+    target.mkdir()
+    return target
+
+
+class TestEntrypointFirstRun:
+    """First-run config bootstrap: example.yaml present, config.yaml missing."""
+
+    def test_copies_example_to_config_and_logs_guidance(self, config_dir: Path) -> None:
+        """Requirement: an empty config directory mounted on first start gets
+        a working config.yaml seeded from example.yaml so the user has a file
+        to edit. Both stdout messages (copy-success and edit-then-restart
+        guidance) must be emitted so users see the next step they need to take.
+        """
+        example_content = "features:\n  ai_enabled: false\n"
+        (config_dir / "example.yaml").write_text(example_content)
+
+        result = _run(config_dir, "echo", "exec-target-ran")
+
+        assert result.returncode == 0
+        config = config_dir / "config.yaml"
+        assert config.exists()
+        assert config.read_text() == example_content
+        assert "copied example.yaml as a starting point" in result.stdout
+        assert "Edit ./config/config.yaml on the host" in result.stdout
+        # Verify exec actually replaced the shell — the passed command's
+        # stdout must reach the test, not get swallowed.
+        assert "exec-target-ran" in result.stdout
+
+
+class TestEntrypointIdempotency:
+    """Subsequent runs: existing config.yaml must never be clobbered."""
+
+    def test_existing_config_is_preserved_silently(self, config_dir: Path) -> None:
+        """Requirement: editing config.yaml then restarting must not lose
+        user settings, and the script should not log copy-success messages
+        (the entrypoint runs on every container start; spurious messages
+        pollute logs at steady state).
+        """
+        user_config = "features:\n  ai_enabled: true\n  custom: value\n"
+        (config_dir / "config.yaml").write_text(user_config)
+        (config_dir / "example.yaml").write_text("features:\n  ai_enabled: false\n")
+
+        result = _run(config_dir, "echo", "ok")
+
+        assert result.returncode == 0
+        assert (config_dir / "config.yaml").read_text() == user_config
+        # No bootstrap messages on the steady-state path.
+        assert "copied example.yaml" not in result.stdout
+        assert "Edit ./config/config.yaml" not in result.stdout
+
+
+class TestEntrypointMissingExample:
+    """No example.yaml available — script warns but still execs."""
+
+    def test_warns_with_specific_message_and_continues(self, config_dir: Path) -> None:
+        """Requirement: an empty config dir with no example.yaml is not an
+        abort condition — the application should still get a chance to start
+        and surface a clearer error. The warning message must name both files
+        so operators know what went wrong.
+        """
+        result = _run(config_dir, "echo", "still-ran")
+
+        assert result.returncode == 0
+        assert "still-ran" in result.stdout
+        assert "neither config.yaml nor example.yaml present" in result.stderr
+        assert not (config_dir / "config.yaml").exists()
+
+
+class TestEntrypointFailurePropagation:
+    """`set -eu` and `exec "$@"` must not swallow errors."""
+
+    def test_exec_propagates_command_exit_code(self, config_dir: Path) -> None:
+        """Requirement: exec replaces the shell, so the exec'd command's exit
+        code must reach the container runtime. A non-zero exit from /bin/false
+        must produce a non-zero exit from the entrypoint as a whole.
+        """
+        (config_dir / "example.yaml").write_text("placeholder: true\n")
+
+        result = _run(config_dir, "/bin/false")
+
+        assert result.returncode != 0
+
+    def test_set_eu_aborts_on_cp_failure(
+        self, config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Requirement: set -eu must surface filesystem errors instead of
+        silently dropping the user into a half-bootstrapped state. A
+        read-only config dir would cause cp to fail; the script must abort
+        before exec'ing the command.
+        """
+        (config_dir / "example.yaml").write_text("placeholder: true\n")
+        # Drop write permission so cp will fail.
+        config_dir.chmod(0o555)
+        try:
+            result = _run(config_dir, "echo", "should-not-run")
+        finally:
+            # Restore write so pytest can clean up tmp_path.
+            config_dir.chmod(0o755)
+
+        assert result.returncode != 0
+        # The exec'd command must NOT have run.
+        assert "should-not-run" not in result.stdout
+
+
+class TestEntrypointBoundsCheck:
+    """CONFIG_DIR override is restricted to /app/* and /tmp/* paths."""
+
+    @pytest.mark.parametrize(
+        "bad_dir",
+        [
+            "/etc/recommendinator",
+            "/home/attacker/config",
+            # Prefix-collision boundary: /app-evil must NOT match /app/*.
+            # Catches a regression where the case glob is loosened to /app*.
+            "/app-evil",
+            "/tmpevil",
+            "relative/config",
+        ],
+    )
+    def test_rejects_config_dir_outside_allowed_paths(self, bad_dir: str) -> None:
+        """Requirement: defense-in-depth against accidental misconfiguration —
+        a CONFIG_DIR pointing outside /app/* or /tmp/* would let the entrypoint
+        write outside the application tree. The script must refuse and exit
+        with a clear error before running cp.
+        """
+        result = subprocess.run(
+            [str(ENTRYPOINT), "echo", "should-not-run"],
+            env={
+                "CONFIG_DIR": bad_dir,
+                "PATH": "/usr/bin:/bin",
+                "HOME": "/tmp",
+            },
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode != 0
+        assert "CONFIG_DIR must be under" in result.stderr
+        assert "should-not-run" not in result.stdout
+
+
+class TestEntrypointShellLint:
+    """Static checks that catch obvious script regressions in pytest."""
+
+    def test_script_is_executable(self) -> None:
+        """The script must be executable; a non-executable file fails to
+        invoke as ENTRYPOINT in Docker."""
+        assert ENTRYPOINT.exists()
+        assert ENTRYPOINT.stat().st_mode & 0o100
+
+    def test_script_declares_set_eu_at_a_real_command_line(self) -> None:
+        """Anchored check: ``set -eu`` must appear at the start of a non-comment
+        line so the shell actually executes it. A loose substring search
+        (``"set -eu" in content``) would happily pass if the directive only
+        appeared in a comment — useless for catching a regression where the
+        line was accidentally deleted but a comment about it survived.
+        """
+        for raw_line in ENTRYPOINT.read_text().splitlines():
+            line = raw_line.lstrip()
+            if line.startswith("#") or not line:
+                continue
+            if line.startswith("set -eu"):
+                return
+        raise AssertionError(
+            "entrypoint.sh does not start a non-comment line with 'set -eu'"
+        )

--- a/tests/web/test_main.py
+++ b/tests/web/test_main.py
@@ -1,9 +1,11 @@
 """Tests for web server entry point utilities."""
 
+import os
 import socket
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from src.web.main import get_local_ip_addresses
+from src.web.main import get_local_ip_addresses, main
 
 
 class TestGetLocalIpAddresses:
@@ -225,3 +227,115 @@ class TestGetLocalIpAddresses:
         get_local_ip_addresses()
 
         mock_udp_socket.close.assert_called_once()
+
+
+class TestMainReloadBehavior:
+    """Verify how main() decides between reload mode and production mode.
+
+    Two inputs activate reload: the --reload CLI flag (used by the dev compose
+    override) or web.debug=true in config (legacy behavior). The branches call
+    uvicorn.run with structurally different first arguments — an import string
+    for reload, the app object for production — so a regression in this logic
+    silently breaks either dev hot-reload or production startup.
+    """
+
+    @patch("src.web.main.uvicorn.run")
+    @patch("src.web.main.create_app")
+    @patch("src.web.main.load_config")
+    def test_reload_flag_uses_import_string_and_dirs(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_app: MagicMock,
+        mock_uvicorn_run: MagicMock,
+    ) -> None:
+        mock_load_config.return_value = {}
+        with patch("sys.argv", ["src.web", "--reload"]):
+            main()
+
+        mock_uvicorn_run.assert_called_once()
+        args, kwargs = mock_uvicorn_run.call_args
+        assert args[0] == "src.web.app:app"
+        assert kwargs["reload"] is True
+        # reload_dirs must be absolute paths to the project's src and templates
+        # so --reload works regardless of cwd.
+        reload_dirs = kwargs["reload_dirs"]
+        assert len(reload_dirs) == 2
+        assert all(Path(d).is_absolute() for d in reload_dirs)
+        assert reload_dirs[0].endswith("/src")
+        assert reload_dirs[1].endswith("/templates")
+
+    @patch("src.web.main.uvicorn.run")
+    @patch("src.web.main.create_app")
+    @patch("src.web.main.load_config")
+    def test_web_debug_config_activates_reload_without_flag(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_app: MagicMock,
+        mock_uvicorn_run: MagicMock,
+    ) -> None:
+        mock_load_config.return_value = {"web": {"debug": True}}
+        with patch("sys.argv", ["src.web"]):
+            main()
+
+        args, kwargs = mock_uvicorn_run.call_args
+        assert args[0] == "src.web.app:app"
+        assert kwargs["reload"] is True
+        # reload_dirs must apply on every reload-enabled path, not just --reload
+        assert len(kwargs["reload_dirs"]) == 2
+
+    @patch("src.web.main.uvicorn.run")
+    @patch("src.web.main.create_app")
+    @patch("src.web.main.load_config")
+    def test_no_flag_no_debug_uses_app_object(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_app: MagicMock,
+        mock_uvicorn_run: MagicMock,
+    ) -> None:
+        mock_load_config.return_value = {}
+        sentinel_app = MagicMock(name="created_app")
+        mock_create_app.return_value = sentinel_app
+        with patch("sys.argv", ["src.web"]):
+            main()
+
+        args, kwargs = mock_uvicorn_run.call_args
+        # First positional arg must be the app object, not an import string
+        assert args[0] is sentinel_app
+        assert kwargs["reload"] is False
+        assert "reload_dirs" not in kwargs
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("src.web.main.uvicorn.run")
+    @patch("src.web.main.create_app")
+    @patch("src.web.main.load_config")
+    def test_reload_with_config_path_sets_env_var(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_app: MagicMock,
+        mock_uvicorn_run: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        config_file = tmp_path / "myconfig.yaml"
+        config_file.write_text("web:\n  debug: false\n")
+        mock_load_config.return_value = {}
+        with patch("sys.argv", ["src.web", "--reload", "--config", str(config_file)]):
+            main()
+
+        assert os.environ["CONFIG_PATH"] == str(config_file.resolve())
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("src.web.main.uvicorn.run")
+    @patch("src.web.main.create_app")
+    @patch("src.web.main.load_config")
+    def test_reload_without_config_path_leaves_env_unchanged(
+        self,
+        mock_load_config: MagicMock,
+        mock_create_app: MagicMock,
+        mock_uvicorn_run: MagicMock,
+    ) -> None:
+        mock_load_config.return_value = {}
+        with patch("sys.argv", ["src.web", "--reload"]):
+            main()
+
+        # No --config supplied: CONFIG_PATH must not be injected into env.
+        assert "CONFIG_PATH" not in os.environ


### PR DESCRIPTION
## Summary

Implements the Docker container shipping work tracked in #41. Recommendinator now publishes official multi-arch images (`linux/amd64` + `linux/arm64`) to GitHub Container Registry on every release tag, in two flavors:

- `ghcr.io/therealahall/recommendinator:VERSION` — default, no AI dependencies
- `ghcr.io/therealahall/recommendinator:VERSION-ai` — adds Ollama client + ChromaDB

A companion sidecar image `ghcr.io/therealahall/recommendinator-ollama:VERSION` (built on `ollama/ollama:0.22.0`) bakes in the model-pull entrypoint so end users never need to download a second file alongside `docker-compose.yml`.

End users can now run:

```bash
docker run -d -p 18473:8000 \
  -v "$(pwd)/config:/app/config" -v "$(pwd)/data:/app/data" \
  ghcr.io/therealahall/recommendinator:latest
```

…or pull `docker-compose.yml` from the release page (it's uploaded as a release asset) and run `COMPOSE_PROFILES=ai docker compose up -d` for the full AI stack.

## What's in the box

**Container plumbing.** `docker/entrypoint.sh` seeds `config.yaml` from `example.yaml` on first run (idempotent, `set -eu`, `CONFIG_DIR` bounded to `/app/*` or `/tmp/*`). `Dockerfile` wires it as `ENTRYPOINT`. `docker-compose.yml` pulls from GHCR with `IMAGE_TAG` and `APP_PORT` env-overridable. `docker-compose.dev.yml` (committed) layers on bind-mounts and uvicorn `--reload` for fast local iteration without rebuilding.

**Source change.** `src/web/main.py` gains an explicit `--reload` CLI flag (was previously gated only by `web.debug` config). `reload_dirs` resolves to absolute paths derived from the project root so it works regardless of cwd.

**Publish workflow.** `.github/workflows/docker.yml` has two jobs. PRs build all three images on amd64 only (no push) and smoke-test the default variant by curling `/api/status`. Tag pushes build multi-arch and push to GHCR with provenance + SBOM attestations. A `Validate semver tag` step at the top of the publish job rejects any tag that isn't strict `vMAJOR.MINOR.PATCH`. The smoke-test curl uses `--max-time 3` so a hung response can't stall the loop.

**CI hardening.** `ci.yml` adds hadolint, shellcheck, and `docker compose config` validation. Two previously-tag-pinned actions (`pnpm/action-setup`, `actions/setup-node`) are now SHA-pinned to match the rest of the workflow.

**Tests.** 12 entrypoint tests in `tests/docker/test_entrypoint.py` cover first-run copy, idempotency, missing-example fallback, exec propagation, `set -eu` cp-failure abort, parametrized `CONFIG_DIR` rejection (`/etc/...`, `/home/...`, `/app-evil`, `/tmpevil`, relative paths), and shell lint. 5 new tests in `tests/web/test_main.py` (`TestMainReloadBehavior`) pin down the `--reload` × `web.debug` × `--config` matrix.

**Docs.** New `docs/DOCKER.md` (linuxserver.io-style: parameter table, GPU notes, reverse proxy, troubleshooting). README and QUICKSTART now lead with Docker; native install is the contributor path. CONTRIBUTING gets a dev-with-Docker section. ARCHITECTURE adds a Container Artifacts subsection. Stale `docker compose --profile ai up app-ai` invocations in README and TROUBLESHOOTING are corrected to `COMPOSE_PROFILES=ai docker compose up -d`.

## Commit structure

10 atomic commits: foundation → fix → feature → tests → CI → publish → docs. The first commit carries the `feat` type (containerized deployment is the user-facing capability); subsequent commits are `fix`/`feat`/`test`/`ci`/`docs` so semantic-release computes a single minor bump.

```
8b4f0e4 feat(docker): bootstrap containerized deployment with compose manifests
d40491d fix(docker): anchor and escape ollama model-name regex
fa00204 feat(web): add --reload CLI flag for development hot reload
c8d5ecd test(web): cover reload-vs-production branching in main()
9904ffd test(docker): cover entrypoint bootstrap and CONFIG_DIR validation
3137c60 ci: lint Dockerfiles, shell scripts, and compose manifests in PR builds
83ad639 ci(docker): build images on PRs and publish multi-arch to GHCR on tags
3d98701 ci(release): attach docker-compose.yml to release assets
28f4789 docs(docker): add deployment guide for default and AI image variants
673eb1b docs: lead install instructions with Docker across project documentation
```

Closes #41

## Test Plan

- [ ] CI green on the PR (Python: black, ruff, mypy, 2542 pytest cases; frontend: vue-tsc, vitest 264 cases; Docker: hadolint, shellcheck, compose config, PR image builds, smoke test).
- [ ] After merge, watch the release workflow tag a new version (semantic-release will see `feat:` commits and bump minor) and confirm `docker.yml` publishes images for default, ai, and ollama variants on both amd64 and arm64.
- [ ] Manually verify `curl -L .../releases/latest/download/docker-compose.yml -o docker-compose.yml && docker compose up -d` works end-to-end on a fresh directory once the first release ships.
- [ ] Confirm the dev override path works locally: `docker compose -f docker-compose.yml -f docker-compose.dev.yml up` plus `pnpm dev` for frontend HMR.

## Follow-ups

- `personal-recommendations-dsfv` (beads): add Trivy vulnerability scanning of the published images on a schedule. Out of scope for this PR.