### PR TITLE
fix(ingestion): drop slow Steam Store appdetails pass (closes #34)

### DIFF
--- a/src/ingestion/sources/steam.py
+++ b/src/ingestion/sources/steam.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import time
 from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Any
 
@@ -16,7 +15,6 @@ from src.ingestion.plugin_base import (
     SourcePlugin,
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
-from src.utils.progress import log_progress
 
 if TYPE_CHECKING:
     from src.storage.manager import StorageManager
@@ -89,101 +87,6 @@ def get_owned_games(
     except requests.RequestException as error:
         logger.error("Error fetching Steam games: %s", error)
         raise SteamAPIError(f"Failed to fetch Steam games: {error}") from error
-
-
-def get_game_details(
-    app_ids: list[int],
-    rate_limit_seconds: float = 3.0,
-    max_retries: int = 3,
-    backoff_multiplier: float = 2.0,
-    progress_callback: Callable[[int, int], None] | None = None,
-) -> dict[int, dict[str, Any]]:
-    """Fetch detailed information for multiple games with rate limiting and backoff.
-
-    Args:
-        app_ids: List of Steam app IDs
-        rate_limit_seconds: Base delay between requests to avoid rate limiting.
-            Steam's store API is rate-limited; 3 seconds is a safe default.
-        max_retries: Maximum number of retries per request on failure.
-        backoff_multiplier: Multiplier for exponential backoff on retries.
-        progress_callback: Optional callback(current, total) called after each
-            successful fetch for progress reporting.
-
-    Returns:
-        Dictionary mapping app_id to game details
-    """
-    # Steam Store API for game details
-    # Note: This is a public API, no key required
-    # Steam Store API has a limit on batch size (typically 1-5 app IDs)
-    # Using single requests to avoid 400 Bad Request errors
-    details: dict[int, dict[str, Any]] = {}
-    total = len(app_ids)
-    current_delay = rate_limit_seconds
-
-    for index, app_id in enumerate(app_ids):
-        app_ids_str = str(app_id)
-        url = "https://store.steampowered.com/api/appdetails"
-        params = {"appids": app_ids_str, "l": "en"}
-
-        current = index + 1
-        log_progress(logger, "game details", current, total)
-
-        # Retry loop with exponential backoff
-        retry_delay = current_delay
-        for attempt in range(max_retries + 1):
-            try:
-                response = requests.get(url, params=params, timeout=30)
-
-                # Check for rate limiting (429) or server errors (5xx)
-                if response.status_code == 429:
-                    logger.warning(
-                        "Rate limited by Steam API. Backing off for %.1fs...",
-                        retry_delay,
-                    )
-                    time.sleep(retry_delay)
-                    retry_delay *= backoff_multiplier
-                    # Increase base delay for future requests
-                    current_delay = min(current_delay * 1.5, 30.0)
-                    continue
-
-                response.raise_for_status()
-                data = response.json()
-                for app_id_str, app_data in data.items():
-                    if app_data.get("success"):
-                        details[int(app_id_str)] = app_data.get("data", {})
-                if progress_callback:
-                    progress_callback(current, total)
-                # Gradually reduce delay back toward base if successful
-                current_delay = max(rate_limit_seconds, current_delay * 0.9)
-                break
-
-            except requests.RequestException as error:
-                if attempt < max_retries:
-                    logger.warning(
-                        "Error fetching game details for app ID %s: %s. "
-                        "Retrying in %.1fs (attempt %d/%d)...",
-                        app_id,
-                        error,
-                        retry_delay,
-                        attempt + 1,
-                        max_retries,
-                    )
-                    time.sleep(retry_delay)
-                    retry_delay *= backoff_multiplier
-                else:
-                    logger.warning(
-                        "Error fetching game details for app ID %s: %s. "
-                        "Max retries exceeded, skipping.",
-                        app_id,
-                        error,
-                    )
-
-        # Rate limit: wait between requests to avoid being blocked
-        # Skip delay after the last request
-        if index + 1 < len(app_ids) and current_delay > 0:
-            time.sleep(current_delay)
-
-    return details
 
 
 class SteamPlugin(SourcePlugin):
@@ -298,11 +201,7 @@ class SteamPlugin(SourcePlugin):
         # Adapter: Steam internal (current, total, phase) -> plugin (items, total, item)
         def steam_internal_callback(current: int, total: int, phase: str) -> None:
             if progress_callback:
-                phase_msg = (
-                    "Fetching game details..."
-                    if phase == "game_details"
-                    else "Fetching library..." if phase == "owned_games" else phase
-                )
+                phase_msg = "Fetching library..." if phase == "owned_games" else phase
                 progress_callback(current, total, phase_msg)
 
         try:
@@ -330,6 +229,11 @@ def _fetch_steam_games(
 ) -> Iterator[ContentItem]:
     """Fetch and parse Steam game library.
 
+    Only the GetOwnedGames endpoint is called. Richer per-game metadata
+    (release date, developers, publishers, genres, Metacritic score, etc.)
+    is filled in asynchronously by the RAWG enrichment provider so initial
+    sync stays fast even for large libraries.
+
     Args:
         api_key: Steam Web API key
         steam_id: Steam ID (64-bit)
@@ -337,8 +241,7 @@ def _fetch_steam_games(
         min_playtime_minutes: Minimum playtime filter
         source: Source identifier for ContentItems
         progress_callback: Optional callback(fetched_count, total, phase) for
-            progress reporting. Phase is "owned_games", "game_details", or
-            "processing".
+            progress reporting. Phase is "owned_games" or a per-item title.
 
     Yields:
         ContentItem objects for each game
@@ -364,53 +267,26 @@ def _fetch_steam_games(
         logger.warning("No games found in Steam library")
         return
 
-    # Fetch additional game details for better metadata
-    app_ids = [game["appid"] for game in games]
-    total_games = len(app_ids)
-    logger.info(
-        "Fetching detailed information for %d games "
-        "(this may take a while due to API rate limits)...",
-        total_games,
-    )
-
-    def game_details_progress(current: int, total: int) -> None:
-        if progress_callback:
-            progress_callback(current, total, "game_details")
-
-    game_details = get_game_details(app_ids, progress_callback=game_details_progress)
-    logger.info("Successfully fetched details for %d games", len(game_details))
-
-    # Process each game
     count = 0
     for game in games:
         app_id = game.get("appid")
         if not app_id:
             continue
 
-        # Get playtime (in minutes)
         playtime_minutes = game.get("playtime_forever", 0)
         if playtime_minutes < min_playtime_minutes:
             continue
 
-        # Get game name
         game_name = game.get("name", "").strip()
         if not game_name:
-            # Try to get from details
-            details = game_details.get(app_id, {})
-            game_name = details.get("name", f"Steam App {app_id}")
-            if not game_name or game_name == f"Steam App {app_id}":
-                continue  # Skip games without names
+            continue
 
         # Steam exposes no explicit "currently playing" or "completed" signal,
         # so we never infer status from playtime. Users mark progress in the UI.
         status = ConsumptionStatus.UNREAD
-
-        # Convert playtime to hours for metadata
         playtime_hours = playtime_minutes / 60.0
 
-        # Get additional metadata from game details
-        details = game_details.get(app_id, {})
-        metadata = {
+        metadata: dict[str, Any] = {
             "steam_app_id": str(app_id),
             "playtime_minutes": playtime_minutes,
             "playtime_hours": round(playtime_hours, 1),
@@ -420,26 +296,6 @@ def _fetch_steam_games(
             "playtime_linux_forever": game.get("playtime_linux_forever", 0),
         }
 
-        # Add game details if available
-        if details:
-            metadata.update(
-                {
-                    "release_date": details.get("release_date", {}).get("date"),
-                    "developers": details.get("developers", []),
-                    "publishers": details.get("publishers", []),
-                    "genres": [
-                        genre.get("description") for genre in details.get("genres", [])
-                    ],
-                    "categories": [
-                        category.get("description")
-                        for category in details.get("categories", [])
-                    ],
-                    "short_description": details.get("short_description"),
-                    "website": details.get("website"),
-                    "metacritic_score": details.get("metacritic", {}).get("score"),
-                }
-            )
-
         count += 1
 
         if progress_callback:
@@ -448,12 +304,12 @@ def _fetch_steam_games(
         yield ContentItem(
             id=str(app_id),
             title=game_name,
-            author=None,  # Games don't have authors
+            author=None,
             content_type=ContentType.VIDEO_GAME,
             rating=None,
-            review=None,  # Steam API doesn't provide user reviews
+            review=None,
             status=status,
-            date_completed=None,  # Steam doesn't track completion dates
+            date_completed=None,
             metadata=metadata,
             source=source,
         )

--- a/src/ingestion/sources/steam.py
+++ b/src/ingestion/sources/steam.py
@@ -31,6 +31,20 @@ class SteamAPIError(Exception):
     pass
 
 
+def _scrub_request_error(error: requests.RequestException) -> str:
+    """Render a requests exception without leaking the URL/query string.
+
+    The default ``str()`` of ``requests.HTTPError`` includes the request URL,
+    which embeds the Steam Web API key (``?key=<api_key>&...``). The wrapped
+    exception flows into ``SourceError`` and from there into the sync job's
+    ``error_message`` field that the web API returns to the browser. Strip the
+    URL and surface only the HTTP status (when known) plus the exception type.
+    """
+    if isinstance(error, requests.HTTPError) and error.response is not None:
+        return f"HTTP {error.response.status_code}"
+    return type(error).__name__
+
+
 def get_steam_id_from_vanity_url(api_key: str, vanity_url: str) -> str | None:
     """Resolve Steam vanity URL to Steam ID.
 
@@ -53,8 +67,9 @@ def get_steam_id_from_vanity_url(api_key: str, vanity_url: str) -> str | None:
             return str(steamid) if steamid else None
         return None
     except requests.RequestException as error:
-        logger.error("Error resolving Steam vanity URL: %s", error)
-        raise SteamAPIError(f"Failed to resolve Steam ID: {error}") from error
+        scrubbed = _scrub_request_error(error)
+        logger.error("Error resolving Steam vanity URL: %s", scrubbed)
+        raise SteamAPIError(f"Failed to resolve Steam ID: {scrubbed}") from error
 
 
 def get_owned_games(
@@ -85,8 +100,9 @@ def get_owned_games(
         games = data.get("response", {}).get("games", [])
         return list(games) if games else []
     except requests.RequestException as error:
-        logger.error("Error fetching Steam games: %s", error)
-        raise SteamAPIError(f"Failed to fetch Steam games: {error}") from error
+        scrubbed = _scrub_request_error(error)
+        logger.error("Error fetching Steam games: %s", scrubbed)
+        raise SteamAPIError(f"Failed to fetch Steam games: {scrubbed}") from error
 
 
 class SteamPlugin(SourcePlugin):

--- a/tests/test_steam.py
+++ b/tests/test_steam.py
@@ -5,12 +5,12 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
+import src.ingestion.sources.steam as steam_module
 from src.ingestion.plugin_base import SourceError, SourcePlugin
 from src.ingestion.sources.steam import (
     SteamAPIError,
     SteamPlugin,
     _fetch_steam_games,
-    get_game_details,
     get_owned_games,
     get_steam_id_from_vanity_url,
 )
@@ -120,80 +120,11 @@ class TestGetOwnedGames:
             get_owned_games("test_key", "76561198000000000")
 
 
-class TestGetGameDetails:
-    """Tests for fetching game details."""
-
-    @patch("src.ingestion.sources.steam.requests.get")
-    def test_get_game_details_success(self, mock_get):
-        """Test successful game details fetch."""
-        mock_response = Mock(spec=requests.Response)
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "12345": {
-                "success": True,
-                "data": {
-                    "name": "Test Game",
-                    "short_description": "A test game",
-                    "developers": ["Developer 1"],
-                    "publishers": ["Publisher 1"],
-                    "genres": [{"description": "Action"}],
-                    "release_date": {"date": "Jan 1, 2020"},
-                    "metacritic": {"score": 85},
-                },
-            }
-        }
-        mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
-
-        details = get_game_details([12345])
-
-        assert 12345 in details
-        assert details[12345]["name"] == "Test Game"
-        assert details[12345]["short_description"] == "A test game"
-
-    @patch("src.ingestion.sources.steam.requests.get")
-    def test_get_game_details_batch(self, mock_get):
-        """Test game details fetch with multiple games."""
-        mock_response = Mock(spec=requests.Response)
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "12345": {"success": True, "data": {"name": "Game 1"}},
-            "67890": {"success": True, "data": {"name": "Game 2"}},
-        }
-        mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
-
-        details = get_game_details([12345, 67890])
-
-        assert len(details) == 2
-        assert 12345 in details
-        assert 67890 in details
-
-    @patch("src.ingestion.sources.steam.requests.get")
-    def test_get_game_details_large_batch(self, mock_get):
-        """Test game details fetch with large batch (should split)."""
-        mock_response = Mock(spec=requests.Response)
-        mock_response.status_code = 200
-        # Create response for single game (batch_size = 1)
-        mock_response.json.return_value = {
-            "0": {"success": True, "data": {"name": "Game 0"}}
-        }
-        mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
-
-        app_ids = list(range(5))  # 5 games should trigger 5 calls
-        get_game_details(app_ids)
-
-        # Should have made 5 calls (batch_size = 1)
-        assert mock_get.call_count == 5
-
-
 class TestParseSteamGames:
     """Tests for parsing Steam games into ContentItems."""
 
-    @patch("src.ingestion.sources.steam.get_game_details")
     @patch("src.ingestion.sources.steam.get_owned_games")
-    def test__fetch_steam_games_basic(self, mock_get_games, mock_get_details):
+    def test__fetch_steam_games_basic(self, mock_get_games):
         """Test basic game parsing."""
         mock_get_games.return_value = [
             {
@@ -203,14 +134,6 @@ class TestParseSteamGames:
                 "playtime_2weeks": 30,
             }
         ]
-        mock_get_details.return_value = {
-            12345: {
-                "name": "Test Game",
-                "short_description": "A great game",
-                "developers": ["Developer 1"],
-                "genres": [{"description": "Action"}],
-            }
-        }
 
         items = list(_fetch_steam_games("test_key", steam_id="76561198000000000"))
 
@@ -226,14 +149,9 @@ class TestParseSteamGames:
         assert item.metadata["playtime_hours"] == 2.0
         assert item.metadata["playtime_minutes"] == 120
 
-    @patch("src.ingestion.sources.steam.get_game_details")
     @patch("src.ingestion.sources.steam.get_owned_games")
-    def test__fetch_steam_games_rating_always_none(
-        self, mock_get_games, mock_get_details
-    ):
+    def test__fetch_steam_games_rating_always_none(self, mock_get_games):
         """Test that ratings are always None (user-provided, not inferred from playtime)."""
-        mock_get_details.return_value = {}
-
         for playtime_minutes in [0, 1, 60, 300, 600, 1200]:
             mock_get_games.return_value = [
                 {
@@ -247,22 +165,14 @@ class TestParseSteamGames:
                 items[0].rating is None
             ), f"Expected None rating for {playtime_minutes} minutes, got {items[0].rating}"
 
-    @patch("src.ingestion.sources.steam.get_game_details")
     @patch("src.ingestion.sources.steam.get_owned_games")
-    def test__fetch_steam_games_min_playtime_filter(
-        self, mock_get_games, mock_get_details
-    ):
+    def test__fetch_steam_games_min_playtime_filter(self, mock_get_games):
         """Test minimum playtime filter."""
         mock_get_games.return_value = [
             {"appid": 1, "name": "Game 1", "playtime_forever": 10},
             {"appid": 2, "name": "Game 2", "playtime_forever": 100},
             {"appid": 3, "name": "Game 3", "playtime_forever": 200},
         ]
-        mock_get_details.return_value = {
-            1: {"name": "Game 1"},
-            2: {"name": "Game 2"},
-            3: {"name": "Game 3"},
-        }
 
         # Filter games with < 50 minutes playtime
         items = list(
@@ -274,10 +184,9 @@ class TestParseSteamGames:
         assert len(items) == 2  # Only games 2 and 3
         assert all(item.metadata["playtime_minutes"] >= 50 for item in items)
 
-    @patch("src.ingestion.sources.steam.get_game_details")
     @patch("src.ingestion.sources.steam.get_owned_games")
-    def test__fetch_steam_games_metadata(self, mock_get_games, mock_get_details):
-        """Test that game metadata is properly extracted."""
+    def test__fetch_steam_games_metadata(self, mock_get_games):
+        """Playtime fields from GetOwnedGames flow into metadata."""
         mock_get_games.return_value = [
             {
                 "appid": 12345,
@@ -289,19 +198,6 @@ class TestParseSteamGames:
                 "playtime_linux_forever": 0,
             }
         ]
-        mock_get_details.return_value = {
-            12345: {
-                "name": "Test Game",
-                "short_description": "A great game",
-                "developers": ["Dev 1", "Dev 2"],
-                "publishers": ["Pub 1"],
-                "genres": [{"description": "Action"}, {"description": "Adventure"}],
-                "categories": [{"description": "Single-player"}],
-                "release_date": {"date": "Jan 1, 2020"},
-                "website": "https://example.com",
-                "metacritic": {"score": 85},
-            }
-        }
 
         items = list(_fetch_steam_games("test_key", steam_id="76561198000000000"))
 
@@ -311,23 +207,17 @@ class TestParseSteamGames:
         assert metadata["playtime_minutes"] == 120
         assert metadata["playtime_hours"] == 2.0
         assert metadata["playtime_2weeks"] == 30
-        assert metadata["developers"] == ["Dev 1", "Dev 2"]
-        assert metadata["publishers"] == ["Pub 1"]
-        assert metadata["genres"] == ["Action", "Adventure"]
-        assert metadata["metacritic_score"] == 85
+        assert metadata["playtime_windows_forever"] == 100
+        assert metadata["playtime_mac_forever"] == 20
+        assert metadata["playtime_linux_forever"] == 0
 
-    @patch("src.ingestion.sources.steam.get_game_details")
     @patch("src.ingestion.sources.steam.get_owned_games")
-    def test__fetch_steam_games_no_name_skipped(self, mock_get_games, mock_get_details):
+    def test__fetch_steam_games_no_name_skipped(self, mock_get_games):
         """Test that games without names are skipped."""
         mock_get_games.return_value = [
             {"appid": 12345, "name": "", "playtime_forever": 120},
             {"appid": 67890, "name": "Valid Game", "playtime_forever": 60},
         ]
-        mock_get_details.return_value = {
-            12345: {},  # No name in details either
-            67890: {"name": "Valid Game"},
-        }
 
         items = list(_fetch_steam_games("test_key", steam_id="76561198000000000"))
 
@@ -335,17 +225,13 @@ class TestParseSteamGames:
         assert items[0].title == "Valid Game"
 
     @patch("src.ingestion.sources.steam.get_steam_id_from_vanity_url")
-    @patch("src.ingestion.sources.steam.get_game_details")
     @patch("src.ingestion.sources.steam.get_owned_games")
-    def test__fetch_steam_games_vanity_url(
-        self, mock_get_games, mock_get_details, mock_resolve_vanity
-    ):
+    def test__fetch_steam_games_vanity_url(self, mock_get_games, mock_resolve_vanity):
         """Test parsing with vanity URL instead of Steam ID."""
         mock_resolve_vanity.return_value = "76561198000000000"
         mock_get_games.return_value = [
             {"appid": 12345, "name": "Test Game", "playtime_forever": 60}
         ]
-        mock_get_details.return_value = {12345: {"name": "Test Game"}}
 
         items = list(_fetch_steam_games("test_key", vanity_url="testuser"))
 
@@ -367,17 +253,14 @@ class TestParseSteamGames:
         ):
             list(_fetch_steam_games("test_key"))
 
-    @patch("src.ingestion.sources.steam.get_game_details")
     @patch("src.ingestion.sources.steam.get_owned_games")
-    def test__fetch_steam_games_empty_library(self, mock_get_games, mock_get_details):
+    def test__fetch_steam_games_empty_library(self, mock_get_games):
         """Test parsing with empty game library."""
         mock_get_games.return_value = []
 
         items = list(_fetch_steam_games("test_key", steam_id="76561198000000000"))
 
         assert len(items) == 0
-        # Should not call get_game_details for empty library
-        mock_get_details.assert_not_called()
 
 
 class TestSteamPluginProperties:
@@ -517,16 +400,13 @@ class TestSteamStatusInferenceRegression:
     """
 
     @pytest.mark.parametrize("playtime_minutes", [0, 1, 30, 6000])
-    @patch("src.ingestion.sources.steam.get_game_details")
     @patch("src.ingestion.sources.steam.get_owned_games")
     def test_fetch_steam_games_status_always_unread_regression(
         self,
         mock_get_games: Mock,
-        mock_get_details: Mock,
         playtime_minutes: int,
     ) -> None:
         """Status is UNREAD regardless of playtime."""
-        mock_get_details.return_value = {}
         mock_get_games.return_value = [
             {
                 "appid": 12345,
@@ -597,12 +477,10 @@ class TestSteamNoneConfigValuesRegression:
         assert result["vanity_url"] is None
 
     @patch("src.ingestion.sources.steam.get_steam_id_from_vanity_url")
-    @patch("src.ingestion.sources.steam.get_game_details")
     @patch("src.ingestion.sources.steam.get_owned_games")
     def test_fetch_pipeline_none_values_regression(
         self,
         mock_get_games: Mock,
-        mock_get_details: Mock,
         mock_resolve_vanity: Mock,
     ) -> None:
         """Full pipeline: None YAML values survive transform_config -> fetch.
@@ -615,7 +493,6 @@ class TestSteamNoneConfigValuesRegression:
         mock_get_games.return_value = [
             {"appid": 1, "name": "Game", "playtime_forever": 60}
         ]
-        mock_get_details.return_value = {1: {"name": "Game"}}
 
         plugin = SteamPlugin()
         raw_config = {"api_key": "test_key", "steam_id": None, "vanity_url": "testuser"}
@@ -629,16 +506,12 @@ class TestSteamNoneConfigValuesRegression:
 class TestSteamPluginFetch:
     """Tests for SteamPlugin.fetch()."""
 
-    @patch("src.ingestion.sources.steam.get_game_details")
     @patch("src.ingestion.sources.steam.get_owned_games")
-    def test_fetch_through_plugin(
-        self, mock_get_games: Mock, mock_get_details: Mock
-    ) -> None:
+    def test_fetch_through_plugin(self, mock_get_games: Mock) -> None:
         """Test fetching games through the plugin interface."""
         mock_get_games.return_value = [
             {"appid": 12345, "name": "Test Game", "playtime_forever": 120}
         ]
-        mock_get_details.return_value = {12345: {"name": "Test Game"}}
 
         plugin = SteamPlugin()
         items = list(
@@ -659,3 +532,102 @@ class TestSteamPluginFetch:
             list(plugin.fetch({"api_key": "test_key", "steam_id": "76561198000000000"}))
 
         assert exc_info.value.plugin_name == "steam"
+
+
+class TestSteamTwoPassRegression:
+    """Regression tests for the slow Steam Store API metadata pass (issue #34).
+
+    Bug: Steam sync ran a slow first pass calling the Steam Store appdetails
+    endpoint once per game (rate-limited to ~3s per request) before yielding
+    any items, then a fast second pass that emitted ContentItems with
+    per-game progress. For libraries of a few hundred games the first pass
+    took 15+ minutes and blocked all sync output.
+
+    Root cause: ``_fetch_steam_games`` called ``get_game_details(app_ids)``
+    inline to enrich each game with release_date/genres/publishers/etc.,
+    duplicating metadata that the RAWG enrichment provider already supplies
+    asynchronously after ingestion.
+
+    Fix: Drop the inline Steam Store API pass entirely. Sync only calls
+    ``GetOwnedGames`` (one request) and yields items immediately. Background
+    enrichment via RAWG fills in the same metadata without blocking.
+
+    Reported in: https://github.com/therealahall/recommendinator/issues/34
+    """
+
+    @patch("src.ingestion.sources.steam.requests.get")
+    def test_fetch_calls_only_owned_games_endpoint(self, mock_get: Mock) -> None:
+        """Sync hits GetOwnedGames once and never the Steam Store appdetails endpoint."""
+        mock_response = Mock(spec=requests.Response)
+        mock_response.json.return_value = {
+            "response": {
+                "games": [
+                    {"appid": 1, "name": "Game 1", "playtime_forever": 60},
+                    {"appid": 2, "name": "Game 2", "playtime_forever": 120},
+                    {"appid": 3, "name": "Game 3", "playtime_forever": 180},
+                ]
+            }
+        }
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        items = list(_fetch_steam_games("test_key", steam_id="76561198000000000"))
+
+        assert len(items) == 3
+        assert mock_get.call_count == 1
+        called_url = mock_get.call_args_list[0][0][0]
+        assert "IPlayerService/GetOwnedGames" in called_url
+        assert "store.steampowered.com" not in called_url
+
+    def test_get_game_details_no_longer_exported(self) -> None:
+        """The old slow per-game appdetails helper is removed from the module."""
+        assert not hasattr(steam_module, "get_game_details")
+
+    @patch("src.ingestion.sources.steam.get_owned_games")
+    def test_fetch_skips_games_with_missing_appid(self, mock_get_games: Mock) -> None:
+        """Games whose appid is missing or None are silently skipped."""
+        mock_get_games.return_value = [
+            {"name": "No appid", "playtime_forever": 100},
+            {"appid": None, "name": "Null appid", "playtime_forever": 100},
+            {"appid": 42, "name": "Valid", "playtime_forever": 100},
+        ]
+
+        items = list(_fetch_steam_games("test_key", steam_id="76561198000000000"))
+
+        assert len(items) == 1
+        assert items[0].id == "42"
+
+    def test_fetch_missing_id_and_vanity_raises_source_error(self) -> None:
+        """SteamPlugin.fetch wraps the ValueError from missing id+vanity in SourceError."""
+        plugin = SteamPlugin()
+        with pytest.raises(SourceError, match="steam_id or vanity_url") as exc_info:
+            list(
+                plugin.fetch({"api_key": "test_key", "steam_id": "", "vanity_url": ""})
+            )
+
+        assert exc_info.value.plugin_name == "steam"
+
+    @patch("src.ingestion.sources.steam.get_owned_games")
+    def test_fetch_progress_callback_translates_phase(
+        self, mock_get_games: Mock
+    ) -> None:
+        """Adapter translates 'owned_games' phase to a human-readable label
+        and forwards per-item titles unchanged."""
+        mock_get_games.return_value = [
+            {"appid": 1, "name": "Alpha", "playtime_forever": 30},
+            {"appid": 2, "name": "Beta", "playtime_forever": 60},
+        ]
+        callback = Mock()
+
+        plugin = SteamPlugin()
+        list(
+            plugin.fetch(
+                {"api_key": "test_key", "steam_id": "76561198000000000"},
+                progress_callback=callback,
+            )
+        )
+
+        phases = [call.args[2] for call in callback.call_args_list]
+        assert "Fetching library..." in phases
+        assert "Alpha" in phases
+        assert "Beta" in phases

--- a/tests/test_steam.py
+++ b/tests/test_steam.py
@@ -631,3 +631,102 @@ class TestSteamTwoPassRegression:
         assert "Fetching library..." in phases
         assert "Alpha" in phases
         assert "Beta" in phases
+
+
+class TestSteamApiKeyScrubbingRegression:
+    """Regression tests for Steam API key leaking via error messages.
+
+    Bug: ``requests.HTTPError.__str__`` includes the full request URL, which
+    for Steam Web API calls embeds ``?key=<api_key>`` in the query string. The
+    plugin wrapped the exception verbatim as ``SteamAPIError(f'... {error}')``
+    and again as ``SourceError(self.name, str(error))``. ``SourceError``
+    propagates into ``SyncJob.error_message``, which the web API returns to
+    the browser and writes to logs — exposing the user's Steam API key.
+
+    Root cause: `f"... {error}"` interpolation called the default
+    ``RequestException.__str__``, which contains the full URL (including the
+    ``key`` query parameter) for HTTPErrors raised by ``raise_for_status()``.
+
+    Fix: ``_scrub_request_error`` renders only ``HTTP <status>`` for HTTP
+    errors and the bare exception class name for transport errors, before the
+    string ever reaches ``SteamAPIError`` or any logger.
+    """
+
+    @patch("src.ingestion.sources.steam.requests.get")
+    def test_vanity_url_http_error_does_not_leak_api_key(self, mock_get: Mock) -> None:
+        """HTTPError on vanity resolution surfaces only the status code."""
+        api_key = "SECRET_STEAM_KEY_123"
+        url_with_key = (
+            "https://api.steampowered.com/ISteamUser/ResolveVanityURL/v0001/"
+            f"?key={api_key}&vanityurl=user"
+        )
+        response = Mock(spec=requests.Response)
+        response.status_code = 401
+        http_error = requests.HTTPError(
+            f"401 Client Error: UNAUTHORIZED for url: {url_with_key}",
+            response=response,
+        )
+        response.raise_for_status = Mock(side_effect=http_error)
+        mock_get.return_value = response
+
+        with pytest.raises(SteamAPIError) as exc_info:
+            get_steam_id_from_vanity_url(api_key, "user")
+
+        message = str(exc_info.value)
+        assert api_key not in message
+        assert "HTTP 401" in message
+
+    @patch("src.ingestion.sources.steam.requests.get")
+    def test_owned_games_http_error_does_not_leak_api_key(self, mock_get: Mock) -> None:
+        """HTTPError on owned-games fetch surfaces only the status code."""
+        api_key = "SECRET_STEAM_KEY_456"
+        url_with_key = (
+            "https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/"
+            f"?key={api_key}&steamid=76561198000000000"
+        )
+        response = Mock(spec=requests.Response)
+        response.status_code = 503
+        http_error = requests.HTTPError(
+            f"503 Server Error: Service Unavailable for url: {url_with_key}",
+            response=response,
+        )
+        response.raise_for_status = Mock(side_effect=http_error)
+        mock_get.return_value = response
+
+        with pytest.raises(SteamAPIError) as exc_info:
+            get_owned_games(api_key, "76561198000000000")
+
+        message = str(exc_info.value)
+        assert api_key not in message
+        assert "HTTP 503" in message
+
+    @patch("src.ingestion.sources.steam.requests.get")
+    def test_transport_error_surfaces_only_exception_type(self, mock_get: Mock) -> None:
+        """Connection errors surface only the exception class, not message text."""
+        api_key = "SECRET_STEAM_KEY_789"
+        mock_get.side_effect = requests.ConnectionError(
+            f"Failed to connect; key={api_key} was in URL"
+        )
+
+        with pytest.raises(SteamAPIError) as exc_info:
+            get_owned_games(api_key, "76561198000000000")
+
+        message = str(exc_info.value)
+        assert api_key not in message
+        assert "ConnectionError" in message
+
+    @patch("src.ingestion.sources.steam.get_owned_games")
+    def test_source_error_propagates_scrubbed_message(
+        self, mock_get_games: Mock
+    ) -> None:
+        """End-to-end: SourceError raised through plugin.fetch carries no API key."""
+        api_key = "SECRET_STEAM_KEY_END2END"
+        mock_get_games.side_effect = SteamAPIError(
+            "Failed to fetch Steam games: HTTP 401"
+        )
+
+        plugin = SteamPlugin()
+        with pytest.raises(SourceError) as exc_info:
+            list(plugin.fetch({"api_key": api_key, "steam_id": "76561198000000000"}))
+
+        assert api_key not in str(exc_info.value)


### PR DESCRIPTION
## Summary

Steam sync ran a slow per-game Steam Store appdetails fetch (~3s rate-limited per request) before yielding any items, blocking sync output for 15+ minutes on libraries of a few hundred games. Drop the inline pass entirely; RAWG enrichment already supplies the same metadata asynchronously after ingestion.

While in the same code path, scrub the Steam Web API key from `requests.HTTPError` messages before they propagate into `SteamAPIError` / `SourceError` / log lines (security finding surfaced during code review of the same diff).

Fixes #34.

## What Changed

- **Commit 1 — `fix(ingestion): drop Steam Store appdetails pass during sync`**
  - Removed `get_game_details()` and the inline call from `_fetch_steam_games()`.
  - Removed metadata fields previously sourced from appdetails (`release_date`, `developers`, `publishers`, `genres`, `categories`, `short_description`, `website`, `metacritic_score`) — RAWG enrichment provides equivalents.
  - Simplified the progress callback adapter (no more `game_details` phase).
  - Added `TestSteamTwoPassRegression` covering: only `GetOwnedGames` is hit, the helper symbol is gone, missing `appid` skip, `ValueError` -> `SourceError` wrapping, callback phase translation.
- **Commit 2 — `fix(ingestion): scrub Steam API key from request error messages`**
  - Added `_scrub_request_error()` helper returning `HTTP <status>` for HTTPErrors or the bare exception class name otherwise.
  - Routed both `get_steam_id_from_vanity_url()` and `get_owned_games()` exception handlers through it.
  - Added `TestSteamApiKeyScrubbingRegression` covering HTTPError on both endpoints, transport errors, and end-to-end `SourceError` propagation.

## Test Plan

- [ ] `python3.11 -m pytest tests/test_steam.py` — 50 tests pass.
- [ ] `command make check` — full suite green (2687 Python tests + 264 frontend tests).
- [ ] Trigger a Steam sync against a real library and observe items appearing immediately rather than after a long delay.
- [ ] Force a Steam API failure (revoke API key, confirm sync error message contains `HTTP 401` / exception class name only — never the API key).