### PR TITLE
chore(github): simplify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,136 +2,53 @@ name: Bug Report
 description: Report a bug or unexpected behavior
 labels: ["bug"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for reporting a bug! Please fill out the sections below so we can reproduce and fix the issue.
-
   - type: textarea
     id: description
     attributes:
-      label: Bug Description
-      description: A clear, concise description of what went wrong.
-      placeholder: "When I try to sync my Goodreads library, the import fails with a KeyError."
-    validations:
-      required: true
-
-  - type: textarea
-    id: steps
-    attributes:
-      label: Steps to Reproduce
+      label: What happened?
       description: |
-        Exact steps to reproduce the behavior. The more specific, the faster we can fix it.
+        Describe the bug: what you did, what you expected, what happened instead.
+        Include reproduction steps and any error output (remove secrets first).
       placeholder: |
-        1. Set up config with Goodreads source pointing to `inputs/goodreads_export.csv`
+        Syncing my Goodreads library fails after ~50 items.
+        Expected all items to import; instead got a KeyError.
+
+        Repro:
+        1. Configure goodreads source in config.yaml
         2. Run `python3.11 -m src.cli update --source goodreads`
-        3. See error after ~50 items processed
-    validations:
-      required: true
 
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected Behavior
-      description: What you expected to happen.
-      placeholder: "All items from my Goodreads export should be imported successfully."
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual
-    attributes:
-      label: Actual Behavior
-      description: What actually happened instead.
-      placeholder: "Import stops midway with an error traceback."
-    validations:
-      required: true
-
-  - type: textarea
-    id: error-logs
-    attributes:
-      label: Error Logs / Traceback
-      description: |
-        Paste the full error output or traceback. This is critical for diagnosis.
-        **Remove any secrets** (API keys, Steam IDs, file paths with usernames) before pasting.
-      render: shell
-      placeholder: |
         Traceback (most recent call last):
           File "src/ingestion/sources/goodreads.py", line 42, in fetch
             ...
         KeyError: 'Date Read'
-
-  - type: dropdown
-    id: interface
-    attributes:
-      label: Interface
-      description: Where did you encounter the bug?
-      options:
-        - CLI
-        - Web UI
-        - Docker
-        - Both CLI and Web UI
-        - N/A
     validations:
       required: true
-
-  - type: dropdown
-    id: content-type
-    attributes:
-      label: Content Type (if applicable)
-      description: Which content type is affected?
-      options:
-        - Books
-        - Movies
-        - TV Shows
-        - Video Games
-        - All types
-        - N/A
-      default: 5
-
-  - type: input
-    id: data-source
-    attributes:
-      label: Data Source (if applicable)
-      description: Which ingestion source is involved?
-      placeholder: "e.g., Goodreads, Steam, GOG, Epic Games, Sonarr, Radarr, CSV, JSON, Markdown"
-
-  - type: textarea
-    id: config
-    attributes:
-      label: Relevant Config (secrets removed)
-      description: |
-        Paste the relevant section of your `config.yaml`. **Remove all secrets** (API keys, tokens, Steam IDs).
-      render: yaml
-      placeholder: |
-        inputs:
-          goodreads:
-            plugin: goodreads
-            path: "inputs/goodreads_export.csv"
-            enabled: true
 
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Please provide your environment details.
+      description: How are you running Recommendinator?
       value: |
-        - **OS**: [e.g., Ubuntu 24.04, macOS 15, Windows 11]
-        - **Python version**: [output of `python3.11 --version`]
-        - **Installation method**: [uv / Docker / pip]
-        - **AI features enabled**: [yes / no]
-        - **Ollama model** (if applicable): [e.g., mistral:7b, llama3.2]
-    validations:
-      required: true
+        - Install method: [Docker / uv / pip]
+        - OS: [e.g., Fedora 43, macOS 15]
+        - AI features enabled: [yes / no]
+
+  - type: dropdown
+    id: interface
+    attributes:
+      label: Interface
+      description: Where did you hit the bug?
+      options:
+        - CLI
+        - Web UI
+        - Docker
+        - Other / N/A
 
   - type: checkboxes
     id: checklist
     attributes:
-      label: Pre-submission Checklist
+      label: Before submitting
       options:
-        - label: I checked the [Troubleshooting Guide](https://github.com/ahall/recommendinator/blob/main/docs/TROUBLESHOOTING.md) for known solutions
-          required: true
-        - label: I searched existing issues to confirm this hasn't been reported
-          required: true
-        - label: I removed all secrets (API keys, tokens, personal IDs) from this report
+        - label: I removed any secrets (API keys, tokens, personal IDs) from this report
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Troubleshooting Guide
-    url: https://github.com/ahall/recommendinator/blob/main/docs/TROUBLESHOOTING.md
+    url: https://github.com/therealahall/recommendinator/blob/main/docs/TROUBLESHOOTING.md
     about: Check the troubleshooting guide before opening a bug report
   - name: Documentation
-    url: https://github.com/ahall/recommendinator/blob/main/README.md
+    url: https://github.com/therealahall/recommendinator/blob/main/README.md
     about: Read the project documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,44 +2,32 @@ name: Feature Request
 description: Suggest a new feature or enhancement
 labels: ["enhancement"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Have an idea for Recommendinator? We'd love to hear it. Please describe the problem you're solving and your proposed solution.
-
   - type: textarea
-    id: problem
+    id: description
     attributes:
-      label: Problem Statement
-      description: What problem does this feature solve? What's frustrating or missing today?
-      placeholder: "I have a large library and there's no way to filter recommendations by content length, so I keep getting 1000-page books when I only want short reads."
-    validations:
-      required: true
-
-  - type: textarea
-    id: solution
-    attributes:
-      label: Proposed Solution
-      description: How do you envision this working? Be as specific as you like.
+      label: What would you like to see?
+      description: |
+        Describe the feature: the problem it solves, how you envision it working,
+        and any alternatives you've considered.
       placeholder: |
-        Add a "content length" preference that lets users specify preferred length per content type:
-        - Books: short (<300 pages), medium (300-500), long (500+)
-        - Games: short (<10h), medium (10-30h), long (30h+)
+        Filtering recommendations by content length.
+
+        Today there's no way to ask for short reads — I keep getting 1000-page
+        books when I want something I can finish in a weekend.
+
+        A "preferred length" setting per content type would solve this:
+        - Books: short / medium / long (by page count)
+        - Games: short / medium / long (by hours-to-beat)
+
+        I tried custom rules but the scoring doesn't expose page count directly.
     validations:
       required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives Considered
-      description: Have you considered other approaches? What are the trade-offs?
-      placeholder: "I tried using custom rules like 'prefer short books' but the scoring doesn't account for page count directly."
 
   - type: dropdown
     id: area
     attributes:
-      label: Feature Area
-      description: Which part of the system does this affect?
+      label: Area (optional)
+      description: Which part of the system does this touch? Pick the closest match.
       options:
         - Ingestion / Data Sources
         - Recommendations / Scoring
@@ -51,35 +39,4 @@ body:
         - Conversation / Chat
         - Storage / Database
         - Documentation
-        - Other
-    validations:
-      required: true
-
-  - type: dropdown
-    id: content-type
-    attributes:
-      label: Content Type (if applicable)
-      description: Does this feature target specific content types?
-      options:
-        - Books
-        - Movies
-        - TV Shows
-        - Video Games
-        - All types
-        - N/A
-      default: 5
-
-  - type: checkboxes
-    id: ai-required
-    attributes:
-      label: AI Dependency
-      description: Does this feature require AI/Ollama?
-      options:
-        - label: This feature requires AI/Ollama to work
-        - label: This feature works without AI but could be enhanced by it
-
-  - type: textarea
-    id: context
-    attributes:
-      label: Additional Context
-      description: Any other context, screenshots, mockups, or examples that help explain the feature.
+        - Other / Not sure

--- a/.github/ISSUE_TEMPLATE/plugin_request.yml
+++ b/.github/ISSUE_TEMPLATE/plugin_request.yml
@@ -5,15 +5,15 @@ body:
   - type: markdown
     attributes:
       value: |
-        Plugins add new data sources to Recommendinator. You can request support for a service or submit a working plugin.
+        Plugins add new data sources to Recommendinator. Use this form to request
+        a source or submit a working plugin.
 
-        See the [Plugin Development Guide](https://github.com/ahall/recommendinator/blob/main/docs/PLUGIN_DEVELOPMENT.md) for how plugins work.
+        See the [Plugin Development Guide](https://github.com/therealahall/recommendinator/blob/main/docs/PLUGIN_DEVELOPMENT.md) for the plugin contract.
 
   - type: dropdown
     id: type
     attributes:
-      label: Request Type
-      description: Are you requesting a new source or submitting a working plugin?
+      label: Request or submission?
       options:
         - Request — I'd like this data source supported
         - Submission — I have a working plugin ready to contribute
@@ -23,105 +23,35 @@ body:
   - type: input
     id: source-name
     attributes:
-      label: Data Source Name
-      description: The name of the service or platform.
-      placeholder: "e.g., Letterboxd, IMDB, Trakt, IGDB, StoryGraph"
-    validations:
-      required: true
-
-  - type: dropdown
-    id: content-types
-    attributes:
-      label: Content Types
-      description: What type(s) of content does this source provide?
-      multiple: true
-      options:
-        - Books
-        - Movies
-        - TV Shows
-        - Video Games
-    validations:
-      required: true
-
-  - type: dropdown
-    id: data-access
-    attributes:
-      label: Data Access Method
-      description: How does data get into Recommendinator from this source?
-      options:
-        - Public API (with API key)
-        - Public API (no key needed)
-        - OAuth / Token-based API
-        - File export (CSV, JSON, etc.)
-        - Web scraping (no API available)
-        - Other / Unknown
+      label: Data source name
+      placeholder: "e.g., Letterboxd, Trakt, IGDB, StoryGraph"
     validations:
       required: true
 
   - type: textarea
     id: description
     attributes:
-      label: Description
+      label: Details
       description: |
-        Why is this source valuable? What data does it provide?
-        For requests: include links to the API documentation or export format if available.
-        For submissions: describe your implementation approach.
+        What content does this source provide, and how does data get out of it
+        (API, CSV export, OAuth, scraping, etc.)? Include links to API docs or
+        export format if you have them. For submissions, summarize your approach.
       placeholder: |
-        Letterboxd lets users track movies with ratings, reviews, and watchlists.
-        They offer a CSV export: https://letterboxd.com/settings/data/
-        The export includes: Date, Name, Year, Rating, Review, etc.
+        Letterboxd is a movie tracking site. Users can export their data as CSV
+        from https://letterboxd.com/settings/data/ — fields include Date, Name,
+        Year, Rating (1-10), and Review.
+
+        Access method: file export (no API key required).
     validations:
       required: true
-
-  - type: textarea
-    id: data-fields
-    attributes:
-      label: Available Data Fields
-      description: |
-        What fields does this source provide? At minimum, plugins need a title and content type.
-        Mark which fields map to ContentItem properties (title, rating, review, author, status, metadata).
-      placeholder: |
-        - Title → ContentItem.title
-        - Rating (1-10 scale) → ContentItem.rating (normalized to 1-5)
-        - Review text → ContentItem.review
-        - Watch date → metadata
-        - Year → metadata
-        - Directors → ContentItem.author
-        - Genres → metadata.genres
-
-  - type: textarea
-    id: api-docs
-    attributes:
-      label: API / Export Documentation
-      description: Links to API docs, export format descriptions, or example data files.
-      placeholder: |
-        - API docs: https://api.example.com/docs
-        - Export guide: https://example.com/help/export
-        - Rate limits: 100 requests/minute
-
-  - type: textarea
-    id: config-example
-    attributes:
-      label: Proposed Config Format
-      description: How would this source look in `config.yaml`?
-      render: yaml
-      placeholder: |
-        inputs:
-          letterboxd:
-            plugin: letterboxd
-            path: "inputs/letterboxd-export.csv"
-            enabled: true
 
   - type: checkboxes
     id: submission-checklist
     attributes:
-      label: Submission Checklist (for plugin submissions)
-      description: If submitting a working plugin, confirm you've followed the development guide.
+      label: Submission checklist (skip if this is a request)
+      description: For working plugins, confirm you've followed the development guide.
       options:
-        - label: Plugin implements the `SourcePlugin` ABC from `src/ingestion/plugin_base.py`
-        - label: All network calls are mocked in tests (no real API requests)
-        - label: Config validation covers all required fields
-        - label: Ratings are normalized to 1-5 scale
-        - label: Statuses map to `ConsumptionStatus` (COMPLETED, CURRENTLY_CONSUMING, UNREAD)
-        - label: I added the source to `config/example.yaml`
-        - label: Tests pass with `python3.11 -m pytest`
+        - label: Implements the `SourcePlugin` ABC from `src/ingestion/plugin_base.py`
+        - label: All network calls are mocked in tests
+        - label: Ratings normalized to 1-5 and statuses mapped to `ConsumptionStatus`
+        - label: Added the source to `config/example.yaml`

--- a/.github/ISSUE_TEMPLATE/theme_request.yml
+++ b/.github/ISSUE_TEMPLATE/theme_request.yml
@@ -5,15 +5,15 @@ body:
   - type: markdown
     attributes:
       value: |
-        Themes are community-contributed color schemes for the web interface. You can propose a theme idea or submit a ready-to-merge theme.
+        Themes are community-contributed color schemes for the web UI. Use this
+        form to propose a theme or submit a ready-to-merge one.
 
-        See the [Theme Development Guide](https://github.com/ahall/recommendinator/blob/main/docs/THEME_DEVELOPMENT.md) for how themes work.
+        See the [Theme Development Guide](https://github.com/therealahall/recommendinator/blob/main/docs/THEME_DEVELOPMENT.md) for the CSS variable contract.
 
   - type: dropdown
     id: type
     attributes:
-      label: Request Type
-      description: Are you proposing an idea or submitting a ready theme?
+      label: Idea or submission?
       options:
         - Idea — I'd like this theme to exist
         - Submission — I have a working theme ready to contribute
@@ -23,25 +23,15 @@ body:
   - type: input
     id: name
     attributes:
-      label: Theme Name
-      description: A short, descriptive name for the theme.
+      label: Theme name
       placeholder: "e.g., Solarized Dark, Catppuccin Mocha, Dracula"
-    validations:
-      required: true
-
-  - type: textarea
-    id: description
-    attributes:
-      label: Theme Description
-      description: Describe the visual style, mood, or inspiration for the theme.
-      placeholder: "A warm, low-contrast dark theme inspired by the Catppuccin Mocha palette. Easy on the eyes for long browsing sessions."
     validations:
       required: true
 
   - type: dropdown
     id: theme-type
     attributes:
-      label: Theme Type
+      label: Light or dark?
       options:
         - Dark
         - Light
@@ -49,59 +39,27 @@ body:
       required: true
 
   - type: textarea
-    id: colors
+    id: description
     attributes:
-      label: Color Palette
+      label: Description and palette
       description: |
-        List the key colors for your theme. At minimum, provide:
-        - Primary background color
-        - Card/surface background color
-        - Primary text color
-        - Accent color (buttons, links, active states)
-
-        Hex codes preferred. You can reference an existing palette (e.g., "Dracula theme colors").
+        Describe the visual style and key colors (background, surface, text,
+        accent at minimum). Hex codes preferred. Link or screenshot welcome.
       placeholder: |
+        Warm, low-contrast dark theme based on Catppuccin Mocha.
+
         - Background: #1e1e2e
         - Surface: #313244
         - Text: #cdd6f4
         - Accent: #89b4fa
-        - Success: #a6e3a1
-        - Warning: #f9e2af
-        - Error: #f38ba8
     validations:
       required: true
 
   - type: textarea
-    id: preview
-    attributes:
-      label: Preview / Inspiration
-      description: |
-        Attach screenshots, mockups, or links to the color scheme you're basing this on.
-        If submitting a working theme, include a screenshot of the Recommendinator UI with your theme applied.
-
-  - type: textarea
     id: css
     attributes:
-      label: colors.css (for submissions)
+      label: colors.css (submissions only)
       description: |
-        If you're submitting a ready theme, paste your `colors.css` file contents here.
-        See the [Theme Development Guide](https://github.com/ahall/recommendinator/blob/main/docs/THEME_DEVELOPMENT.md) for the full list of CSS variables.
+        For submissions, paste your `colors.css` file. See the Theme Development
+        Guide for the full CSS variable list.
       render: css
-      placeholder: |
-        :root {
-            --bg-primary: #1e1e2e;
-            --bg-card: #313244;
-            --text-primary: #cdd6f4;
-            --accent: #89b4fa;
-            /* ... */
-        }
-
-  - type: checkboxes
-    id: testing
-    attributes:
-      label: Testing (for submissions)
-      description: If submitting a working theme, confirm you've tested it.
-      options:
-        - label: I tested this theme on all pages (Recommendations, Library, Chat, Data, Preferences)
-        - label: I verified text readability, badge contrast, and button visibility
-        - label: I included a `theme.json` with all required fields (name, description, author, version, type)


### PR DESCRIPTION
## Summary

Trims the issue templates so reporters aren't asked to write the same content four different ways.

Fixes #48.

## What changed

- **bug_report.yml**: collapses Description / Steps / Expected / Actual / Error Logs into one "What happened?" textarea. Environment and Interface stay (Environment unrequired, Interface kept as a hint). Pre-submission checklist drops to a single required item: "I removed any secrets". Net: 138 lines → 50 lines.
- **feature_request.yml**: merges Problem / Solution / Alternatives into one description. Drops AI-dependency and content-type fields (mention in description if relevant). Area dropdown stays but is now optional.
- **plugin_request.yml**: merges data-fields / api-docs / config-format / description into one Details textarea. Trims the submission checklist to load-bearing items.
- **theme_request.yml**: merges description / palette / preview into one textarea. `colors.css` upload kept for submissions.
- **config.yml**: fixes stale `github.com/ahall/recommendinator` contact links to use the actual `therealahall/recommendinator` repo path.

## Test plan

- [x] `python3.11 -c "import yaml; [yaml.safe_load(open(f)) for f in ...]"` — all five templates parse.
- [ ] On merge: open a test issue against each template via the GitHub UI to confirm the form renders and required validation fires only on the intended fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)