### PR TITLE
fix(release): pass --no-vcs-release so psr does not pre-create release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: uv run python -m semantic_release version --push --commit --tag
+        run: uv run python -m semantic_release version --push --commit --tag --no-vcs-release
 
       - name: Create GitHub release with docker-compose.yml asset
         env:
@@ -66,6 +66,17 @@ jobs:
           fi
           NEW_TAG=$(printf '%s\n' "$TAGS" | head -1)
           VERSION="${NEW_TAG#v}"
+
+          # Recovery path: if a prior partial run already created the release
+          # (e.g. before --no-vcs-release was wired up, or a future psr default
+          # change), delete it so we can recreate it with the asset bundled at
+          # creation. Tag is preserved (--cleanup-tag=false). This is safe for
+          # immutable releases too — deletion is allowed; only post-creation
+          # mutation is forbidden.
+          if gh release view "$NEW_TAG" >/dev/null 2>&1; then
+            echo "Release $NEW_TAG already exists; deleting so it can be recreated with asset."
+            gh release delete "$NEW_TAG" --yes --cleanup-tag=false
+          fi
 
           # Extract the section for this version from CHANGELOG.md
           # (everything between "## vX.Y.Z " and the next "## v" heading).


### PR DESCRIPTION
## Summary
- Previous PR (#61) dropped the explicit \`--vcs-release\` flag, but psr defaults to creating the GitHub release anyway. v0.9.1 release run proved this: psr created an immutable, asset-less release, then \`gh release create\` failed with \"tag already exists\".
- Pass \`--no-vcs-release\` explicitly so psr only commits/tags/pushes.
- Add defensive recovery: if a release already exists for the target tag, delete it before recreating (preserves the tag via \`--cleanup-tag=false\`). Protects against partial prior runs wedging the next release.

## Test plan
- [ ] CI green on this PR.
- [ ] Next release run on main: psr step pushes tag, \`gh release create\` step succeeds, resulting GitHub release has \`docker-compose.yml\` attached.

## Recovery for v0.9.1
v0.9.1 release exists immutable + asset-less. After this PR merges, the recovery branch in the workflow won't help because no new release run will trigger for that tag. Manual fix required: \`gh release delete v0.9.1 --yes --cleanup-tag=false\` then \`gh release create v0.9.1 --title v0.9.1 --notes-file <changelog-section> docker-compose.yml\`.