### PR TITLE
feat(ingestion): add ROM Library scanner plugin

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,6 +19,7 @@ Responsible for parsing and normalizing data from various sources.
 - Epic Games via Legendary (video games)
 - Sonarr API (TV shows)
 - Radarr API (movies)
+- ROM Library — local filesystem scanner with curated ROM extensions, built-in No-Intro/Redump/TOSEC title cleaner, and multi-disc collapse
 - Generic CSV, JSON, Markdown (any content type)
 
 **Design:**

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -110,7 +110,7 @@ With `auto_enrich_on_sync: true`, enrichment runs automatically every time you s
 
 The system supports multiple data sources through a plugin architecture. See `config/example.yaml` for the full list of available plugins and their configuration options.
 
-**Available plugins:** Goodreads (books), Steam (games), GOG (games), Epic Games (games), Sonarr (TV shows), Radarr (movies), and generic CSV/JSON/Markdown importers for any content type.
+**Available plugins:** Goodreads (books), Steam (games), GOG (games), Epic Games (games), Sonarr (TV shows), Radarr (movies), ROM Library (games), and generic CSV/JSON/Markdown importers for any content type.
 
 ### Configure a source
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Most recommendation systems are black boxes that harvest your data. This one:
 
 ### Core Features (No AI Required)
 
-- **Multi-source ingestion** — Import from Goodreads, Steam, GOG, Epic Games, Sonarr, Radarr, or generic CSV/JSON/Markdown files
+- **Multi-source ingestion** — Import from Goodreads, Steam, GOG, Epic Games, Sonarr, Radarr, a local ROM library, or generic CSV/JSON/Markdown files
 - **Cross-content recommendations** — Your love of sci-fi books influences game and movie suggestions via semantic genre clusters that bridge different vocabularies
 - **Smart scoring pipeline** — Genre matching, creator preferences, series order, cluster-aware tag overlap, rating patterns
 - **Custom rules** — Natural language preferences like "avoid horror" or "prefer short books"
@@ -126,6 +126,7 @@ you hot reload without rebuilding.
 | **Epic Games** | Games | Import from your Epic Games library |
 | **Sonarr** | TV Shows | Import from your Sonarr library |
 | **Radarr** | Movies | Import from your Radarr library |
+| **ROM Library** | Games | Scan filesystem directories for emulator ROMs (No-Intro/Redump/TOSEC title cleaning, multi-disc collapse) |
 | **CSV** | Any | Generic CSV with customizable mapping |
 | **JSON** | Any | Generic JSON/JSONL import |
 | **Markdown** | Any | Human-readable markdown lists |

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -134,6 +134,33 @@ inputs:
     content_type: "movie"  # Content type for enrichment
     enabled: false
 
+  # ROM Library — scan local directories for emulator ROMs and game files.
+  # Files are filtered by a curated default ROM extension list (.nes, .smc,
+  # .iso, .chd, .nsp, .xci, .zip, .7z, .m3u, etc.). Folders are always
+  # included so disc-image dirs (e.g. "Final Fantasy VII (Disc 1)/") count
+  # as one game. Titles are run through a built-in cleaner that strips
+  # No-Intro / Redump / TOSEC tags (region, language, year, revision, disc,
+  # bracket dump-codes). Multi-disc games collapse to one item.
+  my_roms:
+    plugin: roms
+    paths:
+      - "/path/to/your/roms/snes"  # One scan root per system directory.
+      - "/path/to/your/roms/n64"
+    # Optional: ADD extensions to the default list (case-insensitive).
+    # Example: include .exe to also pick up Windows installers.
+    include_extensions: []
+    # Optional: REMOVE extensions from the default list.
+    # Example: exclude .tgz if your stash has tgz archives that aren't games.
+    exclude_extensions: []
+    # Optional: glob patterns matched against entry names to skip — useful
+    # for emulator junk folders (e.g. "scripts", "mlc01", "model2"). Hidden
+    # dotfiles are always skipped.
+    exclude_names: []
+    # Optional: extra Python regex patterns appended to the built-in title
+    # cleaner via re.sub. Useful for site-specific tags the defaults miss.
+    extra_strip_patterns: []
+    enabled: false
+
   # You can add multiple instances of the same plugin. For example:
   # tv_shows_json:
   #   plugin: json_import

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -521,3 +521,4 @@ enrichment:
 - `src/ingestion/sources/generic_csv.py` - Flexible CSV importer
 - `src/ingestion/sources/generic_json.py` - Flexible JSON importer
 - `src/ingestion/sources/markdown.py` - Flexible Markdown importer
+- `src/ingestion/sources/roms.py` - ROM Library scanner with curated extension defaults and built-in No-Intro/Redump/TOSEC title cleaner (`_rom_title.py`)

--- a/src/ingestion/sources/_rom_title.py
+++ b/src/ingestion/sources/_rom_title.py
@@ -32,6 +32,11 @@ _INLINE_NOISE = [
     re.compile(r"\s*\(nsw2u\.com\)\s*", re.IGNORECASE),
 ]
 
+# Filesystem-safe naming substitutes underscores for spaces. Applied before
+# the trailing-strip loop so chains like "Some_Game_(USA)_(Beta)" become
+# "Some Game (USA) (Beta)" and the trailing-paren regex can match.
+_UNDERSCORE_RUN = re.compile(r"_+")
+
 # Cap on user-supplied regex string length. A bound on the input regex is the
 # pragmatic mitigation for ReDoS in a single-user tool: Python's re engine
 # has no timeout, but pathological backtracking patterns are typically much
@@ -75,6 +80,8 @@ def clean_display_title(
 
     for pattern in _INLINE_NOISE:
         title = pattern.sub(" ", title)
+
+    title = _UNDERSCORE_RUN.sub(" ", title)
 
     title = _strip_trailing_groups(title)
 

--- a/src/ingestion/sources/_rom_title.py
+++ b/src/ingestion/sources/_rom_title.py
@@ -1,0 +1,137 @@
+"""Internal ROM title cleaner for the roms plugin.
+
+Module-private (underscore prefix); not part of the plugin discovery surface.
+Used by ``RomScannerPlugin`` to normalize ROM filenames into user-facing
+titles.
+
+The cleaner removes the No-Intro / Redump / TOSEC release-tag conventions
+that plague ROM filenames — region codes, language sets, year, revision,
+disc markers, status flags, dump-quality brackets, hex IDs — leaving the
+plain game name. Case is preserved.
+
+A consolidated approach beats user-supplied regex-soup in two ways:
+- Defaults are curated and tested against real-world ROM datasets.
+- Users only need to add patterns for the corner cases their stash has.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+# Strip exactly one trailing "(...)" or "[...]" group with optional leading
+# whitespace. Re-applied in a loop so chains like
+# "Game (US) (1994) (Action) (Genesis)" flatten in one call.
+_TRAILING_PAREN = re.compile(r"\s*\([^()]*\)\s*$")
+_TRAILING_BRACKET = re.compile(r"\s*\[[^\[\]]*\]\s*$")
+
+# Patterns that target noise appearing mid-title (e.g. scene-release domain
+# stamps) where the trailing-group strip loop would never see them.
+# Applied unconditionally before the trailing strip.
+_INLINE_NOISE = [
+    re.compile(r"\s*\(nsw2u\.com\)\s*", re.IGNORECASE),
+]
+
+# Cap on user-supplied regex string length. A bound on the input regex is the
+# pragmatic mitigation for ReDoS in a single-user tool: Python's re engine
+# has no timeout, but pathological backtracking patterns are typically much
+# longer than legitimate ones. Tested filenames are also NAME_MAX-bounded.
+_MAX_PATTERN_LENGTH = 200
+
+# Real-world chains rarely exceed 6 tail groups; the cap also bounds work
+# on adversarial input.
+_MAX_TRAILING_PASSES = 8
+
+
+def clean_display_title(
+    raw: str, extra_patterns: Iterable[re.Pattern[str]] | None = None
+) -> str:
+    """Return a user-facing title with ROM release artifacts stripped.
+
+    Built-in cleanup handles:
+
+    - No-Intro / Redump / TOSEC trailing tags: ``(USA)``, ``(Europe)``,
+      ``(1994)``, ``(Rev A)``, ``(En,Fr,Es)``, ``(Disc 1)``, ``(Beta)``,
+      ``(Proto)``, ``(Sample)``, ``(Demo)``, ``(Unl)``, ``(Alpha)``,
+      ``(v1.0)``, and any other trailing parenthesized group
+    - Bracket tags: ``[NTSC-U]``, ``[SLUS-00067]``, ``[!]``, ``[b]``, ``[h]``,
+      ``[v0]``, ``[T+En]``, ``[0100F2C0115B6000]``
+    - Known noise suffixes: ``(nsw2u.com)``
+
+    User-supplied ``extra_patterns`` are applied last, after the built-ins.
+
+    Args:
+        raw: The raw filename stem (without file extension).
+        extra_patterns: Optional compiled regex objects appended to the
+            built-in cleanup pipeline.
+
+    Returns:
+        Cleaned title with surrounding whitespace trimmed. Returns the
+        empty string if the input is empty after stripping.
+    """
+    title = raw.strip()
+    if not title:
+        return ""
+
+    for pattern in _INLINE_NOISE:
+        title = pattern.sub(" ", title)
+
+    title = _strip_trailing_groups(title)
+
+    if extra_patterns:
+        for pattern in extra_patterns:
+            title = pattern.sub("", title)
+        # Re-sweep trailing groups so an extra pattern that strips a
+        # mid-title segment (exposing a previously-internal paren as the
+        # new tail) is also handled.
+        title = _strip_trailing_groups(title)
+
+    return _collapse_whitespace(title.strip())
+
+
+def _strip_trailing_groups(title: str) -> str:
+    """Repeatedly remove trailing ``(...)`` and ``[...]`` groups."""
+    for _ in range(_MAX_TRAILING_PASSES):
+        new = _TRAILING_BRACKET.sub("", title)
+        new = _TRAILING_PAREN.sub("", new)
+        if new == title:
+            break
+        title = new.rstrip()
+    return title
+
+
+def compile_extra_patterns(patterns: Iterable[str]) -> list[re.Pattern[str]]:
+    """Compile user-supplied regex strings.
+
+    Raises ``ValueError`` on the first invalid pattern (syntax error or
+    excessive length).
+    """
+    compiled: list[re.Pattern[str]] = []
+    for raw_pattern in patterns:
+        if len(raw_pattern) > _MAX_PATTERN_LENGTH:
+            raise ValueError(
+                f"Pattern exceeds {_MAX_PATTERN_LENGTH} chars "
+                f"({len(raw_pattern)}): {raw_pattern!r}"
+            )
+        try:
+            compiled.append(re.compile(raw_pattern))
+        except re.error as error:
+            raise ValueError(f"Invalid regex {raw_pattern!r}: {error}") from error
+    return compiled
+
+
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+
+def _collapse_whitespace(text: str) -> str:
+    """Collapse internal whitespace runs to single spaces."""
+    return _WHITESPACE_RUN.sub(" ", text)
+
+
+def normalize_title_key(title: str) -> str:
+    """Return a key for case-insensitive whitespace-collapsed dedup.
+
+    Two titles whose normalized keys match are considered the same game by
+    the plugin's title-level deduplication.
+    """
+    return _WHITESPACE_RUN.sub(" ", title.strip().lower())

--- a/src/ingestion/sources/roms.py
+++ b/src/ingestion/sources/roms.py
@@ -1,0 +1,459 @@
+"""ROM Library scanner plugin.
+
+Scans configurable filesystem directories at a single depth level. Each
+direct child becomes one :class:`ContentItem`:
+
+- **File** entries are included only when their extension matches the
+  effective extension allow-list (``DEFAULT_EXTENSIONS`` plus
+  ``include_extensions`` minus ``exclude_extensions``).
+- **Folder** entries are always included (a multi-disc folder layout like
+  ``Final Fantasy VII (Disc 1)/`` containing ``.bin`` + ``.cue`` is one
+  game, not two), unless an ``exclude_names`` glob skips the folder name.
+
+Titles are run through the built-in ROM title cleaner
+(``_rom_title.clean_display_title``) which strips region/language/year/
+revision/disc tags and bracket noise from No-Intro / Redump / TOSEC style
+filenames. Users can append additional regex strips via
+``extra_strip_patterns``.
+
+Entries are deduplicated within a single fetch by both **resolved
+absolute path** (so two symlinks to the same target collapse) and
+**normalized title** (so multi-disc games collapse to one item once
+``(Disc N)`` is stripped). The first matching entry wins (entries are
+processed in case-insensitive name order per scan root, then in
+scan-root order).
+
+Item IDs are stable SHA-256 hashes of the resolved path so re-syncs
+update existing rows rather than create duplicates. The storage layer's
+forward-only status progression preserves any user-set status (e.g. a
+ROM marked ``completed`` in the UI keeps that status across re-syncs).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from src.ingestion.plugin_base import (
+    ConfigField,
+    ProgressCallback,
+    SourceError,
+    SourcePlugin,
+)
+from src.ingestion.sources._rom_title import (
+    clean_display_title,
+    compile_extra_patterns,
+    normalize_title_key,
+)
+from src.models.content import ConsumptionStatus, ContentItem, ContentType
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
+
+logger = logging.getLogger(__name__)
+
+
+# Curated ROM extension list. Lowercase, leading dot. When users add or
+# remove extensions via config, the comparison is also case-insensitive.
+DEFAULT_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        # Cartridge ROMs
+        ".nes",
+        ".unf",
+        ".unif",
+        ".sfc",
+        ".smc",
+        ".swc",
+        ".fig",
+        ".gb",
+        ".gbc",
+        ".gba",
+        ".n64",
+        ".z64",
+        ".v64",
+        ".u64",
+        ".nds",
+        ".3ds",
+        ".cia",
+        ".smd",
+        ".gen",
+        ".md",
+        ".bin",
+        ".32x",
+        ".sms",
+        ".gg",
+        ".pce",
+        ".ws",
+        ".wsc",
+        ".ngp",
+        ".ngc",
+        ".col",
+        ".int",
+        ".vec",
+        ".a26",
+        ".a78",
+        ".lnx",
+        ".car",
+        ".crt",
+        ".d64",
+        ".t64",
+        ".tap",
+        ".prg",
+        ".cdt",
+        ".dsk",
+        # Disc images
+        ".iso",
+        ".cue",
+        ".chd",
+        ".gdi",
+        ".cdi",
+        ".img",
+        ".nrg",
+        ".mds",
+        ".mdf",
+        ".gcm",
+        ".rvz",
+        ".wbfs",
+        ".wad",
+        ".nsp",
+        ".xci",
+        ".nro",
+        ".vpk",
+        ".psv",
+        ".pbp",
+        # Multi-disc playlists
+        ".m3u",
+        # Compressed
+        ".zip",
+        ".7z",
+        ".rar",
+        ".gz",
+        ".tgz",
+        ".xz",
+        ".zst",
+    }
+)
+
+
+def _coerce_string_list(value: Any, field_name: str) -> tuple[list[str], str | None]:
+    """Coerce a YAML value into a list of strings.
+
+    Returns ``(values, error)``. Error is non-None when *value* is not a
+    list of strings.
+    """
+    if value is None:
+        return [], None
+    if isinstance(value, str):
+        return [], f"'{field_name}' must be a list, got string"
+    if not isinstance(value, list):
+        return [], f"'{field_name}' must be a list"
+    coerced: list[str] = []
+    for entry in value:
+        if not isinstance(entry, str):
+            return [], f"'{field_name}' entries must be strings"
+        coerced.append(entry)
+    return coerced, None
+
+
+def _normalize_extensions(raw: list[str]) -> set[str]:
+    """Lowercase and ensure each extension begins with a single leading dot."""
+    normalized: set[str] = set()
+    for ext in raw:
+        cleaned = ext.strip().lower()
+        if not cleaned:
+            continue
+        if not cleaned.startswith("."):
+            cleaned = f".{cleaned}"
+        normalized.add(cleaned)
+    return normalized
+
+
+def _effective_extensions(include: list[str], exclude: list[str]) -> set[str]:
+    """Compute the active extension set: defaults + include - exclude."""
+    return (set(DEFAULT_EXTENSIONS) | _normalize_extensions(include)) - (
+        _normalize_extensions(exclude)
+    )
+
+
+def _matches_any_glob(name: str, patterns: list[str]) -> bool:
+    """True when *name* matches any glob in *patterns* (case-sensitive)."""
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
+
+
+def _entry_id(absolute_path: Path) -> str:
+    """Build a stable, unique ContentItem ID from an absolute path."""
+    digest = hashlib.sha256(str(absolute_path).encode("utf-8")).hexdigest()
+    return f"rom:{digest[:16]}"
+
+
+def _safe_size_bytes(path: Path) -> int | None:
+    """Return ``path.stat().st_size`` or ``None`` if stat fails.
+
+    Wrapper exists so the size lookup is independently testable and so
+    flaky-mount stat failures don't abort the surrounding scan.
+    """
+    try:
+        return path.stat().st_size
+    except OSError as error:
+        logger.warning(
+            "Failed to read size for %s: %s; skipping size_bytes", path, error
+        )
+        return None
+
+
+class RomScannerPlugin(SourcePlugin):
+    """Scan local directories for emulator ROMs and game files.
+
+    Each direct child (file matching the active extension set, or any
+    directory) becomes one :class:`ContentItem`. Titles are cleaned with
+    a built-in ROM title cleaner; users can extend the cleanup with
+    ``extra_strip_patterns``.
+    """
+
+    @property
+    def name(self) -> str:
+        return "roms"
+
+    @property
+    def display_name(self) -> str:
+        return "ROM Library"
+
+    @property
+    def description(self) -> str:
+        return "Scan local directories for emulator ROMs and game files"
+
+    @property
+    def content_types(self) -> list[ContentType]:
+        return [ContentType.VIDEO_GAME]
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    def get_config_schema(self) -> list[ConfigField]:
+        return [
+            ConfigField(
+                name="paths",
+                field_type=list,
+                required=True,
+                description=(
+                    "List of directory paths to scan. Each direct child "
+                    "(folder, or file with a matching extension) becomes "
+                    "one game."
+                ),
+            ),
+            ConfigField(
+                name="include_extensions",
+                field_type=list,
+                required=False,
+                default=[],
+                description=(
+                    "Extensions added to the built-in ROM extension list "
+                    "(e.g. ['.exe'] to also include Windows installers). "
+                    "Leading dot optional; case-insensitive."
+                ),
+            ),
+            ConfigField(
+                name="exclude_extensions",
+                field_type=list,
+                required=False,
+                default=[],
+                description=(
+                    "Extensions removed from the built-in list "
+                    "(e.g. ['.tgz'] if your stash has tgz archives that "
+                    "are not games). Leading dot optional; case-insensitive."
+                ),
+            ),
+            ConfigField(
+                name="exclude_names",
+                field_type=list,
+                required=False,
+                default=[],
+                description=(
+                    "Glob patterns matched against entry names (files or "
+                    "folders) to skip — useful for emulator junk folders "
+                    "like 'scripts' or 'mlc01'. Hidden dotfiles are always "
+                    "skipped."
+                ),
+            ),
+            ConfigField(
+                name="extra_strip_patterns",
+                field_type=list,
+                required=False,
+                default=[],
+                description=(
+                    "Optional Python regex patterns appended to the "
+                    "built-in title cleaner via re.sub. Useful for "
+                    "stripping site-specific tags the defaults miss. "
+                    "Avoid unbounded repetition that could backtrack "
+                    "catastrophically on long titles."
+                ),
+            ),
+        ]
+
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: StorageManager | None = None,
+        user_id: int = 1,
+    ) -> list[str]:
+        errors: list[str] = []
+
+        paths_raw = config.get("paths")
+        if paths_raw is None:
+            errors.append("'paths' is required")
+            return errors
+
+        paths, paths_error = _coerce_string_list(paths_raw, "paths")
+        if paths_error is not None:
+            errors.append(paths_error)
+            return errors
+        if not paths:
+            errors.append("'paths' must contain at least one directory")
+
+        for path_str in paths:
+            path = Path(path_str).expanduser()
+            if not path.exists():
+                errors.append(f"Scan path not found: {path_str}")
+            elif not path.is_dir():
+                errors.append(f"Scan path is not a directory: {path_str}")
+
+        for field_name in ("include_extensions", "exclude_extensions", "exclude_names"):
+            _, error = _coerce_string_list(config.get(field_name), field_name)
+            if error is not None:
+                errors.append(error)
+
+        extra_raw, extra_error = _coerce_string_list(
+            config.get("extra_strip_patterns"), "extra_strip_patterns"
+        )
+        if extra_error is not None:
+            errors.append(extra_error)
+        else:
+            try:
+                compile_extra_patterns(extra_raw)
+            except ValueError as error:
+                errors.append(f"Invalid 'extra_strip_patterns' entry: {error}")
+
+        return errors
+
+    def fetch(
+        self,
+        config: dict[str, Any],
+        progress_callback: ProgressCallback | None = None,
+    ) -> Iterator[ContentItem]:
+        scan_roots = [Path(str(p)).expanduser() for p in config["paths"]]
+        for root in scan_roots:
+            if not root.exists():
+                raise SourceError(self.name, f"Scan path not found: {root}")
+            if not root.is_dir():
+                raise SourceError(self.name, f"Scan path is not a directory: {root}")
+
+        active_extensions = _effective_extensions(
+            config.get("include_extensions", []),
+            config.get("exclude_extensions", []),
+        )
+        exclude_names = list(config.get("exclude_names", []))
+        try:
+            extra_patterns = compile_extra_patterns(
+                config.get("extra_strip_patterns", [])
+            )
+        except ValueError as error:
+            raise SourceError(
+                self.name, f"Invalid 'extra_strip_patterns' entry: {error}"
+            ) from error
+
+        source = self.get_source_identifier(config)
+        seen_paths: set[Path] = set()
+        seen_titles: set[str] = set()
+        candidates = _collect_entries(scan_roots, exclude_names)
+        total = len(candidates)
+        logger.info(
+            "Found %d ROM candidates across %d scan roots", total, len(scan_roots)
+        )
+
+        count = 0
+        for index, entry in enumerate(candidates):
+            try:
+                absolute = entry.resolve()
+                is_file = entry.is_file()
+                is_dir = entry.is_dir()
+            except OSError as error:
+                logger.warning("Failed to stat %s: %s; skipping entry", entry, error)
+                continue
+
+            if absolute in seen_paths:
+                continue
+            seen_paths.add(absolute)
+
+            # Dangling symlinks (or other non-file, non-dir entries) report
+            # is_file=False and is_dir=False without raising. Skip them — a
+            # broken link should not surface as a phantom item.
+            if not is_file and not is_dir:
+                logger.debug("Skipping non-file, non-dir entry %s", absolute)
+                continue
+
+            if is_file and entry.suffix.lower() not in active_extensions:
+                continue
+
+            raw_stem = entry.stem if is_file else entry.name
+            title = clean_display_title(raw_stem, extra_patterns)
+            if not title:
+                continue
+
+            normalized = normalize_title_key(title)
+            if normalized in seen_titles:
+                logger.debug("Skipping duplicate title %r at %s", title, absolute)
+                continue
+            seen_titles.add(normalized)
+
+            metadata: dict[str, Any] = {
+                "path": str(absolute),
+                "is_directory": is_dir,
+                "parent_dir": entry.parent.name,
+            }
+            if is_file:
+                size = _safe_size_bytes(entry)
+                if size is not None:
+                    metadata["size_bytes"] = size
+
+            if progress_callback:
+                progress_callback(index + 1, total, title)
+
+            yield ContentItem(
+                id=_entry_id(absolute),
+                title=title,
+                content_type=ContentType.VIDEO_GAME,
+                status=ConsumptionStatus.UNREAD,
+                rating=None,
+                metadata=metadata,
+                source=source,
+            )
+            count += 1
+
+        logger.info("Imported %d items from ROM scan", count)
+
+
+def _collect_entries(scan_roots: list[Path], exclude_names: list[str]) -> list[Path]:
+    """Collect direct children of each scan root in deterministic order.
+
+    Hidden dotfiles (names starting with ``.``) are always skipped. Entries
+    whose name matches any glob in *exclude_names* are also skipped.
+    """
+    entries: list[Path] = []
+    for root in scan_roots:
+        try:
+            children = sorted(root.iterdir(), key=lambda entry: entry.name.lower())
+        except OSError as error:
+            logger.warning("Failed to read scan root %s: %s", root, error)
+            continue
+        for child in children:
+            if child.name.startswith("."):
+                continue
+            if _matches_any_glob(child.name, exclude_names):
+                continue
+            entries.append(child)
+    return entries

--- a/tests/test_rom_title.py
+++ b/tests/test_rom_title.py
@@ -1,0 +1,205 @@
+"""Tests for the internal ROM title cleaner used by the roms plugin."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from src.ingestion.sources._rom_title import (
+    clean_display_title,
+    compile_extra_patterns,
+    normalize_title_key,
+)
+
+
+class TestCleanDisplayTitleBasics:
+    def test_empty_string(self) -> None:
+        assert clean_display_title("") == ""
+
+    def test_whitespace_only(self) -> None:
+        assert clean_display_title("   ") == ""
+
+    def test_plain_title_unchanged(self) -> None:
+        assert clean_display_title("Chrono Trigger") == "Chrono Trigger"
+
+    def test_trims_surrounding_whitespace(self) -> None:
+        assert clean_display_title("  Chrono Trigger  ") == "Chrono Trigger"
+
+    def test_collapses_internal_whitespace(self) -> None:
+        assert clean_display_title("Mega  Man   X") == "Mega Man X"
+
+    def test_preserves_case(self) -> None:
+        assert clean_display_title("FINAL FANTASY") == "FINAL FANTASY"
+
+
+class TestCleanDisplayTitleParens:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Tetris (USA)", "Tetris"),
+            ("Tetris (Europe)", "Tetris"),
+            ("Tetris (Japan)", "Tetris"),
+            ("Tetris (World)", "Tetris"),
+            ("Tetris (USA, Europe)", "Tetris"),
+            ("Tetris (Japan, USA)", "Tetris"),
+            ("1942 (Japan, USA) (En)", "1942"),
+            ("Mario Kart Wii (USA) (En,Fr,Es)", "Mario Kart Wii"),
+            ("Mario Party 9 (USA, Asia) (En,Fr,Es)", "Mario Party 9"),
+            (
+                "Phantasy Star III - Generations of Doom (USA, Europe, Korea) (En)",
+                "Phantasy Star III - Generations of Doom",
+            ),
+            ("Golden Axe (World) (Rev A)", "Golden Axe"),
+            ("Mario Party 4 (USA) (Rev 1)", "Mario Party 4"),
+            (
+                "Castlevania - Bloodlines (US) (1994) (Action Platform) (Sega Genesis)",
+                "Castlevania - Bloodlines",
+            ),
+            (
+                "Trials of Mana (World) (Rev 1) (Collection of Mana)",
+                "Trials of Mana",
+            ),
+            ("Final Fantasy VII (Disc 1)", "Final Fantasy VII"),
+            ("Dragon Warrior VII (Disc 2)", "Dragon Warrior VII"),
+            (
+                "Tactics Ogre - Let Us Cling Together (tr)",
+                "Tactics Ogre - Let Us Cling Together",
+            ),
+        ],
+    )
+    def test_strips_trailing_paren_groups(self, raw: str, expected: str) -> None:
+        assert clean_display_title(raw) == expected
+
+    def test_does_not_strip_internal_parens(self) -> None:
+        # Parens inside the title (not at the end) are preserved.
+        assert (
+            clean_display_title("Game (HD Remix) Edition") == "Game (HD Remix) Edition"
+        )
+
+    def test_no_paren_at_all(self) -> None:
+        assert clean_display_title("Bard's Tale, The") == "Bard's Tale, The"
+
+
+class TestCleanDisplayTitleBrackets:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Castlevania - SoTN [NTSC-U]", "Castlevania - SoTN"),
+            ("Castlevania - SoTN [NTSC-U] [SLUS-00067]", "Castlevania - SoTN"),
+            ("Game [!]", "Game"),
+            ("Game [b]", "Game"),
+            ("Game [h]", "Game"),
+            ("Game [T+En]", "Game"),
+            ("Game [v0]", "Game"),
+            (
+                "The Legend of Zelda Tears of the Kingdom [0100F2C0115B6000][v0][US]",
+                "The Legend of Zelda Tears of the Kingdom",
+            ),
+        ],
+    )
+    def test_strips_trailing_bracket_groups(self, raw: str, expected: str) -> None:
+        assert clean_display_title(raw) == expected
+
+    def test_does_not_strip_internal_brackets(self) -> None:
+        assert clean_display_title("Game [Mid] Edition") == "Game [Mid] Edition"
+
+
+class TestCleanDisplayTitleMixed:
+    def test_mixed_brackets_and_parens(self) -> None:
+        assert (
+            clean_display_title(
+                "Super Mario Party Jamboree [0100965017338000][v0][US](nsw2u.com)"
+            )
+            == "Super Mario Party Jamboree"
+        )
+
+    def test_inline_nsw2u_noise_stripped(self) -> None:
+        # nsw2u.com tag mid-title is removed even without trailing strip.
+        assert clean_display_title("Game (nsw2u.com) Title") == "Game Title"
+
+
+class TestCleanDisplayTitleStatusTags:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Some Game (Beta)", "Some Game"),
+            ("Some Game (Proto)", "Some Game"),
+            ("Some Game (Sample)", "Some Game"),
+            ("Some Game (Demo)", "Some Game"),
+            ("Some Game (Unl)", "Some Game"),
+            ("Some Game (Alpha)", "Some Game"),
+            ("Some Game (v1.0)", "Some Game"),
+            ("Some Game (USA) (Beta)", "Some Game"),
+        ],
+    )
+    def test_status_tags_stripped(self, raw: str, expected: str) -> None:
+        assert clean_display_title(raw) == expected
+
+
+class TestCleanDisplayTitleEdgeCases:
+    def test_only_paren_returns_empty(self) -> None:
+        assert clean_display_title("(USA)") == ""
+
+    def test_only_bracket_returns_empty(self) -> None:
+        assert clean_display_title("[!]") == ""
+
+    def test_paren_then_bracket_then_paren(self) -> None:
+        assert clean_display_title("Game [a] (b) [c]") == "Game"
+
+    def test_extreme_trailing_chain_capped(self) -> None:
+        """12 trailing groups; cap is 8 passes, so 8 groups strip and 4 remain."""
+        raw = "Game" + " (x)" * 12
+        result = clean_display_title(raw)
+        # 12 groups - 8 passes = 4 remaining trailing groups.
+        assert result.count("(x)") == 4
+
+
+class TestCleanDisplayTitleExtraPatterns:
+    def test_extra_pattern_runs_after_defaults(self) -> None:
+        extra = compile_extra_patterns([r"\s*-\s*Definitive Edition$"])
+        assert (
+            clean_display_title("Mass Effect - Definitive Edition (USA)", extra)
+            == "Mass Effect"
+        )
+
+    def test_extra_pattern_can_strip_what_defaults_miss(self) -> None:
+        # No-Intro tag ":Special Edition:" — non-paren marker user wants gone.
+        extra = compile_extra_patterns([r"\s*:Special Edition:$"])
+        assert clean_display_title("Some Game:Special Edition:", extra) == "Some Game"
+
+    def test_no_extra_patterns_still_works(self) -> None:
+        assert clean_display_title("Tetris (USA)", None) == "Tetris"
+
+
+class TestCompileExtraPatterns:
+    def test_compiles_valid_patterns(self) -> None:
+        compiled = compile_extra_patterns([r"\d+$", r"foo"])
+        assert len(compiled) == 2
+        assert all(isinstance(p, re.Pattern) for p in compiled)
+
+    def test_raises_value_error_on_invalid_regex(self) -> None:
+        with pytest.raises(ValueError, match=r"\[unclosed"):
+            compile_extra_patterns(["[unclosed"])
+
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert compile_extra_patterns([]) == []
+
+    def test_rejects_pattern_exceeding_length_cap(self) -> None:
+        """Long patterns are bounded — pragmatic ReDoS mitigation."""
+        with pytest.raises(ValueError, match="exceeds 200 chars"):
+            compile_extra_patterns(["a" * 201])
+
+
+class TestNormalizeTitleKey:
+    def test_lowercases(self) -> None:
+        assert normalize_title_key("TETRIS") == "tetris"
+
+    def test_collapses_whitespace(self) -> None:
+        assert normalize_title_key("Mega  Man   X") == "mega man x"
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        assert normalize_title_key("  Tetris  ") == "tetris"
+
+    def test_distinct_titles_distinct_keys(self) -> None:
+        assert normalize_title_key("Tetris") != normalize_title_key("Tetris 2")

--- a/tests/test_rom_title.py
+++ b/tests/test_rom_title.py
@@ -119,6 +119,21 @@ class TestCleanDisplayTitleMixed:
         assert clean_display_title("Game (nsw2u.com) Title") == "Game Title"
 
 
+class TestCleanDisplayTitleUnderscores:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Mortal_Kombat", "Mortal Kombat"),
+            ("Final_Fantasy_VII", "Final Fantasy VII"),
+            ("Some___Game", "Some Game"),  # multiple underscores collapse
+            ("Some_Game_(USA)_(Beta)", "Some Game"),  # underscores expose tail parens
+            ("Foo_Bar.Baz_Qux", "Foo Bar.Baz Qux"),  # dots preserved
+        ],
+    )
+    def test_underscores_become_spaces(self, raw: str, expected: str) -> None:
+        assert clean_display_title(raw) == expected
+
+
 class TestCleanDisplayTitleStatusTags:
     @pytest.mark.parametrize(
         "raw,expected",

--- a/tests/test_rom_title.py
+++ b/tests/test_rom_title.py
@@ -128,10 +128,22 @@ class TestCleanDisplayTitleUnderscores:
             ("Some___Game", "Some Game"),  # multiple underscores collapse
             ("Some_Game_(USA)_(Beta)", "Some Game"),  # underscores expose tail parens
             ("Foo_Bar.Baz_Qux", "Foo Bar.Baz Qux"),  # dots preserved
+            # Leading and trailing underscores get swept by the surrounding strip
+            # (underscore→space then final .strip()).
+            ("_Leading_Game", "Leading Game"),
+            ("Trailing_Game_", "Trailing Game"),
+            # Inline-noise + underscore interaction: nsw2u stripped first
+            # (replaced with space), then underscores become spaces, then
+            # whitespace collapses.
+            ("Some_Game_(nsw2u.com)_Edition", "Some Game Edition"),
         ],
     )
     def test_underscores_become_spaces(self, raw: str, expected: str) -> None:
         assert clean_display_title(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["_", "___"])
+    def test_underscore_only_input_returns_empty(self, raw: str) -> None:
+        assert clean_display_title(raw) == ""
 
 
 class TestCleanDisplayTitleStatusTags:

--- a/tests/test_roms.py
+++ b/tests/test_roms.py
@@ -1,0 +1,705 @@
+"""Tests for the RomScannerPlugin (ROM Library)."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from src.ingestion.plugin_base import SourceError, SourcePlugin
+from src.ingestion.sources.roms import (
+    DEFAULT_EXTENSIONS,
+    RomScannerPlugin,
+    _safe_size_bytes,
+)
+from src.models.content import ConsumptionStatus, ContentType
+
+
+@pytest.fixture()
+def plugin() -> RomScannerPlugin:
+    return RomScannerPlugin()
+
+
+@pytest.fixture()
+def rom_dir(tmp_path: Path) -> Path:
+    """A scan root with a realistic mix of ROMs, a folder, and junk files.
+
+    Default-extension matches: Chrono Trigger.zip, Mario Kart 64 (USA).z64
+    Folder (always included): Doom/
+    Filtered out by default-extension check: notes.txt, EMULATOR.cfg
+    """
+    root = tmp_path / "snes"
+    root.mkdir()
+    (root / "Chrono Trigger.zip").write_bytes(b"rom-data")
+    (root / "Mario Kart 64 (USA).z64").write_bytes(b"rom-data-2")
+    (root / "Doom").mkdir()
+    (root / "Doom" / "doom.exe").write_bytes(b"exe")
+    (root / "notes.txt").write_text("ignore me — wrong extension")
+    (root / "EMULATOR.cfg").write_text("emulator config")
+    (root / ".hidden").write_text("hidden")
+    return root
+
+
+class TestRomScannerProperties:
+    """Tests for plugin metadata properties."""
+
+    def test_is_source_plugin(self, plugin: RomScannerPlugin) -> None:
+        assert isinstance(plugin, SourcePlugin)
+
+    def test_name(self, plugin: RomScannerPlugin) -> None:
+        assert plugin.name == "roms"
+
+    def test_display_name(self, plugin: RomScannerPlugin) -> None:
+        assert plugin.display_name == "ROM Library"
+
+    def test_content_types(self, plugin: RomScannerPlugin) -> None:
+        assert plugin.content_types == [ContentType.VIDEO_GAME]
+
+    def test_requires_api_key(self, plugin: RomScannerPlugin) -> None:
+        assert plugin.requires_api_key is False
+
+    def test_requires_network(self, plugin: RomScannerPlugin) -> None:
+        assert plugin.requires_network is False
+
+    def test_description(self, plugin: RomScannerPlugin) -> None:
+        assert plugin.description == (
+            "Scan local directories for emulator ROMs and game files"
+        )
+
+    def test_config_schema_field_set(self, plugin: RomScannerPlugin) -> None:
+        names = {field.name for field in plugin.get_config_schema()}
+        assert names == {
+            "paths",
+            "include_extensions",
+            "exclude_extensions",
+            "exclude_names",
+            "extra_strip_patterns",
+        }
+
+    def test_default_extensions_cover_common_systems(self) -> None:
+        # Spot check: every major system the user actually has.
+        for ext in (".nes", ".smc", ".z64", ".gba", ".rvz", ".7z", ".m3u", ".xci"):
+            assert ext in DEFAULT_EXTENSIONS
+
+
+class TestRomScannerValidation:
+    """Tests for config validation."""
+
+    def test_valid_config(self, plugin: RomScannerPlugin, rom_dir: Path) -> None:
+        errors = plugin.validate_config({"paths": [str(rom_dir)]})
+        assert errors == []
+
+    def test_missing_paths(self, plugin: RomScannerPlugin) -> None:
+        errors = plugin.validate_config({})
+        assert any("paths" in error for error in errors)
+
+    def test_empty_paths(self, plugin: RomScannerPlugin) -> None:
+        errors = plugin.validate_config({"paths": []})
+        assert any("paths" in error for error in errors)
+
+    def test_paths_not_a_list(self, plugin: RomScannerPlugin, rom_dir: Path) -> None:
+        errors = plugin.validate_config({"paths": str(rom_dir)})
+        assert any("list" in error.lower() for error in errors)
+
+    def test_nonexistent_path(self, plugin: RomScannerPlugin) -> None:
+        errors = plugin.validate_config({"paths": ["/does/not/exist"]})
+        assert any("not found" in error.lower() for error in errors)
+
+    def test_path_is_file_not_directory(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        file_path = tmp_path / "not-a-dir.txt"
+        file_path.write_text("x")
+        errors = plugin.validate_config({"paths": [str(file_path)]})
+        assert any("directory" in error.lower() for error in errors)
+
+    def test_invalid_extra_strip_pattern_regex(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        errors = plugin.validate_config(
+            {"paths": [str(rom_dir)], "extra_strip_patterns": ["[unclosed"]}
+        )
+        assert any("extra_strip_patterns" in error for error in errors)
+
+    def test_include_extensions_must_be_list(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        errors = plugin.validate_config(
+            {"paths": [str(rom_dir)], "include_extensions": ".zip"}
+        )
+        assert any("include_extensions" in error for error in errors)
+
+    def test_exclude_extensions_must_be_list(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        errors = plugin.validate_config(
+            {"paths": [str(rom_dir)], "exclude_extensions": ".zip"}
+        )
+        assert any("exclude_extensions" in error for error in errors)
+
+    def test_exclude_names_must_be_list(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        errors = plugin.validate_config(
+            {"paths": [str(rom_dir)], "exclude_names": "scripts"}
+        )
+        assert any("exclude_names" in error for error in errors)
+
+    def test_collects_multiple_errors(self, plugin: RomScannerPlugin) -> None:
+        errors = plugin.validate_config(
+            {"paths": ["/does/not/exist"], "exclude_names": "scripts"}
+        )
+        assert any("not found" in error.lower() for error in errors)
+        assert any("exclude_names" in error for error in errors)
+
+    def test_include_extensions_int_value_rejected(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        """Coercion error when value is neither None, str, nor list."""
+        errors = plugin.validate_config(
+            {"paths": [str(rom_dir)], "include_extensions": 42}
+        )
+        assert any("include_extensions" in error for error in errors)
+
+    def test_include_extensions_non_string_entry_rejected(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        errors = plugin.validate_config(
+            {"paths": [str(rom_dir)], "include_extensions": [".zip", 99]}
+        )
+        assert any(
+            "include_extensions" in error and "strings" in error for error in errors
+        )
+
+    def test_extra_strip_patterns_non_list_rejected(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        """Coercion error path (line 319 branch) — non-list value."""
+        errors = plugin.validate_config(
+            {"paths": [str(rom_dir)], "extra_strip_patterns": "not-a-list"}
+        )
+        assert any("extra_strip_patterns" in error for error in errors)
+
+    def test_extra_strip_patterns_length_cap_rejected(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        errors = plugin.validate_config(
+            {
+                "paths": [str(rom_dir)],
+                "extra_strip_patterns": ["a" * 201],
+            }
+        )
+        assert any("extra_strip_patterns" in error for error in errors)
+
+
+class TestRomScannerFetchExtensionFiltering:
+    """Default extension filter and include/exclude knobs."""
+
+    def test_only_extension_matching_files_included(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        items = list(plugin.fetch({"paths": [str(rom_dir)]}))
+        titles = {item.title for item in items}
+        # Doom/ folder always included; .zip + .z64 match defaults;
+        # .txt and .cfg are filtered out by extension; dotfile skipped.
+        assert titles == {"Chrono Trigger", "Mario Kart 64", "Doom"}
+
+    def test_include_extensions_adds_to_defaults(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "Game.zip").write_bytes(b"x")
+        (root / "Installer.exe").write_bytes(b"y")
+        items = list(
+            plugin.fetch({"paths": [str(root)], "include_extensions": [".exe"]})
+        )
+        titles = {item.title for item in items}
+        assert titles == {"Game", "Installer"}
+
+    def test_exclude_extensions_removes_from_defaults(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "Game.zip").write_bytes(b"x")
+        (root / "Other.tgz").write_bytes(b"y")
+        items = list(
+            plugin.fetch({"paths": [str(root)], "exclude_extensions": [".tgz"]})
+        )
+        titles = {item.title for item in items}
+        assert titles == {"Game"}
+
+    def test_extensions_are_case_insensitive(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "GameA.ZIP").write_bytes(b"x")
+        (root / "GameB.Z64").write_bytes(b"y")
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert {item.title for item in items} == {"GameA", "GameB"}
+
+    def test_extension_normalization_accepts_no_dot(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "Installer.exe").write_bytes(b"x")
+        items = list(
+            plugin.fetch({"paths": [str(root)], "include_extensions": ["exe"]})
+        )
+        assert {item.title for item in items} == {"Installer"}
+
+    def test_empty_extension_entries_silently_dropped(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        """Empty/whitespace extension entries are skipped, not crashes."""
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "Game.zip").write_bytes(b"x")
+        items = list(
+            plugin.fetch(
+                {"paths": [str(root)], "include_extensions": ["", "  ", ".exe"]}
+            )
+        )
+        assert {item.title for item in items} == {"Game"}
+
+
+class TestRomScannerFetchTitleCleaning:
+    """Built-in cleaner and extra_strip_patterns interaction."""
+
+    def test_default_cleaner_strips_region_and_year(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "snes"
+        root.mkdir()
+        (root / "1942 (Japan, USA) (En).zip").write_bytes(b"x")
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert items[0].title == "1942"
+
+    def test_default_cleaner_strips_brackets(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "psx"
+        root.mkdir()
+        (root / "Castlevania - SoTN [NTSC-U] [SLUS-00067].rar").write_bytes(b"x")
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert items[0].title == "Castlevania - SoTN"
+
+    def test_extra_strip_patterns_appended_after_defaults(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "Mass Effect (USA) - Definitive Edition.zip").write_bytes(b"x")
+        items = list(
+            plugin.fetch(
+                {
+                    "paths": [str(root)],
+                    "extra_strip_patterns": [r"\s*-\s*Definitive Edition$"],
+                }
+            )
+        )
+        assert items[0].title == "Mass Effect"
+
+    def test_invalid_extra_strip_pattern_raises_in_fetch(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        with pytest.raises(SourceError, match="extra_strip_patterns"):
+            list(
+                plugin.fetch(
+                    {
+                        "paths": [str(rom_dir)],
+                        "extra_strip_patterns": ["[unclosed"],
+                    }
+                )
+            )
+
+    def test_empty_title_after_strip_skips_entry(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "(USA).zip").write_bytes(b"x")
+        (root / "Tetris.zip").write_bytes(b"y")
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert {item.title for item in items} == {"Tetris"}
+
+
+class TestRomScannerMultiDiscCollapse:
+    """The hero use case: 4 discs of one game collapse to one item."""
+
+    def test_multi_disc_collapses_to_one_item(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "psx"
+        root.mkdir()
+        for disc in range(1, 5):
+            (root / f"Final Fantasy VII (USA) (Disc {disc}).bin").write_bytes(b"x")
+        (root / "Chrono Trigger (USA).zip").write_bytes(b"y")
+
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        titles = {item.title for item in items}
+        assert titles == {"Final Fantasy VII", "Chrono Trigger"}
+
+    def test_disc_1_wins_via_sort_order(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "psx"
+        root.mkdir()
+        # Create out of order to prove sort wins, not creation order.
+        (root / "Final Fantasy VII (USA) (Disc 2).bin").write_bytes(b"d2")
+        (root / "Final Fantasy VII (USA) (Disc 1).bin").write_bytes(b"d1")
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert len(items) == 1
+        assert items[0].title == "Final Fantasy VII"
+        assert items[0].metadata["path"].endswith("(Disc 1).bin")
+
+
+class TestRomScannerFolders:
+    """Folder entries are always included unless excluded by name."""
+
+    def test_folder_included_regardless_of_extension(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "psx"
+        root.mkdir()
+        nested = root / "Resident Evil"
+        nested.mkdir()
+        (nested / "track1.bin").write_bytes(b"x")
+        (nested / "track1.cue").write_text("cue")
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert {item.title for item in items} == {"Resident Evil"}
+
+    def test_exclude_names_skips_folder(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "model2"
+        root.mkdir()
+        (root / "scripts").mkdir()
+        (root / "Daytona.zip").write_bytes(b"x")
+        items = list(plugin.fetch({"paths": [str(root)], "exclude_names": ["scripts"]}))
+        assert {item.title for item in items} == {"Daytona"}
+
+    def test_exclude_names_glob_pattern(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        """Glob exclusion runs against names that would otherwise pass the
+        extension filter — proves the glob is the operative filter, not a
+        side-effect of the extension check.
+        """
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "common.zip").write_bytes(b"a")
+        (root / "daytona.zip").write_bytes(b"b")
+        (root / "Daytona USA.zip").write_bytes(b"c")
+        items = list(
+            plugin.fetch(
+                {
+                    "paths": [str(root)],
+                    "exclude_names": ["common.*", "daytona.*"],
+                }
+            )
+        )
+        assert {item.title for item in items} == {"Daytona USA"}
+
+    def test_exclude_names_skips_files_too(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "Tetris.zip").write_bytes(b"x")
+        (root / "BadGame.zip").write_bytes(b"y")
+        items = list(
+            plugin.fetch({"paths": [str(root)], "exclude_names": ["BadGame.zip"]})
+        )
+        assert {item.title for item in items} == {"Tetris"}
+
+
+class TestRomScannerHidden:
+    def test_hidden_dotfiles_always_skipped(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / ".DS_Store").write_bytes(b"x")
+        (root / ".cache").mkdir()
+        (root / "Tetris.zip").write_bytes(b"y")
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert {item.title for item in items} == {"Tetris"}
+
+    def test_directory_with_only_hidden_yields_nothing(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / ".DS_Store").write_bytes(b"x")
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert items == []
+
+
+class TestRomScannerDedup:
+    def test_dedupes_when_same_path_listed_twice(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        items = list(plugin.fetch({"paths": [str(rom_dir), str(rom_dir)]}))
+        assert len(items) == 3
+
+    def test_symlink_to_same_target_dedupes(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "stash"
+        root.mkdir()
+        target = root / "Tetris.zip"
+        target.write_bytes(b"x")
+        (root / "tetris-link.zip").symlink_to(target)
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert len(items) == 1
+
+    def test_dangling_symlink_skipped(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        """A symlink whose target does not exist reports neither file nor dir;
+        it's skipped rather than yielded as a phantom entry."""
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "Tetris.zip").write_bytes(b"x")
+        (root / "broken.zip").symlink_to(tmp_path / "missing-target")
+
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert {item.title for item in items} == {"Tetris"}
+
+    def test_title_dedup_spans_scan_roots(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        nes = tmp_path / "nes"
+        nes.mkdir()
+        (nes / "Tetris.nes").write_bytes(b"x")
+        snes = tmp_path / "snes"
+        snes.mkdir()
+        (snes / "Tetris.smc").write_bytes(b"y")
+        items = list(plugin.fetch({"paths": [str(nes), str(snes)]}))
+        assert len(items) == 1
+        assert items[0].metadata["parent_dir"] == "nes"
+
+
+class TestRomScannerMetadata:
+    def test_metadata_includes_path_and_is_directory(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        items = list(plugin.fetch({"paths": [str(rom_dir)]}))
+        by_title = {item.title: item for item in items}
+        assert by_title["Chrono Trigger"].metadata["is_directory"] is False
+        assert by_title["Doom"].metadata["is_directory"] is True
+
+    def test_metadata_includes_parent_dir_name(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        items = list(plugin.fetch({"paths": [str(rom_dir)]}))
+        for item in items:
+            assert item.metadata["parent_dir"] == "snes"
+
+    def test_metadata_includes_size_for_files(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        items = list(plugin.fetch({"paths": [str(rom_dir)]}))
+        by_title = {item.title: item for item in items}
+        assert by_title["Chrono Trigger"].metadata["size_bytes"] == len(b"rom-data")
+        # Directory entries have no size_bytes — only files do.
+        assert "size_bytes" not in by_title["Doom"].metadata
+
+
+class TestRomScannerItem:
+    def test_all_items_unread_video_game(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        items = list(plugin.fetch({"paths": [str(rom_dir)]}))
+        assert len(items) == 3
+        for item in items:
+            assert item.content_type == ContentType.VIDEO_GAME.value
+            assert item.status == ConsumptionStatus.UNREAD.value
+            assert item.rating is None
+
+    def test_id_uses_rom_prefix_and_is_stable(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        config = {"paths": [str(rom_dir)]}
+        first = {item.title: item.id for item in plugin.fetch(config)}
+        second = {item.title: item.id for item in plugin.fetch(config)}
+        assert first == second
+        for item_id in first.values():
+            assert item_id.startswith("rom:")
+
+    def test_source_set_from_source_id(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        items = list(plugin.fetch({"_source_id": "my_roms", "paths": [str(rom_dir)]}))
+        for item in items:
+            assert item.source == "my_roms"
+
+    def test_source_falls_back_to_plugin_name(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        items = list(plugin.fetch({"paths": [str(rom_dir)]}))
+        for item in items:
+            assert item.source == "roms"
+
+
+class TestRomScannerProgressCallback:
+    def test_callback_fires_per_yielded_item(
+        self, plugin: RomScannerPlugin, rom_dir: Path
+    ) -> None:
+        calls: list[tuple[int, int | None, str | None]] = []
+
+        def cb(processed: int, total: int | None, current: str | None) -> None:
+            calls.append((processed, total, current))
+
+        list(plugin.fetch({"paths": [str(rom_dir)]}, progress_callback=cb))
+        # 3 yielded items, processed monotonic, total = candidate count (5:
+        # Chrono, Doom, EMULATOR.cfg, Mario Kart, notes.txt). The callback
+        # receives the cleaned title at yield time.
+        assert len(calls) == 3
+        processed_values = [call[0] for call in calls]
+        assert processed_values == sorted(processed_values)
+        for call in calls:
+            assert call[1] == 5
+        titles_seen = {call[2] for call in calls}
+        assert titles_seen == {"Chrono Trigger", "Mario Kart 64", "Doom"}
+
+    def test_callback_skips_deduped_titles(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "psx"
+        root.mkdir()
+        for disc in range(1, 5):
+            (root / f"Final Fantasy VII (USA) (Disc {disc}).bin").write_bytes(b"x")
+        (root / "Chrono Trigger.zip").write_bytes(b"y")
+
+        calls: list[tuple[int, int | None, str | None]] = []
+
+        def cb(processed: int, total: int | None, current: str | None) -> None:
+            calls.append((processed, total, current))
+
+        list(plugin.fetch({"paths": [str(root)]}, progress_callback=cb))
+        # 5 candidates total; 2 unique titles after dedup.
+        assert len(calls) == 2
+        for call in calls:
+            assert call[1] == 5
+
+
+class TestRomScannerErrors:
+    def test_missing_path_raises(self, plugin: RomScannerPlugin) -> None:
+        with pytest.raises(SourceError, match="not found"):
+            list(plugin.fetch({"paths": ["/nonexistent/scan/root"]}))
+
+    def test_path_not_directory_raises(
+        self, plugin: RomScannerPlugin, tmp_path: Path
+    ) -> None:
+        file_path = tmp_path / "file.txt"
+        file_path.write_text("x")
+        with pytest.raises(SourceError, match="directory"):
+            list(plugin.fetch({"paths": [str(file_path)]}))
+
+    def test_unreadable_scan_root_skipped(
+        self,
+        plugin: RomScannerPlugin,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        good = tmp_path / "good"
+        good.mkdir()
+        (good / "Zelda.zip").write_bytes(b"x")
+        bad = tmp_path / "bad"
+        bad.mkdir()
+
+        original_iterdir = Path.iterdir
+
+        def fake_iterdir(self: Path) -> Iterator[Path]:
+            if self == bad:
+                raise PermissionError("denied")
+            return original_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+        items = list(plugin.fetch({"paths": [str(bad), str(good)]}))
+        assert {item.title for item in items} == {"Zelda"}
+
+    def test_is_file_oserror_skips_entry(
+        self,
+        plugin: RomScannerPlugin,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "Bad.zip").write_bytes(b"x")
+        (root / "Good.zip").write_bytes(b"y")
+        original_is_file = Path.is_file
+
+        def fake_is_file(self: Path) -> bool:
+            if self.name == "Bad.zip":
+                raise PermissionError("denied")
+            return original_is_file(self)
+
+        monkeypatch.setattr(Path, "is_file", fake_is_file)
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert {item.title for item in items} == {"Good"}
+
+    def test_size_lookup_failure_skips_size_bytes(
+        self,
+        plugin: RomScannerPlugin,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When _safe_size_bytes returns None, the entry is yielded without a
+        size_bytes metadata key — flaky-mount tolerance."""
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "Tetris.zip").write_bytes(b"x")
+
+        monkeypatch.setattr(
+            "src.ingestion.sources.roms._safe_size_bytes", lambda path: None
+        )
+
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert len(items) == 1
+        assert "size_bytes" not in items[0].metadata
+
+    def test_safe_size_bytes_returns_none_on_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unit test for the size helper itself."""
+        target = tmp_path / "Tetris.zip"
+        target.write_bytes(b"x")
+
+        def fake_stat(self: Path, *args: object, **kwargs: object) -> os.stat_result:
+            raise OSError("stat failed")
+
+        monkeypatch.setattr(Path, "stat", fake_stat)
+        assert _safe_size_bytes(target) is None
+
+    def test_resolve_failure_skips_entry(
+        self,
+        plugin: RomScannerPlugin,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An OSError from Path.resolve() (e.g. circular symlink) skips the
+        entry instead of aborting the entire scan."""
+        root = tmp_path / "stash"
+        root.mkdir()
+        (root / "Bad.zip").write_bytes(b"x")
+        (root / "Good.zip").write_bytes(b"y")
+
+        original_resolve = Path.resolve
+
+        def fake_resolve(self: Path, *args: object, **kwargs: object) -> Path:
+            if self.name == "Bad.zip":
+                raise OSError("resolve failed")
+            return original_resolve(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", fake_resolve)
+        items = list(plugin.fetch({"paths": [str(root)]}))
+        assert {item.title for item in items} == {"Good"}


### PR DESCRIPTION
## Summary

Adds a depth-1 filesystem scanner targeted at emulator ROMs and game files.

Closes #33

## What Changed

- `src/ingestion/sources/roms.py` — `RomScannerPlugin` (id: `roms`, display: "ROM Library"). Auto-discovered by `PluginRegistry`.
- `src/ingestion/sources/_rom_title.py` — module-private ROM title cleaner with No-Intro/Redump/TOSEC defaults. Underscore prefix excludes it from plugin discovery.
- `tests/test_roms.py` + `tests/test_rom_title.py` — 122 tests (100% line coverage on both source modules).
- Docs: README, ARCHITECTURE, QUICKSTART, `docs/PLUGIN_DEVELOPMENT.md`, `config/example.yaml`.

## Plugin behavior

**Files** are included only when the extension matches the active allow-list (`DEFAULT_EXTENSIONS` plus `include_extensions` minus `exclude_extensions`). Curated ~70-extension list covers cartridge ROMs, disc images, multi-disc playlists (`.m3u`), and common compressed archives.

**Folders** are always included so a multi-disc folder layout (`Final Fantasy VII (Disc 1)/` containing `.bin` + `.cue`) counts as one game. The `exclude_names` glob list provides an escape valve for emulator junk folders (`scripts/`, `mlc01/`, `model2/`).

**Title cleaner** strips No-Intro / Redump / TOSEC release tags: region (`(USA)`, `(Europe)`), language (`(En,Fr,Es)`), year, revision (`(Rev A)`), status (`(Beta)`, `(Proto)`), disc markers (`(Disc N)`), bracket dump-codes (`[NTSC-U]`, `[SLUS-00067]`, `[!]`), domain noise (`(nsw2u.com)`). Users can extend with `extra_strip_patterns` (length-capped at 200 chars as a pragmatic ReDoS mitigation).

**Dedup** runs at two levels:
- Resolved absolute path (symlinks to the same target collapse)
- Normalized title (multi-disc games collapse to one item once `(Disc N)` is stripped)

**Stable IDs** — SHA-256 hash of resolved absolute path, prefixed `rom:`. Re-syncs update existing rows. The storage layer's forward-only status progression preserves any user-set status across re-syncs.

**Resilience** — every filesystem call (resolve, is_file, is_dir, stat) is OSError-wrapped. Flaky NFS/FUSE mounts skip the bad entry rather than aborting the whole scan.

## Config example

```yaml
my_roms:
  plugin: roms
  paths:
    - "/path/to/your/roms/snes"
    - "/path/to/your/roms/n64"
  include_extensions: []        # ADDS to defaults
  exclude_extensions: []        # REMOVES from defaults
  exclude_names: []             # glob skips for files/folders
  extra_strip_patterns: []      # extra title regex
  enabled: true
```

## Test Plan

- [ ] `command make check` passes (black, ruff, mypy, pytest 2668, vue-tsc, vitest 264)
- [ ] Add `my_roms` to `config.yaml` pointing at a real ROM dir, sync via `python3.11 -m src.cli update --source my_roms`
- [ ] Verify titles are clean (no trailing region/year/lang/disc tags) in the library tab
- [ ] Verify a multi-disc PSX game appears as ONE entry, not N
- [ ] Re-run sync — confirm no duplicates created (stable IDs)
- [ ] Mark a ROM `completed` in the UI, re-sync — confirm status preserved

## Reviews

All six review agents approved on the final round: security, code, test, document, parity, accessibility. Commit-hygiene approved the 2-commit split (feat + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)