### PR TITLE
fix(enrichment): report total_items upfront instead of per batch

### DIFF
--- a/src/enrichment/manager.py
+++ b/src/enrichment/manager.py
@@ -267,6 +267,16 @@ class EnrichmentManager:
                     len(not_found_ids),
                 )
 
+            # Status polling reads total_items mid-run, so it must be set
+            # before the first batch starts. Querying upfront avoids the
+            # previous "growing in batch_size steps" UI behavior.
+            pending_count = self.storage_manager.count_items_needing_enrichment(
+                content_type=content_type,
+                user_id=user_id,
+            )
+            with self._lock:
+                self._status.total_items = pending_count + len(not_found_ids)
+
             # Process items in batches
             while not self._stop_requested:
                 # Fetch next batch of items (normal items only, not include_not_found)
@@ -298,9 +308,6 @@ class EnrichmentManager:
                 if not items:
                     # No more items to process
                     break
-
-                with self._lock:
-                    self._status.total_items += len(items)
 
                 # Process each item
                 self._process_batch(items)

--- a/src/storage/manager.py
+++ b/src/storage/manager.py
@@ -648,6 +648,25 @@ class StorageManager:
             include_not_found=include_not_found,
         )
 
+    def count_items_needing_enrichment(
+        self,
+        content_type: ContentType | None = None,
+        user_id: int | None = None,
+    ) -> int:
+        """Count content items that need enrichment.
+
+        Args:
+            content_type: Optional filter by content type
+            user_id: Filter by user ID (defaults to the default user when None)
+
+        Returns:
+            Number of items matching the enrichment filter.
+        """
+        return self.sqlite_db.count_items_needing_enrichment(
+            content_type=content_type,
+            user_id=user_id,
+        )
+
     def get_enrichment_status(
         self, content_item_id: int
     ) -> EnrichmentStatusDict | None:

--- a/src/storage/sqlite_db.py
+++ b/src/storage/sqlite_db.py
@@ -1371,35 +1371,12 @@ class SQLiteDB:
 
         with self.connection() as conn:
             cursor = conn.cursor()
-
-            # Find items without enrichment status or with needs_enrichment=TRUE
-            # Optionally also include items with enrichment_quality='not_found'
-            if include_not_found:
-                status_filter = (
-                    "(es.content_item_id IS NULL OR es.needs_enrichment = 1"
-                    " OR es.enrichment_quality = ?)"
-                )
-            else:
-                status_filter = (
-                    "(es.content_item_id IS NULL OR es.needs_enrichment = 1)"
-                )
-
-            query = f"""
-                SELECT ci.id
-                FROM content_items ci
-                LEFT JOIN enrichment_status es ON ci.id = es.content_item_id
-                WHERE ci.user_id = ?
-                  AND {status_filter}
-            """
-            params: list[Any] = [effective_user_id]
-            if include_not_found:
-                params.append("not_found")
-
-            if content_type:
-                query += " AND ci.content_type = ?"
-                content_type_value = get_enum_value(content_type)
-                params.append(content_type_value)
-
+            query, params = self._build_enrichment_query(
+                effective_user_id,
+                content_type,
+                include_not_found,
+                count_only=False,
+            )
             query += " ORDER BY ci.id LIMIT ?"
             params.append(limit)
 
@@ -1410,6 +1387,79 @@ class SQLiteDB:
         # Batch-fetch all items in a single query (outside the first connection)
         items = self.get_content_items_by_db_ids(db_ids)
         return [(item.db_id, item) for item in items if item.db_id is not None]
+
+    def count_items_needing_enrichment(
+        self,
+        content_type: ContentType | None = None,
+        user_id: int | None = None,
+    ) -> int:
+        """Count content items that need enrichment.
+
+        Uses the same filter as :meth:`get_items_needing_enrichment` (with
+        ``include_not_found=False``) so the enrichment manager can report a
+        total upfront instead of incrementing per batch. Items previously
+        marked as ``not_found`` are tracked separately by the manager and are
+        intentionally excluded here to avoid double-counting.
+
+        Args:
+            content_type: Optional filter by content type
+            user_id: Filter by user ID (defaults to default user)
+
+        Returns:
+            Number of items matching the enrichment filter.
+        """
+        effective_user_id = user_id if user_id is not None else get_default_user_id()
+
+        with self.connection() as conn:
+            cursor = conn.cursor()
+            query, params = self._build_enrichment_query(
+                effective_user_id,
+                content_type,
+                include_not_found=False,
+                count_only=True,
+            )
+            cursor.execute(query, params)
+            row = cursor.fetchone()
+            return int(row[0]) if row else 0
+
+    @staticmethod
+    def _build_enrichment_query(
+        user_id: int,
+        content_type: ContentType | None,
+        include_not_found: bool,
+        count_only: bool,
+    ) -> tuple[str, list[Any]]:
+        """Build the shared SELECT for items needing enrichment.
+
+        Returns the query string and the bound parameter list. Callers append
+        ORDER BY / LIMIT clauses as needed. The SELECT clause is hardcoded
+        based on ``count_only`` rather than accepting an open string, so this
+        helper cannot be misused to inject SQL.
+        """
+        select_clause = "SELECT COUNT(*)" if count_only else "SELECT ci.id"
+
+        if include_not_found:
+            status_filter = (
+                "(es.content_item_id IS NULL OR es.needs_enrichment = 1"
+                " OR es.enrichment_quality = ?)"
+            )
+        else:
+            status_filter = "(es.content_item_id IS NULL OR es.needs_enrichment = 1)"
+
+        query = f"""
+            {select_clause}
+            FROM content_items ci
+            LEFT JOIN enrichment_status es ON ci.id = es.content_item_id
+            WHERE ci.user_id = ?
+              AND {status_filter}
+        """
+        params: list[Any] = [user_id]
+        if include_not_found:
+            params.append("not_found")
+        if content_type:
+            query += " AND ci.content_type = ?"
+            params.append(get_enum_value(content_type))
+        return query, params
 
     def get_content_item_db_id(
         self,

--- a/tests/enrichment/test_enrichment_manager.py
+++ b/tests/enrichment/test_enrichment_manager.py
@@ -2,7 +2,7 @@
 
 import time
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -227,6 +227,9 @@ class TestEnrichmentManager:
         """Create a mock storage manager."""
         storage = MagicMock(spec=StorageManager)
         storage.get_items_needing_enrichment.return_value = []
+        # Return an int so `_run_enrichment` can compute total_items without
+        # silently producing a MagicMock when tests don't override the value.
+        storage.count_items_needing_enrichment.return_value = 0
         return storage
 
     @pytest.fixture
@@ -336,6 +339,7 @@ class TestEnrichmentManager:
 
         # Return items on first call, empty on second
         mock_storage.get_items_needing_enrichment.side_effect = [items, []]
+        mock_storage.count_items_needing_enrichment.return_value = 2
 
         # Setup provider
         provider = MockProvider()
@@ -350,6 +354,7 @@ class TestEnrichmentManager:
         assert status.completed is True
         assert status.items_processed == 2
         assert status.items_enriched == 2
+        assert status.total_items == 2
 
     def test_enrichment_marks_not_found(
         self,
@@ -435,6 +440,12 @@ class TestEnrichmentManager:
             limit=10,
             include_not_found=False,
         )
+        # The count query that drives total_items must propagate the same filter,
+        # otherwise the UI would show a total for all types while processing one.
+        mock_storage.count_items_needing_enrichment.assert_called_once_with(
+            content_type=ContentType.MOVIE,
+            user_id=None,
+        )
 
     def test_enrichment_merges_genres_and_tags(
         self,
@@ -504,3 +515,155 @@ class TestEnrichmentManager:
 
         status = manager.get_status()
         assert status.items_not_found == 1
+
+
+class TestEnrichmentProgressRegressions:
+    """Regression tests for enrichment progress reporting (issue #60).
+
+    Reported symptom: the web UI showed enrichment ``total_items`` jumping in
+    batch_size steps (e.g. 50, 100, 150, 200) for a 200-item enrichment run
+    rather than displaying the real total from the start.
+
+    Root cause: ``EnrichmentManager._run_enrichment`` accumulated the total
+    via ``self._status.total_items += len(items)`` inside the batch loop, so
+    the value reported by ``get_status()`` only matched reality once every
+    page had been fetched.
+
+    Fix: query ``StorageManager.count_items_needing_enrichment`` once before
+    the batch loop and assign ``total_items`` in a single statement (combined
+    with the precomputed ``not_found_ids`` set when retrying not-found items).
+    """
+
+    @pytest.fixture
+    def mock_storage(self) -> MagicMock:
+        storage = MagicMock(spec=StorageManager)
+        storage.get_items_needing_enrichment.return_value = []
+        storage.count_items_needing_enrichment.return_value = 0
+        return storage
+
+    @pytest.fixture
+    def mock_registry(self) -> EnrichmentRegistry:
+        registry = EnrichmentRegistry()
+        registry._discovered = True
+        return registry
+
+    @pytest.fixture
+    def config(self) -> dict[str, Any]:
+        return {
+            "enrichment": {
+                "batch_size": 10,
+                "providers": {"mock": {"enabled": True}},
+            }
+        }
+
+    def test_total_items_set_before_first_batch(
+        self,
+        mock_storage: MagicMock,
+        mock_registry: EnrichmentRegistry,
+        config: dict[str, Any],
+    ) -> None:
+        """total_items must equal the upfront count when the first batch starts.
+
+        Pre-fix the value would have been ``len(items)`` for the first batch
+        (1) and grown to 3 only after the third batch. Post-fix the count
+        method is consulted once and total_items reflects the real total
+        from batch 1 onward.
+        """
+        items_batches = [
+            [
+                (
+                    db_id,
+                    ContentItem(
+                        id=f"movie{db_id}",
+                        title=f"Movie {db_id}",
+                        content_type=ContentType.MOVIE,
+                        status=ConsumptionStatus.UNREAD,
+                    ),
+                )
+            ]
+            for db_id in (1, 2, 3)
+        ]
+        mock_storage.get_items_needing_enrichment.side_effect = items_batches + [[]]
+        mock_storage.count_items_needing_enrichment.return_value = 3
+
+        provider = MockProvider()
+        mock_registry.register(provider)
+
+        manager = EnrichmentManager(mock_storage, config, mock_registry)
+
+        observed_totals: list[int] = []
+        original_process_batch = manager._process_batch
+
+        def capture_total(items: list[tuple[int, ContentItem]]) -> None:
+            with manager._lock:
+                observed_totals.append(manager._status.total_items)
+            original_process_batch(items)
+
+        with patch.object(manager, "_process_batch", side_effect=capture_total):
+            manager.start_enrichment()
+            manager._wait_for_completion()
+
+        assert observed_totals == [3, 3, 3], (
+            "total_items should report the full count from the first batch onward, "
+            f"got {observed_totals}"
+        )
+        mock_storage.count_items_needing_enrichment.assert_called_once_with(
+            content_type=None,
+            user_id=None,
+        )
+
+    def test_total_items_includes_not_found_when_retrying(
+        self,
+        mock_storage: MagicMock,
+        mock_registry: EnrichmentRegistry,
+        config: dict[str, Any],
+    ) -> None:
+        """With include_not_found=True, total_items = pending count + not_found IDs.
+
+        The manager fetches not-found IDs upfront into a separate set and the
+        batch loop only counts them once they're mixed into a batch. Without
+        adding them to the upfront total, the displayed total would understate
+        the work and progress would briefly exceed 100%. Post-fix the regression
+        is guarded by combining ``count_items_needing_enrichment`` with the
+        precomputed ``not_found_ids`` set.
+        """
+        not_found_item = ContentItem(
+            id="movie99",
+            title="Previously Not Found",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+        )
+        not_found_item.db_id = 99
+        # Sequence: include_not_found=True for the upfront candidate scan,
+        # then include_not_found=False on each batch-loop iteration. The third
+        # entry must exist so the loop exits via the empty-batch break instead
+        # of via StopIteration (which would silently route through the broad
+        # `except Exception` in _run_enrichment and mask any real failure).
+        mock_storage.get_items_needing_enrichment.side_effect = [
+            [(99, not_found_item)],
+            [],
+            [],
+        ]
+        mock_storage.get_enrichment_status.return_value = {
+            "enrichment_quality": "not_found"
+        }
+        mock_storage.count_items_needing_enrichment.return_value = 5
+        mock_storage.get_content_items_by_db_ids.return_value = [not_found_item]
+
+        provider = MockProvider()
+        mock_registry.register(provider)
+
+        manager = EnrichmentManager(mock_storage, config, mock_registry)
+        manager.start_enrichment(include_not_found=True)
+        manager._wait_for_completion()
+
+        status = manager.get_status()
+        assert status.total_items == 6  # 5 pending + 1 not_found
+        # Guard that the job ended via the normal completion path, not via
+        # the broad except in _run_enrichment swallowing a mock-setup error.
+        assert status.completed is True
+        assert status.errors == []
+        mock_storage.count_items_needing_enrichment.assert_called_once_with(
+            content_type=None,
+            user_id=None,
+        )

--- a/tests/enrichment/test_enrichment_storage.py
+++ b/tests/enrichment/test_enrichment_storage.py
@@ -309,6 +309,137 @@ class TestGetItemsNeedingEnrichment:
         assert len(items) == 3
 
 
+class TestCountItemsNeedingEnrichment:
+    """Tests for counting items needing enrichment.
+
+    The count and get methods share ``_build_enrichment_query`` so the same
+    WHERE clause drives both. These tests verify count parity with the get
+    path and exercise the COUNT(*) -> int cursor branch.
+    """
+
+    @pytest.fixture
+    def storage_manager(self, tmp_path: Path) -> StorageManager:
+        db_path = tmp_path / "test.db"
+        return StorageManager(sqlite_path=db_path, ai_enabled=False)
+
+    def test_count_empty_database_returns_zero(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """Empty database returns 0 (covers the `if row else 0` guard)."""
+        assert storage_manager.count_items_needing_enrichment() == 0
+
+    def test_count_includes_new_and_pending_items(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """Items without an enrichment_status row are counted (NULL branch)."""
+        for index in range(4):
+            storage_manager.save_content_item(
+                ContentItem(
+                    id=f"movie{index}",
+                    title=f"Movie {index}",
+                    content_type=ContentType.MOVIE,
+                    status=ConsumptionStatus.UNREAD,
+                )
+            )
+
+        assert storage_manager.count_items_needing_enrichment() == 4
+
+    def test_count_includes_items_marked_needs_enrichment(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """Items with `needs_enrichment = 1` are counted (the second WHERE branch).
+
+        The shared `_build_enrichment_query` matches both `content_item_id IS NULL`
+        and `needs_enrichment = 1`. Without an explicit test here, the count path
+        only exercises the NULL branch even though the get path covers both.
+        """
+        # Save the item, then mark needs_enrichment so it has a status row
+        # with needs_enrichment = 1 (no longer NULL on the JOIN side).
+        item = ContentItem(
+            id="movie1",
+            title="Movie",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+        )
+        db_id = storage_manager.save_content_item(item)
+        storage_manager.mark_item_needs_enrichment(db_id)
+
+        assert (
+            storage_manager.get_enrichment_status(db_id) is not None
+        ), "expected enrichment_status row to exist for the needs_enrichment=1 branch"
+        assert storage_manager.count_items_needing_enrichment() == 1
+
+    def test_count_excludes_enriched_items(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """Items already enriched are not counted."""
+        item = ContentItem(
+            id="movie1",
+            title="Movie 1",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+        )
+        db_id = storage_manager.save_content_item(item)
+        storage_manager.mark_enrichment_complete(db_id, "tmdb", "high")
+
+        assert storage_manager.count_items_needing_enrichment() == 0
+
+    def test_count_filters_by_content_type(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """`content_type` parameter scopes the count to a single type."""
+        storage_manager.save_content_item(
+            ContentItem(
+                id="movie1",
+                title="Movie",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+        storage_manager.save_content_item(
+            ContentItem(
+                id="book1",
+                title="Book",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+
+        assert (
+            storage_manager.count_items_needing_enrichment(
+                content_type=ContentType.MOVIE
+            )
+            == 1
+        )
+        assert (
+            storage_manager.count_items_needing_enrichment(
+                content_type=ContentType.BOOK
+            )
+            == 1
+        )
+
+    def test_count_matches_get_length(self, storage_manager: StorageManager) -> None:
+        """Count and get must agree — they share the same WHERE clause."""
+        for index in range(3):
+            db_id = storage_manager.save_content_item(
+                ContentItem(
+                    id=f"movie{index}",
+                    title=f"Movie {index}",
+                    content_type=ContentType.MOVIE,
+                    status=ConsumptionStatus.UNREAD,
+                )
+            )
+            if index == 0:
+                # Enrich one item — both methods should agree it's excluded.
+                storage_manager.mark_enrichment_complete(db_id, "tmdb", "high")
+
+        items = storage_manager.get_items_needing_enrichment(limit=100)
+        count = storage_manager.count_items_needing_enrichment()
+
+        assert count == 2
+        assert len(items) == 2
+
+
 class TestEnrichmentStats:
     """Tests for enrichment statistics."""
 


### PR DESCRIPTION
## Summary
- Fix enrichment progress jumping in batch_size steps (50, 100, 150, 200) — `total_items` is now queried upfront and set once before the batch loop runs
- Add `StorageManager.count_items_needing_enrichment` (with shared `_build_enrichment_query` helper) so the count and list paths share one WHERE clause
- Regression coverage in `TestEnrichmentProgressRegressions` and integration coverage in `TestCountItemsNeedingEnrichment`

Fixes #60

## Test plan
- [x] `python3.11 -m pytest tests/enrichment/` — 197 passed
- [x] `command make check` — 2695 backend + 264 frontend tests passed
- [x] Verify total_items reports the real total from batch 1 onward via `test_total_items_set_before_first_batch`
- [x] Verify pending + not_found count combines correctly via `test_total_items_includes_not_found_when_retrying`
- [x] Verify count and list paths share the same WHERE branches via storage-layer integration tests

Generated with [Claude Code](https://claude.com/claude-code)