### PR TITLE
feat(sync): multi-threaded multi-source sync with --workers (closes #45)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,7 +29,8 @@ Responsible for parsing and normalizing data from various sources.
 - `ContentItem.source` reflects the user-defined key name, not the plugin name, enabling per-instance tracking
 - Each plugin handles config validation, fetching, and rating normalization
 - Shared sync executor (`execute_multi_source_sync`) used by both CLI and web
-- Progress callbacks for long-running operations
+- **Parallel multi-source sync**: `execute_multi_source_sync` accepts `max_workers` (configured via `sync.max_workers`, default 4; CLI override `--workers N`). Each enabled source runs on its own thread in a `concurrent.futures.ThreadPoolExecutor`; per-source results preserve input ordering. Plugin-internal rate limits (e.g. GOG's `rate_limit_seconds`) remain enforced per source so cross-source parallelism is safe.
+- Progress callbacks for long-running operations; the web `SyncManager` aggregates per-source progress into a `sources` map for UI rendering
 - Generic CSV/JSON importers support `ignored` field and `seasons_watched` as a list of specific season numbers
 
 ### 2. Storage Layer (`src/storage/`)
@@ -62,6 +63,9 @@ Sensitive fields (any `ConfigField` with `sensitive=True`) always live in the en
 
 **Cross-Source Deduplication:**
 Items imported from different sources (e.g., Steam and a personal blog) are automatically deduplicated by normalized title. When saving an item, the system first looks up an existing row by `(user_id, external_id, content_type)`. If found, it then checks for a *different* row with the same `(user_id, content_type, normalized_title)` and merges any such duplicate into the kept row. If no external_id match exists, it falls back to a direct normalized_title lookup to merge items from different sources. Merge rules: rating/review are filled from the duplicate only if the kept row is null; `date_completed` keeps the later date; genres/tags are merged additively; monotonic columns (seasons/episodes) keep the higher value; detail-table metadata is merged additively (existing keys preserved). Schema migrations re-normalize all titles and merge any duplicates exposed by the corrected normalization.
+
+**Thread Safety:**
+SQLite runs in WAL mode and `_get_connection` issues `PRAGMA busy_timeout = 5000` so concurrent writers block rather than raising `SQLITE_BUSY`. The read-resolve-write sequence inside `StorageManager.save_content_item` (which performs the cross-source dedup merge) is serialised via a per-`StorageManager` `threading.Lock` so the parallel multi-source sync executor cannot interleave merges on the same normalized title.
 
 ### 3. LLM Interaction Layer (`src/llm/`) — Optional
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,22 @@ DB-backed source entirely (clears every stored secret for that source).
 Sensitive fields are stored encrypted and never returned by the API; the
 UI shows a "set" / "unset" badge with **Replace** and **Clear** actions.
 
+#### Parallel Sync
+
+When syncing multiple sources, each runs on its own worker thread, so
+the total sync time is bounded by the slowest source rather than the
+sum of all sources. Configure the worker pool in `config.yaml`:
+
+```yaml
+sync:
+  max_workers: 4  # default; set to 1 for sequential
+```
+
+The CLI accepts `--workers N` to override per-invocation, e.g.
+`python3.11 -m src.cli update --workers 8`. Per-source rate limits
+(e.g. GOG's `rate_limit_seconds`) are enforced inside each plugin and
+remain untouched.
+
 ### Library Export
 
 Export your library data from the web UI:

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -279,6 +279,15 @@ conversation:
     # detection. Enable when using conversation_model with a 3B parameter model.
     compact_mode: false
 
+# Sync (data ingestion) configuration
+sync:
+  # Number of data sources to sync in parallel. Each enabled source runs
+  # on its own worker thread inside execute_multi_source_sync, so total
+  # sync time scales with the slowest source rather than the sum of all
+  # sources. Set to 1 for sequential (legacy) behaviour. The CLI flag
+  # `--workers N` overrides this value per invocation.
+  max_workers: 4
+
 # Metadata enrichment configuration
 # Enriches content items with additional metadata (genres, tags, descriptions)
 # from external APIs in a background process.

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -417,6 +417,29 @@ class TestMyPlugin:
 10. **Respect the `ignored` field** - If your source provides a way to mark items as excluded, set `ignored=True` on the `ContentItem`. Use `parse_boolean_field()` from `generic_csv` for flexible boolean parsing.
 11. **Use list format for `seasons_watched`** - For TV shows, store `seasons_watched` as a list of specific season numbers (e.g., `[1, 2, 5, 6]`) in metadata. Use `parse_seasons_watched()` from `generic_csv` if converting from string input. A single integer is treated as a count for backward compatibility (e.g., `5` → `[1, 2, 3, 4, 5]`).
 
+## Thread Safety
+
+When the user enables parallel sync (`config.sync.max_workers > 1`), each
+enabled source runs on its own worker thread inside
+`execute_multi_source_sync`. To stay safe under that model:
+
+- **Plugin instances are independent.** The registry instantiates a
+  separate plugin object per source entry, so per-instance state is fine.
+- **Avoid mutable class-level state.** Class attributes are shared across
+  instances and across threads — keep state on `self`, not on the class.
+- **Per-source rate limiting is your responsibility.** Sleep / token-bucket
+  inside `fetch()` for the source you're talking to. Cross-source
+  parallelism is what the framework adds; intra-source pacing must remain.
+- **Storage writes are already serialised.** `StorageManager` takes a
+  lock around `save_content_item` and `save_credential`, so there is
+  nothing for plugins to coordinate on the persistence side.
+- **`progress_callback` is called from the worker thread.** The framework
+  guarantees the callback itself is thread-safe; plugins just call it as
+  documented.
+
+Stateless plugins (the existing CSV / Goodreads / Steam / Sonarr / Radarr
+implementations) need no changes for parallel sync.
+
 ## Handling Token Rotation (OAuth Plugins)
 
 If your plugin uses OAuth refresh tokens, the token may be rotated by the

--- a/resources/js/components/organisms/SyncSourceAccordion.test.ts
+++ b/resources/js/components/organisms/SyncSourceAccordion.test.ts
@@ -65,7 +65,7 @@ describe('SyncSourceAccordion', () => {
 
   it('shows only the source name and Sync button when collapsed', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     await flushPromises()
 
@@ -86,7 +86,7 @@ describe('SyncSourceAccordion', () => {
 
   it('emits sync with the source id when the Sync button is clicked', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     await flushPromises()
 
@@ -115,7 +115,7 @@ describe('SyncSourceAccordion', () => {
 
   it('clicking the trigger loads schema and config and expands the panel', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     const { loadSchema, loadConfig } = primeStore(store, yamlConfig)
@@ -132,7 +132,7 @@ describe('SyncSourceAccordion', () => {
 
   it('shows the Migrate to DB button when the source is not yet migrated', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     primeStore(store, yamlConfig)
@@ -147,7 +147,7 @@ describe('SyncSourceAccordion', () => {
 
   it('shows the config form and enabled toggle once migrated', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     primeStore(store, migratedConfig)
@@ -166,7 +166,7 @@ describe('SyncSourceAccordion', () => {
 
   it('clicking Migrate calls store.migrateSource', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     primeStore(store, yamlConfig)
@@ -187,7 +187,7 @@ describe('SyncSourceAccordion', () => {
 
   it('renders the Sync button label as Syncing… while syncing', () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: true, disabled: false },
+      props: { source: baseSource, syncing: true },
     })
 
     const sync = wrapper.find('[data-testid="sync-btn-steam"]')
@@ -196,19 +196,9 @@ describe('SyncSourceAccordion', () => {
     expect(sync.attributes('aria-label')).toContain('Syncing Steam')
   })
 
-  it('disables the Sync button when another sync is running (disabled prop)', () => {
-    const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: true },
-    })
-
-    const sync = wrapper.find('[data-testid="sync-btn-steam"]')
-    expect(sync.attributes('disabled')).toBeDefined()
-    expect(sync.attributes('aria-label')).toContain('another sync is in progress')
-  })
-
   it('disables the Sync button and shows a Disabled badge when source.enabled is false', () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: disabledSource, syncing: false, disabled: false },
+      props: { source: disabledSource, syncing: false },
     })
 
     const sync = wrapper.find('[data-testid="sync-btn-steam"]')
@@ -219,7 +209,7 @@ describe('SyncSourceAccordion', () => {
 
   it('does not emit sync when disabled source button is clicked', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: disabledSource, syncing: false, disabled: false },
+      props: { source: disabledSource, syncing: false },
     })
 
     await wrapper.find('[data-testid="sync-btn-steam"]').trigger('click')
@@ -228,7 +218,7 @@ describe('SyncSourceAccordion', () => {
 
   it('clicking the Disable button on an enabled source calls store.setSourceEnabled(false)', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     primeStore(store, migratedConfig)
@@ -247,7 +237,7 @@ describe('SyncSourceAccordion', () => {
 
   it('clicking the Enable button on a disabled source calls store.setSourceEnabled(true)', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     primeStore(store, { ...migratedConfig, enabled: false })
@@ -266,7 +256,7 @@ describe('SyncSourceAccordion', () => {
 
   it('saving the form forwards the values to store.updateSourceConfig', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     primeStore(store, migratedConfig)
@@ -289,7 +279,7 @@ describe('SyncSourceAccordion', () => {
 
   it('clicking Remove with confirm=true calls store.deleteSource', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     primeStore(store, migratedConfig)
@@ -308,7 +298,7 @@ describe('SyncSourceAccordion', () => {
 
   it('clicking Remove with confirm=false does NOT call store.deleteSource', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     primeStore(store, migratedConfig)
@@ -327,7 +317,7 @@ describe('SyncSourceAccordion', () => {
 
   it('renders the Saved status pill after a successful save', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     primeStore(store, migratedConfig)
@@ -346,7 +336,7 @@ describe('SyncSourceAccordion', () => {
 
   it('renders the Error status pill when updateSourceConfig rejects', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     primeStore(store, migratedConfig)
@@ -367,7 +357,7 @@ describe('SyncSourceAccordion', () => {
 
   it('disables the toggle button while setSourceEnabled is in flight (re-entrant guard)', async () => {
     const wrapper = mount(SyncSourceAccordion, {
-      props: { source: baseSource, syncing: false, disabled: false },
+      props: { source: baseSource, syncing: false },
     })
     const store = useDataStore()
     primeStore(store, migratedConfig)
@@ -390,5 +380,138 @@ describe('SyncSourceAccordion', () => {
     // Release the in-flight call so component teardown isn't fighting timers.
     releaseToggle()
     await flushPromises()
+  })
+
+  describe('progress + error rendering driven by the job prop', () => {
+    function makeJob(overrides: Record<string, unknown> = {}) {
+      return {
+        source: 'Steam',
+        status: 'running' as const,
+        started_at: null,
+        completed_at: null,
+        items_processed: 4,
+        total_items: 10,
+        current_item: 'Half-Life 2',
+        current_source: 'Steam',
+        error_message: null,
+        progress_percent: 40,
+        error_count: 0,
+        errors: [] as string[],
+        sources: [] as never[],
+        ...overrides,
+      }
+    }
+
+    it('renders progress bar from a single-source running job', () => {
+      const wrapper = mount(SyncSourceAccordion, {
+        props: { source: baseSource, syncing: true, job: makeJob() },
+      })
+
+      const bar = wrapper.find('[role="progressbar"]')
+      expect(bar.exists()).toBe(true)
+      expect(bar.attributes('aria-valuenow')).toBe('40')
+      expect(wrapper.text()).toContain('4/10')
+      expect(wrapper.text()).toContain('40%')
+      expect(wrapper.text()).toContain('Half-Life 2')
+    })
+
+    it('looks up this source in job.sources[] when job is umbrella', () => {
+      const job = makeJob({
+        source: 'All Sources',
+        items_processed: 100,
+        total_items: 200,
+        progress_percent: 50,
+        current_item: 'Other thing',
+        sources: [
+          {
+            source: 'Steam',
+            items_processed: 7,
+            total_items: 8,
+            current_item: 'Portal 2',
+            progress_percent: 87,
+          },
+        ],
+      })
+      const wrapper = mount(SyncSourceAccordion, {
+        props: { source: baseSource, syncing: true, job },
+      })
+
+      const bar = wrapper.find('[role="progressbar"]')
+      expect(bar.attributes('aria-valuenow')).toBe('87')
+      expect(wrapper.text()).toContain('7/8')
+      expect(wrapper.text()).toContain('Portal 2')
+      // The umbrella job's top-level current_item ("Other thing") is for
+      // a different source — it must NOT leak into this accordion.
+      expect(wrapper.text()).not.toContain('Other thing')
+    })
+
+    it('omits the progress bar when progress_percent is null', () => {
+      const job = makeJob({ progress_percent: null, total_items: null })
+      const wrapper = mount(SyncSourceAccordion, {
+        props: { source: baseSource, syncing: true, job },
+      })
+
+      expect(wrapper.find('[role="progressbar"]').exists()).toBe(false)
+      // Counts label uses the items-only fallback, NOT a malformed
+      // fraction with a null total.
+      expect(wrapper.text()).toContain('4 items')
+      expect(wrapper.text()).not.toContain('4/null')
+      expect(wrapper.text()).not.toContain('4/0')
+    })
+
+    it('renders the error badge for a completed job with errors', () => {
+      const job = makeJob({
+        status: 'completed',
+        error_count: 3,
+        errors: ['e1', 'e2', 'e3'],
+      })
+      const wrapper = mount(SyncSourceAccordion, {
+        props: { source: baseSource, syncing: false, job },
+      })
+
+      expect(wrapper.text()).toContain('3 errors')
+      const badge = wrapper.find('.source-accordion-error-badge')
+      expect(badge.attributes('aria-label')).toBe('3 errors on last sync')
+    })
+
+    it('uses singular wording when error_count is 1', () => {
+      const job = makeJob({
+        status: 'completed',
+        error_count: 1,
+        errors: ['e1'],
+      })
+      const wrapper = mount(SyncSourceAccordion, {
+        props: { source: baseSource, syncing: false, job },
+      })
+
+      const badge = wrapper.find('.source-accordion-error-badge')
+      expect(badge.text()).toBe('1 error')
+      expect(badge.attributes('aria-label')).toBe('1 error on last sync')
+    })
+
+    it('hides the error badge while a sync is in progress', () => {
+      const job = makeJob({
+        status: 'running',
+        error_count: 5,
+      })
+      const wrapper = mount(SyncSourceAccordion, {
+        props: { source: baseSource, syncing: true, job },
+      })
+
+      expect(wrapper.find('.source-accordion-error-badge').exists()).toBe(false)
+    })
+
+    it('renders nothing extra when job is null', () => {
+      const wrapper = mount(SyncSourceAccordion, {
+        props: { source: baseSource, syncing: false, job: null },
+      })
+
+      // The aria-live progress region is in the DOM via v-show but
+      // hidden, and the error badge is absent because there's no job.
+      expect(wrapper.find('.source-accordion-error-badge').exists()).toBe(false)
+      const region = wrapper.find('.source-accordion-progress')
+      expect(region.exists()).toBe(true)
+      expect((region.element as HTMLElement).style.display).toBe('none')
+    })
   })
 })

--- a/resources/js/components/organisms/SyncSourceAccordion.vue
+++ b/resources/js/components/organisms/SyncSourceAccordion.vue
@@ -4,12 +4,16 @@ import Accordion from '@/components/atoms/Accordion.vue'
 import SourceConfigForm from '@/components/molecules/SourceConfigForm.vue'
 import OAuthConnectFlow from '@/components/molecules/OAuthConnectFlow.vue'
 import { useDataStore } from '@/stores/data'
-import type { SyncSourceResponse } from '@/types/api'
+import type {
+  SyncJobResponse,
+  SyncSourceProgressResponse,
+  SyncSourceResponse,
+} from '@/types/api'
 
 const props = defineProps<{
   source: SyncSourceResponse
   syncing: boolean
-  disabled: boolean
+  job?: SyncJobResponse | null
 }>()
 
 const emit = defineEmits<{
@@ -151,27 +155,102 @@ onBeforeUnmount(() => {
   }
 })
 
-const sourceEnabled = computed(() => props.source.enabled)
-const syncDisabled = computed(
-  () => props.syncing || props.disabled || !sourceEnabled.value,
-)
+const syncDisabled = computed(() => props.syncing || !props.source.enabled)
 const syncLabel = computed(() => (props.syncing ? 'Syncing…' : 'Sync'))
+
+// Progress for THIS source. When the running job is single-source (the
+// user clicked Sync on this row), use the job's top-level counters. When
+// the job is the umbrella "All Sources" run, look up this source's slot
+// in ``job.sources[]`` by display_name.
+const progress = computed<SyncSourceProgressResponse | null>(() => {
+  const job = props.job
+  if (!job || job.status !== 'running') return null
+  if (job.source === props.source.display_name) {
+    return {
+      source: job.source,
+      items_processed: job.items_processed,
+      total_items: job.total_items,
+      current_item: job.current_item,
+      progress_percent: job.progress_percent,
+    }
+  }
+  return (
+    job.sources.find((entry) => entry.source === props.source.display_name) ||
+    null
+  )
+})
+
+const progressLabel = computed<string>(() => {
+  const entry = progress.value
+  if (!entry) return ''
+  if (entry.total_items != null && entry.total_items > 0) {
+    const pct = entry.progress_percent != null ? ` (${entry.progress_percent}%)` : ''
+    return `${entry.items_processed}/${entry.total_items}${pct}`
+  }
+  return `${entry.items_processed} items`
+})
+
+const errorBadgeText = computed<string>(() => {
+  const count = props.job?.error_count ?? 0
+  return `${count} error${count === 1 ? '' : 's'}`
+})
+
+const errorBadgeAriaLabel = computed<string>(
+  () => `${errorBadgeText.value} on last sync`,
+)
 </script>
 
 <template>
   <Accordion
     :id="source.id"
     :expanded="expanded"
-    :class="{ 'source-accordion--disabled': !sourceEnabled }"
+    :class="{ 'source-accordion--disabled': !props.source.enabled }"
     @update:expanded="onToggleExpanded"
   >
     <template #header>
       <span class="source-accordion-header-text">
         <span class="source-accordion-name">{{ source.display_name }}</span>
         <span
-          v-if="!sourceEnabled"
+          v-if="!props.source.enabled"
           class="source-accordion-status-badge"
         >Disabled</span>
+        <!--
+          v-show (not v-if) keeps the live region in the DOM so JAWS/NVDA
+          announce progress as values change rather than treating each
+          poll as a fresh insertion (WCAG 4.1.3 status messages).
+          All `progress?` derefs are null-safe so the children evaluate
+          cleanly while the region is hidden.
+        -->
+        <span
+          v-show="progress"
+          class="source-accordion-progress"
+          aria-live="polite"
+        >
+          <span
+            v-if="progress?.progress_percent != null"
+            class="source-accordion-progress-bar"
+            role="progressbar"
+            :aria-valuenow="progress.progress_percent"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            :aria-label="`${source.display_name} sync progress: ${progress.progress_percent}%`"
+          >
+            <span
+              class="source-accordion-progress-fill"
+              :style="{ width: `${Math.min(100, progress.progress_percent)}%` }"
+            />
+          </span>
+          <span class="source-accordion-progress-counts">{{ progressLabel }}</span>
+          <span
+            v-if="progress?.current_item"
+            class="source-accordion-progress-item"
+          >{{ progress.current_item }}</span>
+        </span>
+        <span
+          v-if="!progress && job && job.error_count > 0 && !syncing"
+          class="source-accordion-error-badge"
+          :aria-label="errorBadgeAriaLabel"
+        >{{ errorBadgeText }}</span>
       </span>
     </template>
 
@@ -182,12 +261,10 @@ const syncLabel = computed(() => (props.syncing ? 'Syncing…' : 'Sync'))
         :data-testid="`sync-btn-${source.id}`"
         :disabled="syncDisabled"
         :aria-label="
-          !sourceEnabled
+          !props.source.enabled
             ? `Sync ${source.display_name} — source is disabled`
             : props.syncing
             ? `Syncing ${source.display_name} — in progress`
-            : props.disabled
-            ? `Sync ${source.display_name} — another sync is in progress`
             : `Sync ${source.display_name}`
         "
         @click="onSyncClick"
@@ -240,7 +317,7 @@ const syncLabel = computed(() => (props.syncing ? 'Syncing…' : 'Sync'))
           :values="config.field_values"
           :secret-status="config.secret_status"
           :saving="savingConfig"
-          :disabled="props.disabled"
+          :disabled="props.syncing"
           :enabled="config.enabled"
           :enable-busy="togglingEnabled"
           :save-status="saveStatus"
@@ -349,5 +426,63 @@ const syncLabel = computed(() => (props.syncing ? 'Syncing…' : 'Sync'))
 
 .source-accordion-oauth {
   margin-bottom: var(--space-3);
+}
+
+.source-accordion-progress {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  flex-wrap: wrap;
+}
+
+.source-accordion-progress-bar {
+  position: relative;
+  display: inline-block;
+  width: 80px;
+  height: 6px;
+  background: var(--border-default);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  vertical-align: middle;
+}
+
+.source-accordion-progress-fill {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  transition: width 0.2s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .source-accordion-progress-fill {
+    transition: none;
+  }
+}
+
+.source-accordion-progress-counts {
+  font-variant-numeric: tabular-nums;
+}
+
+.source-accordion-progress-item {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-style: italic;
+}
+
+.source-accordion-error-badge {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px var(--space-2);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-error) 18%, transparent);
+  color: var(--text-primary);
+  font-weight: 500;
+  margin-left: var(--space-3);
 }
 </style>

--- a/resources/js/components/pages/DataPage.vue
+++ b/resources/js/components/pages/DataPage.vue
@@ -20,8 +20,7 @@ onUnmounted(() => {
 })
 
 const syncAllLabel = computed(() => {
-  if (data.syncStatus === 'running' && data.syncingSource === 'all') return 'Syncing...'
-  if (data.syncStatus === 'running') return 'Sync in Progress'
+  if (data.isSourceIdSyncing('all')) return 'Syncing...'
   return 'Sync All Sources'
 })
 
@@ -64,18 +63,10 @@ const orderedSources = computed(() => {
           'sync-status-info': data.syncStatus === 'running' || data.syncStatus === 'idle',
         }"
       >{{ data.syncMessage }}</div>
-      <div
-        v-if="data.syncJob?.progress_percent != null && data.syncStatus === 'running'"
-        class="sync-progress-bar"
-        role="progressbar"
-        :aria-valuenow="data.syncJob.progress_percent"
-        aria-valuemin="0"
-        aria-valuemax="100"
-        :aria-label="`Sync progress: ${data.syncJob.progress_percent}%`"
-      >
-        <div class="sync-progress-fill" :style="{ width: `${data.syncJob.progress_percent}%` }" />
-      </div>
-      <p class="help-text">Sync data from your configured sources. Only one sync can run at a time.</p>
+      <p class="help-text">
+        Sync data from your configured sources. Multiple sources can run in
+        parallel.
+      </p>
 
       <div v-if="data.syncLoading" class="empty-state"><span class="spinner" /> Loading sync sources...</div>
       <div v-else-if="data.syncSources.length === 0" class="empty-state">
@@ -86,8 +77,8 @@ const orderedSources = computed(() => {
           v-for="source in orderedSources"
           :key="source.id"
           :source="source"
-          :syncing="data.syncingSource === source.id || data.syncingSource === 'all'"
-          :disabled="data.syncStatus === 'running' && data.syncingSource !== source.id && data.syncingSource !== 'all'"
+          :syncing="data.isSourceIdSyncing(source.id) || data.isSourceIdSyncing('all')"
+          :job="data.jobForSourceId(source.id) || data.jobForSourceId('all')"
           @sync="data.triggerSync($event)"
         />
         <div v-if="data.syncSources.length > 1" class="sync-all-card">
@@ -98,12 +89,10 @@ const orderedSources = computed(() => {
           <button
             type="button"
             class="btn btn-secondary sync-btn"
-            :disabled="data.syncStatus === 'running'"
+            :disabled="data.isSourceIdSyncing('all')"
             :aria-label="
-              data.syncStatus === 'running' && data.syncingSource === 'all'
+              data.isSourceIdSyncing('all')
                 ? 'Syncing all sources — in progress'
-                : data.syncStatus === 'running'
-                ? 'Sync all sources — another sync is in progress'
                 : 'Sync all sources'
             "
             @click="data.triggerSync('all')"
@@ -148,4 +137,5 @@ const orderedSources = computed(() => {
   background: var(--surface);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
 }
+
 </style>

--- a/resources/js/stores/data.test.ts
+++ b/resources/js/stores/data.test.ts
@@ -43,7 +43,8 @@ describe('useDataStore', () => {
     const store = useDataStore()
     expect(store.syncSources).toEqual([])
     expect(store.syncStatus).toBe('idle')
-    expect(store.syncingSource).toBeNull()
+    expect(store.syncJobs).toEqual([])
+    expect(store.isSourceIdSyncing('steam')).toBe(false)
     expect(store.enrichmentStats).toBeNull()
   })
 
@@ -64,58 +65,211 @@ describe('useDataStore', () => {
     expect(store.gogStatus.authUrl).toBe('https://gog.com/auth')
   })
 
-  it('triggerSync sets syncingSource and status', async () => {
-    mockPost.mockResolvedValue({ message: 'Sync started for steam' })
+  function steamSource() {
+    return {
+      id: 'steam',
+      display_name: 'Steam',
+      plugin_display_name: 'Steam',
+      enabled: true,
+    }
+  }
+
+  function goodreadsSource() {
+    return {
+      id: 'goodreads',
+      display_name: 'Goodreads',
+      plugin_display_name: 'Goodreads',
+      enabled: true,
+    }
+  }
+
+  it('triggerSync marks the source label as syncing', async () => {
+    mockPost.mockResolvedValue({ message: 'Sync started for Steam' })
 
     const store = useDataStore()
+    store.$patch({ syncSources: [steamSource()] })
     await store.triggerSync('steam')
 
-    expect(store.syncMessage).toBe('Sync started for steam')
     expect(store.syncStatus).toBe('running')
-    expect(store.syncingSource).toBe('steam')
+    expect(store.syncMessage).toBe('Sync started for Steam')
+    expect(store.isSourceIdSyncing('steam')).toBe(true)
+    expect(store.isSourceIdSyncing('goodreads')).toBe(false)
   })
 
-  it('triggerSync clears syncingSource on API error', async () => {
+  it('triggerSync clears the optimistic trigger on API error', async () => {
     mockPost.mockRejectedValue(new ApiError(503, 'Service Unavailable'))
 
     const store = useDataStore()
+    store.$patch({ syncSources: [steamSource()] })
     await store.triggerSync('steam')
 
     expect(store.syncStatus).toBe('failed')
-    expect(store.syncingSource).toBeNull()
+    expect(store.isSourceIdSyncing('steam')).toBe(false)
     expect(store.syncMessage).toContain('server returned 503')
   })
 
-  it('triggerSync clears syncingSource on generic error', async () => {
+  it('triggerSync clears the optimistic trigger on generic error', async () => {
     mockPost.mockRejectedValue(new Error('network failure'))
 
     const store = useDataStore()
+    store.$patch({ syncSources: [steamSource()] })
     await store.triggerSync('steam')
 
     expect(store.syncStatus).toBe('failed')
-    expect(store.syncingSource).toBeNull()
+    expect(store.isSourceIdSyncing('steam')).toBe(false)
     expect(store.syncMessage).toContain('unexpected failure')
   })
 
-  it('checkSyncStatus clears syncingSource on completed', async () => {
+  it('triggerSync handles the "all" pseudo-source via the All Sources label', async () => {
+    mockPost.mockResolvedValue({ message: 'Sync started for All Sources' })
+
+    const store = useDataStore()
+    await store.triggerSync('all')
+
+    expect(store.isSourceIdSyncing('all')).toBe(true)
+  })
+
+  it('checkSyncStatus drops the optimistic trigger once the server ack\'s the job', async () => {
+    // Plant an optimistic trigger via triggerSync, then poll status and
+    // observe the trigger is cleared because the server now reports the
+    // job — isSourceIdSyncing should still be true (driven by the job),
+    // but the source of truth has shifted from optimistic to server.
+    mockPost.mockResolvedValue({ message: 'Sync started for Steam' })
     mockGet.mockResolvedValue({
-      status: 'completed',
-      job: { items_processed: 42, error_count: 0, source: 'steam' },
+      status: 'running',
+      jobs: [
+        {
+          source: 'Steam',
+          status: 'running',
+          items_processed: 0,
+          total_items: null,
+          error_count: 0,
+          errors: [],
+          sources: [],
+        },
+      ],
     })
 
     const store = useDataStore()
-    store.$patch({ syncingSource: 'steam' })
+    store.$patch({ syncSources: [steamSource()] })
+    await store.triggerSync('steam')
+    await store.checkSyncStatus()
+
+    expect(store.isSourceIdSyncing('steam')).toBe(true)
+    // A second poll with the same response keeps the source syncing —
+    // the source of truth has shifted from optimistic to server, but
+    // the public flag stays true because the server reports running.
+    await store.checkSyncStatus()
+    expect(store.isSourceIdSyncing('steam')).toBe(true)
+  })
+
+  it('checkSyncStatus reports idle on empty jobs array', async () => {
+    mockGet.mockResolvedValue({ status: 'idle', jobs: [] })
+
+    const store = useDataStore()
+    await store.checkSyncStatus()
+
+    expect(store.syncStatus).toBe('idle')
+    expect(store.syncJobs).toEqual([])
+    expect(store.syncMessage).toBe('')
+  })
+
+  it('checkSyncStatus treats total_items=0 as unknown total in aggregate banner', async () => {
+    mockGet.mockResolvedValue({
+      status: 'running',
+      jobs: [
+        {
+          source: 'Steam',
+          status: 'running',
+          items_processed: 5,
+          total_items: 0,
+          error_count: 0,
+          errors: [],
+          sources: [],
+        },
+      ],
+    })
+
+    const store = useDataStore()
+    await store.checkSyncStatus()
+
+    expect(store.syncMessage).toContain('5 items so far')
+    expect(store.syncMessage).not.toContain('/0')
+  })
+
+  it('checkSyncStatus matches the "all" source ID to the "All Sources" job', async () => {
+    mockGet.mockResolvedValue({
+      status: 'running',
+      jobs: [
+        {
+          source: 'All Sources',
+          status: 'running',
+          items_processed: 4,
+          total_items: 10,
+          progress_percent: 40,
+          current_source: 'Steam',
+          current_item: 'Half-Life 2',
+          error_count: 0,
+          errors: [],
+          sources: [],
+        },
+      ],
+    })
+
+    const store = useDataStore()
+    await store.checkSyncStatus()
+
+    expect(store.isSourceIdSyncing('all')).toBe(true)
+    const job = store.jobForSourceId('all')
+    expect(job?.source).toBe('All Sources')
+    expect(job?.items_processed).toBe(4)
+  })
+
+  it('checkSyncStatus reports completed when no jobs are running', async () => {
+    mockGet.mockResolvedValue({
+      status: 'idle',
+      jobs: [
+        {
+          source: 'Steam',
+          status: 'completed',
+          items_processed: 42,
+          total_items: 42,
+          error_count: 0,
+          errors: [],
+          sources: [],
+        },
+      ],
+    })
+
+    const store = useDataStore()
     await store.checkSyncStatus()
 
     expect(store.syncStatus).toBe('completed')
-    expect(store.syncingSource).toBeNull()
     expect(store.syncMessage).toContain('42 items synced')
+    expect(store.isSourceIdSyncing('steam')).toBe(false)
   })
 
-  it('checkSyncStatus includes error count in completed message', async () => {
+  it('checkSyncStatus aggregates errors across completed jobs', async () => {
     mockGet.mockResolvedValue({
-      status: 'completed',
-      job: { items_processed: 100, error_count: 3, source: 'steam' },
+      status: 'idle',
+      jobs: [
+        {
+          source: 'Steam',
+          status: 'completed',
+          items_processed: 90,
+          error_count: 2,
+          errors: ['e1', 'e2'],
+          sources: [],
+        },
+        {
+          source: 'Goodreads',
+          status: 'completed',
+          items_processed: 10,
+          error_count: 1,
+          errors: ['e3'],
+          sources: [],
+        },
+      ],
     })
 
     const store = useDataStore()
@@ -125,52 +279,81 @@ describe('useDataStore', () => {
     expect(store.syncMessage).toContain('3 errors')
   })
 
-  it('checkSyncStatus clears syncingSource on failed', async () => {
+  it('checkSyncStatus surfaces a failed job before completed jobs', async () => {
     mockGet.mockResolvedValue({
-      status: 'failed',
-      job: { error_message: 'timeout', source: 'steam' },
+      status: 'idle',
+      jobs: [
+        {
+          source: 'Steam',
+          status: 'failed',
+          items_processed: 0,
+          error_message: 'timeout',
+          error_count: 1,
+          errors: ['timeout'],
+          sources: [],
+        },
+      ],
     })
 
     const store = useDataStore()
-    store.$patch({ syncingSource: 'steam' })
     await store.checkSyncStatus()
 
     expect(store.syncStatus).toBe('failed')
-    expect(store.syncingSource).toBeNull()
     expect(store.syncMessage).toContain('timeout')
+    expect(store.syncMessage).toContain('Steam')
   })
 
-  it('checkSyncStatus clears syncingSource on idle', async () => {
-    mockGet.mockResolvedValue({ status: 'idle' })
+  it('checkSyncStatus is idle when no jobs are tracked', async () => {
+    mockGet.mockResolvedValue({ status: 'idle', jobs: [] })
 
     const store = useDataStore()
-    store.$patch({ syncingSource: 'steam' })
     await store.checkSyncStatus()
 
     expect(store.syncStatus).toBe('idle')
-    expect(store.syncingSource).toBeNull()
+    expect(store.syncMessage).toBe('')
   })
 
-  it('checkSyncStatus restores syncingSource from server on running', async () => {
+  it('checkSyncStatus marks per-source jobs as syncing for their source IDs', async () => {
     mockGet.mockResolvedValue({
       status: 'running',
-      job: { source: 'goodreads', items_processed: 5, current_source: 'goodreads' },
+      jobs: [
+        {
+          source: 'Goodreads',
+          status: 'running',
+          items_processed: 5,
+          error_count: 0,
+          errors: [],
+          sources: [],
+        },
+      ],
     })
 
     const store = useDataStore()
+    store.$patch({ syncSources: [goodreadsSource(), steamSource()] })
     await store.checkSyncStatus()
 
     expect(store.syncStatus).toBe('running')
-    expect(store.syncingSource).toBe('goodreads')
+    expect(store.isSourceIdSyncing('goodreads')).toBe(true)
+    expect(store.isSourceIdSyncing('steam')).toBe(false)
   })
 
-  it('checkSyncStatus builds progress message with total and percent', async () => {
+  it('checkSyncStatus builds aggregate progress message with totals', async () => {
     mockGet.mockResolvedValue({
       status: 'running',
-      job: {
-        source: 'steam', items_processed: 10, total_items: 100,
-        progress_percent: 10, current_source: 'steam', current_item: 'Half-Life 2',
-      },
+      jobs: [
+        {
+          source: 'Steam',
+          status: 'running',
+          items_processed: 10,
+          total_items: 100,
+          progress_percent: 10,
+          current_source: 'Steam',
+          current_item: 'Half-Life 2',
+          error_count: 0,
+          errors: [],
+          sources: [],
+        },
+      ],
     })
 
     const store = useDataStore()
@@ -181,61 +364,20 @@ describe('useDataStore', () => {
     expect(store.syncMessage).toContain('Half-Life 2')
   })
 
-  it('checkSyncStatus builds progress message at sync start', async () => {
+  it('checkSyncStatus shows "items so far" when total is unknown', async () => {
     mockGet.mockResolvedValue({
       status: 'running',
-      job: {
-        source: 'steam', items_processed: 0, total_items: null,
-        progress_percent: null, current_source: 'steam', current_item: null,
-      },
-    })
-
-    const store = useDataStore()
-    await store.checkSyncStatus()
-
-    expect(store.syncMessage).toContain('0 items so far')
-    expect(store.syncMessage).not.toMatch(/^ *-/)
-  })
-
-  it('checkSyncStatus builds progress message with total but no percent', async () => {
-    mockGet.mockResolvedValue({
-      status: 'running',
-      job: {
-        source: 'steam', items_processed: 10, total_items: 100,
-        progress_percent: null, current_source: 'steam', current_item: null,
-      },
-    })
-
-    const store = useDataStore()
-    await store.checkSyncStatus()
-
-    expect(store.syncMessage).toContain('10/100')
-    expect(store.syncMessage).not.toContain('%')
-  })
-
-  it('checkSyncStatus treats total_items of 0 as unknown total', async () => {
-    mockGet.mockResolvedValue({
-      status: 'running',
-      job: {
-        source: 'steam', items_processed: 5, total_items: 0,
-        progress_percent: null, current_source: 'steam', current_item: null,
-      },
-    })
-
-    const store = useDataStore()
-    await store.checkSyncStatus()
-
-    expect(store.syncMessage).toContain('5 items so far')
-    expect(store.syncMessage).not.toContain('/0')
-  })
-
-  it('checkSyncStatus builds progress message with items only', async () => {
-    mockGet.mockResolvedValue({
-      status: 'running',
-      job: {
-        source: 'steam', items_processed: 7, total_items: null,
-        progress_percent: null, current_source: 'steam', current_item: null,
-      },
+      jobs: [
+        {
+          source: 'Steam',
+          status: 'running',
+          items_processed: 7,
+          total_items: null,
+          error_count: 0,
+          errors: [],
+          sources: [],
+        },
+      ],
     })
 
     const store = useDataStore()
@@ -244,29 +386,70 @@ describe('useDataStore', () => {
     expect(store.syncMessage).toContain('7 items so far')
   })
 
-  it('checkSyncStatus preserves syncingSource when already set and running', async () => {
+  it('checkSyncStatus aggregates running jobs into a single banner', async () => {
     mockGet.mockResolvedValue({
       status: 'running',
-      job: { source: 'steam', items_processed: 5, current_source: 'steam' },
+      jobs: [
+        {
+          source: 'Goodreads',
+          status: 'running',
+          items_processed: 5,
+          total_items: 10,
+          error_count: 0,
+          errors: [],
+          sources: [],
+        },
+        {
+          source: 'Steam',
+          status: 'running',
+          items_processed: 3,
+          total_items: 20,
+          error_count: 0,
+          errors: [],
+          sources: [],
+        },
+      ],
     })
 
     const store = useDataStore()
-    store.$patch({ syncingSource: 'all' })
     await store.checkSyncStatus()
 
-    expect(store.syncingSource).toBe('all')
+    expect(store.syncMessage).toContain('8/30')
+    expect(store.syncMessage).toContain('Syncing 2 sources in parallel')
   })
 
   it('checkSyncStatus silently ignores GET failure without changing state', async () => {
     mockGet.mockRejectedValue(new Error('network error'))
 
     const store = useDataStore()
-    store.$patch({ syncStatus: 'running', syncingSource: 'steam', syncMessage: 'previous message' })
+    store.$patch({ syncStatus: 'running', syncMessage: 'previous message' })
     await store.checkSyncStatus()
 
     expect(store.syncStatus).toBe('running')
-    expect(store.syncingSource).toBe('steam')
     expect(store.syncMessage).toBe('previous message')
+  })
+
+  it('jobForSourceId returns the job whose source matches display_name', async () => {
+    const job = {
+      source: 'Steam',
+      status: 'running' as const,
+      items_processed: 9,
+      total_items: 10,
+      current_item: 'Half-Life 2',
+      error_count: 0,
+      errors: [] as string[],
+      sources: [] as never[],
+    }
+    mockGet.mockResolvedValue({ status: 'running', jobs: [job] })
+
+    const store = useDataStore()
+    store.$patch({ syncSources: [steamSource()] })
+    await store.checkSyncStatus()
+
+    const found = store.jobForSourceId('steam')
+    expect(found?.source).toBe('Steam')
+    expect(found?.current_item).toBe('Half-Life 2')
+    expect(store.jobForSourceId('goodreads')).toBeNull()
   })
 
   it('loadEnrichmentStats fetches stats', async () => {

--- a/resources/js/stores/data.ts
+++ b/resources/js/stores/data.ts
@@ -1,5 +1,5 @@
+import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
 import { useApi, ApiError } from '@/composables/useApi'
 import { useAppStore } from '@/stores/app'
 import { truncate } from '@/utils/format'
@@ -17,17 +17,51 @@ import type {
   SourceCreateRequest,
 } from '@/types/api'
 
+const ALL_SOURCES_LABEL = 'All Sources'
+
 export const useDataStore = defineStore('data', () => {
   const api = useApi()
 
-  // Sync state
+  // Sync state — multi-job after issue #45.
   const syncSources = ref<SyncSourceResponse[]>([])
+  const syncJobs = ref<SyncJobResponse[]>([])
+  // Aggregate banner status: 'running' if any job running, else last terminal.
   const syncStatus = ref<'idle' | 'running' | 'completed' | 'failed'>('idle')
-  const syncingSource = ref<string | null>(null)
-  const syncJob = ref<SyncJobResponse | null>(null)
-  // syncMessage may contain server-supplied source IDs — render with {{ }} only, never v-html
   const syncMessage = ref('')
   const syncLoading = ref(false)
+  // Optimistic set of in-flight source labels — populated immediately on
+  // triggerSync so the per-accordion Sync button switches to "Syncing…"
+  // without waiting for the next /sync/status poll.
+  const optimisticTriggers = ref<Set<string>>(new Set())
+
+  // Map of currently RUNNING jobs by source label, derived from /sync/status.
+  const jobsByLabel = computed<Record<string, SyncJobResponse>>(() => {
+    const map: Record<string, SyncJobResponse> = {}
+    for (const job of syncJobs.value) map[job.source] = job
+    return map
+  })
+
+  function isLabelRunning(label: string): boolean {
+    if (optimisticTriggers.value.has(label)) return true
+    const job = jobsByLabel.value[label]
+    return job?.status === 'running'
+  }
+
+  function jobForLabel(label: string): SyncJobResponse | null {
+    return jobsByLabel.value[label] || null
+  }
+
+  function jobForSourceId(sourceId: string): SyncJobResponse | null {
+    if (sourceId === 'all') return jobForLabel(ALL_SOURCES_LABEL)
+    const display = syncSources.value.find((s) => s.id === sourceId)?.display_name
+    return display ? jobForLabel(display) : null
+  }
+
+  function isSourceIdSyncing(sourceId: string): boolean {
+    if (sourceId === 'all') return isLabelRunning(ALL_SOURCES_LABEL)
+    const display = syncSources.value.find((s) => s.id === sourceId)?.display_name
+    return display ? isLabelRunning(display) : false
+  }
 
   // Auth state
   const gogStatus = ref<{ authUrl: string | null; connected: boolean }>({ authUrl: null, connected: false })
@@ -69,55 +103,95 @@ export const useDataStore = defineStore('data', () => {
     }
   }
 
-  async function triggerSync(source: string) {
-    syncMessage.value = `Starting sync for ${source}...`
+  function _labelForSourceId(sourceId: string): string {
+    if (sourceId === 'all') return ALL_SOURCES_LABEL
+    const found = syncSources.value.find((s) => s.id === sourceId)
+    if (!found) {
+      // Fallback to the raw ID so triggerSync can still post the request,
+      // but warn loudly: a missing entry in syncSources usually means the
+      // store has not loaded yet or the caller passed a stale ID.
+      console.warn(
+        `triggerSync: no source with id="${sourceId}" in syncSources; ` +
+          'using the raw ID as the job label fallback.',
+      )
+      return sourceId
+    }
+    return found.display_name
+  }
+
+  async function triggerSync(sourceId: string) {
+    const label = _labelForSourceId(sourceId)
+    syncMessage.value = `Starting sync for ${label}...`
     syncStatus.value = 'running'
-    syncingSource.value = source
+    optimisticTriggers.value = new Set([...optimisticTriggers.value, label])
     try {
-      const data = await api.post<{ message: string }>('/update', { source })
+      const data = await api.post<{ message: string }>('/update', {
+        source: sourceId,
+      })
       syncMessage.value = data.message
       startSyncPolling()
     } catch (err) {
       console.error('Sync trigger failed:', err)
-      syncMessage.value = err instanceof ApiError
-        ? `Error: server returned ${err.status}`
-        : 'Error: unexpected failure — check the console'
-      syncStatus.value = 'failed'
-      syncingSource.value = null
+      syncMessage.value =
+        err instanceof ApiError
+          ? `Error: server returned ${err.status}`
+          : 'Error: unexpected failure — check the console'
+      const next = new Set(optimisticTriggers.value)
+      next.delete(label)
+      optimisticTriggers.value = next
+      if (next.size === 0) syncStatus.value = 'failed'
     }
   }
 
   async function checkSyncStatus() {
     try {
       const data = await api.get<SyncStatusResponse>('/sync/status')
-      syncJob.value = data.job || null
+      syncJobs.value = data.jobs || []
 
-      if (data.status === 'running' && data.job) {
+      // Drop optimistic flags whose labels the server has now ack'd —
+      // start_sync transitions the job to RUNNING before returning, so
+      // any label present in syncJobs is also reflected in the server's
+      // authoritative state and no longer needs the optimistic shadow.
+      const seen = new Set(syncJobs.value.map((j) => j.source))
+      const next = new Set<string>()
+      for (const label of optimisticTriggers.value) {
+        if (!seen.has(label)) next.add(label)
+      }
+      optimisticTriggers.value = next
+
+      const runningJobs = syncJobs.value.filter((j) => j.status === 'running')
+      const anyRunning = runningJobs.length > 0 || next.size > 0
+
+      if (anyRunning) {
         syncStatus.value = 'running'
-        // Restore syncingSource from server state (e.g. page reload mid-sync).
-        // Use job.source (the original trigger, e.g. "all"), NOT job.current_source
-        // (which tracks the individual source currently processing within an "all" sync).
-        if (!syncingSource.value) {
-          syncingSource.value = data.job.source
-        }
-        syncMessage.value = buildProgressMessage(data.job)
+        syncMessage.value = buildRunningMessage(runningJobs)
         if (!syncPollTimer) startSyncPolling()
-      } else if (data.status === 'completed' && data.job) {
-        syncStatus.value = 'completed'
-        syncingSource.value = null
-        let msg = `Completed: ${data.job.items_processed} items synced`
-        if (data.job.error_count > 0) msg += ` (${data.job.error_count} errors)`
-        syncMessage.value = msg
+      } else if (syncJobs.value.length > 0) {
+        const failedJobs = syncJobs.value.filter((j) => j.status === 'failed')
+        if (failedJobs.length > 0) {
+          syncStatus.value = 'failed'
+          const first = failedJobs[0]
+          syncMessage.value = `Failed (${first.source}): ${
+            first.error_message || 'Unknown error'
+          }`
+        } else {
+          syncStatus.value = 'completed'
+          const totalItems = syncJobs.value.reduce(
+            (sum, j) => sum + j.items_processed,
+            0,
+          )
+          const totalErrors = syncJobs.value.reduce(
+            (sum, j) => sum + j.error_count,
+            0,
+          )
+          let msg = `Completed: ${totalItems} items synced`
+          if (totalErrors > 0) msg += ` (${totalErrors} errors)`
+          syncMessage.value = msg
+        }
         stopSyncPolling()
         loadEnrichmentStats()
-      } else if (data.status === 'failed' && data.job) {
-        syncStatus.value = 'failed'
-        syncingSource.value = null
-        syncMessage.value = `Failed: ${data.job.error_message || 'Unknown error'}`
-        stopSyncPolling()
       } else {
         syncStatus.value = 'idle'
-        syncingSource.value = null
         syncMessage.value = ''
         stopSyncPolling()
       }
@@ -138,19 +212,32 @@ export const useDataStore = defineStore('data', () => {
     }
   }
 
-  function buildProgressMessage(job: SyncJobResponse): string {
-    const parts: string[] = []
-    if (job.total_items != null && job.total_items > 0) {
-      let progress = `${job.items_processed}/${job.total_items}`
-      if (job.progress_percent != null) progress += ` (${job.progress_percent}%)`
-      parts.push(progress)
+  function buildRunningMessage(running: SyncJobResponse[]): string {
+    if (running.length === 0) return ''
+
+    const totalProcessed = running.reduce(
+      (sum, j) => sum + j.items_processed,
+      0,
+    )
+    const totalKnown = running.reduce(
+      (sum, j) => sum + (j.total_items || 0),
+      0,
+    )
+
+    let summary: string
+    if (totalKnown > 0) {
+      const pct = Math.min(100, Math.floor((totalProcessed * 100) / totalKnown))
+      summary = `${totalProcessed}/${totalKnown} (${pct}%)`
     } else {
-      parts.push(`${job.items_processed} items so far`)
+      summary = `${totalProcessed} items so far`
     }
-    const source = job.current_source || job.source
-    const item = job.current_item ? truncate(job.current_item, 50) : '...'
-    parts.push(`- Syncing ${source}: ${item}`)
-    return parts.join(' ')
+
+    if (running.length === 1) {
+      const job = running[0]
+      const item = job.current_item ? truncate(job.current_item, 50) : '...'
+      return `${summary} - Syncing ${job.source}: ${item}`
+    }
+    return `${summary} - Syncing ${running.length} sources in parallel`
   }
 
   // GOG/Epic auth
@@ -412,10 +499,12 @@ export const useDataStore = defineStore('data', () => {
     // State
     syncSources,
     syncStatus,
-    syncingSource,
-    syncJob,
+    syncJobs,
     syncMessage,
     syncLoading,
+    // Helpers
+    isSourceIdSyncing,
+    jobForSourceId,
     gogStatus,
     epicStatus,
     gogConnectMessage,

--- a/resources/js/types/api.ts
+++ b/resources/js/types/api.ts
@@ -140,6 +140,14 @@ export interface SourceCreateRequest {
   enabled: boolean
 }
 
+export interface SyncSourceProgressResponse {
+  source: string
+  items_processed: number
+  total_items: number | null
+  current_item: string | null
+  progress_percent: number | null
+}
+
 export interface SyncJobResponse {
   source: string
   status: string
@@ -152,11 +160,13 @@ export interface SyncJobResponse {
   error_message: string | null
   progress_percent: number | null
   error_count: number
+  errors: string[]
+  sources: SyncSourceProgressResponse[]
 }
 
 export interface SyncStatusResponse {
   status: string
-  job: SyncJobResponse | null
+  jobs: SyncJobResponse[]
 }
 
 // --- Enrichment ---

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import sys
+import threading
 import time
 import webbrowser
 from pathlib import Path
@@ -19,7 +20,11 @@ from src.cli.config import get_feature_flags
 from src.conversation.engine import ConversationEngine
 from src.conversation.profile import ProfileGenerator
 from src.enrichment.manager import EnrichmentManager
-from src.ingestion.sync import execute_sync
+from src.ingestion.sync import (
+    MAX_WORKERS_CEILING,
+    execute_multi_source_sync,
+    resolve_max_workers,
+)
 from src.models.content import (
     ConsumptionStatus,
     ContentItem,
@@ -54,6 +59,7 @@ from src.web.gog_auth import (
 )
 from src.ingestion.plugin_base import ConfigField, SourcePlugin
 from src.web.sync_sources import (
+    ResolvedInput,
     SourceConfigError,
     build_config_view,
     build_schema_view,
@@ -277,8 +283,18 @@ def recommend(
     default="all",
     help="Data source to update (use 'list' to see available sources, 'all' for everything)",
 )
+@click.option(
+    "--workers",
+    type=click.IntRange(1, MAX_WORKERS_CEILING),
+    default=None,
+    help=(
+        f"Number of sources to sync in parallel (1-{MAX_WORKERS_CEILING}). "
+        "Defaults to config.sync.max_workers (or 4 if unset). "
+        "Use 1 for sequential."
+    ),
+)
 @click.pass_context
-def update(ctx: click.Context, source: str) -> None:
+def update(ctx: click.Context, source: str, workers: int | None) -> None:
     """Update data from configured sources."""
     storage = ctx.obj["storage"]
     embedding_gen = ctx.obj["embedding_gen"]
@@ -349,64 +365,79 @@ def update(ctx: click.Context, source: str) -> None:
             if resolved_entry.source_id == source
         ]
 
-    click.echo(
-        f"Updating data from {', '.join(entry.source_id for entry in resolved)}..."
-    )
-
-    try:
-        total_count = 0
-
-        for resolved_entry in resolved:
-            validation_errors = validate_source_config(
-                resolved_entry.source_id, config, storage=storage
-            )
-            if validation_errors:
-                for error in validation_errors:
-                    click.echo(
-                        f"  {resolved_entry.plugin.display_name}: Error: {error}",
-                        err=True,
-                    )
-                continue
-
-            click.echo(
-                f"  Syncing {resolved_entry.plugin.display_name} ({resolved_entry.source_id})..."
-            )
-
-            def cli_progress(
-                items_processed: int,
-                total_items: int | None,
-                current_item: str | None,
-                current_source: str | None = None,
-            ) -> None:
-                if total_items and items_processed > 0 and items_processed % 10 == 0:
-                    click.echo(f"    Processed {items_processed}/{total_items}...")
-
-            try:
-                result = execute_sync(
-                    plugin=resolved_entry.plugin,
-                    plugin_config=resolved_entry.config,
-                    storage_manager=storage,
-                    embedding_generator=embedding_gen,
-                    use_embeddings=use_embeddings,
-                    progress_callback=cli_progress,
-                    mark_for_enrichment=auto_enrich,
-                )
-
+    # Filter out resolved entries that fail validation (preserves the
+    # per-source error reporting from the legacy sequential path).
+    valid: list[ResolvedInput] = []
+    for resolved_entry in resolved:
+        validation_errors = validate_source_config(
+            resolved_entry.source_id, config, storage=storage
+        )
+        if validation_errors:
+            for error in validation_errors:
                 click.echo(
-                    f"  Updated {result.items_synced} items from "
-                    f"{resolved_entry.plugin.display_name} ({resolved_entry.source_id})"
-                )
-                if result.errors:
-                    for error in result.errors:
-                        click.echo(f"    Warning: {error}", err=True)
-
-                total_count += result.items_synced
-
-            except Exception as error:
-                click.echo(
-                    f"  Error syncing {resolved_entry.plugin.display_name}: {error}",
+                    f"  {resolved_entry.plugin.display_name}: Error: {error}",
                     err=True,
                 )
+            continue
+        valid.append(resolved_entry)
+
+    if not valid:
+        click.echo(
+            "No items were updated. Check your configuration and source settings."
+        )
+        return
+
+    max_workers = resolve_max_workers(config, override=workers)
+
+    click.echo(
+        f"Updating data from {', '.join(entry.source_id for entry in valid)}"
+        + (f" (workers={max_workers})" if max_workers > 1 else "")
+        + "..."
+    )
+
+    # Click's echo is not thread-safe and progress messages from parallel
+    # workers can interleave; serialise output via a lock.
+    output_lock = threading.Lock()
+    last_reported: dict[str, int] = {}
+
+    def cli_progress(
+        items_processed: int,
+        total_items: int | None,
+        current_item: str | None,
+        current_source: str | None = None,
+    ) -> None:
+        if not (total_items and items_processed > 0 and items_processed % 10 == 0):
+            return
+        prefix = f"[{current_source}] " if current_source else ""
+        with output_lock:
+            # Suppress duplicate "Processed N/M" lines a worker may emit
+            # if its callback fires twice for the same threshold.
+            key = current_source or ""
+            if last_reported.get(key) == items_processed:
+                return
+            last_reported[key] = items_processed
+            click.echo(f"    {prefix}Processed {items_processed}/{total_items}...")
+
+    try:
+        results = execute_multi_source_sync(
+            sources=[(entry.plugin, entry.config) for entry in valid],
+            storage_manager=storage,
+            embedding_generator=embedding_gen,
+            use_embeddings=use_embeddings,
+            progress_callback=cli_progress,
+            mark_for_enrichment=auto_enrich,
+            max_workers=max_workers,
+        )
+
+        total_count = 0
+        for result, resolved_entry in zip(results, valid, strict=True):
+            click.echo(
+                f"  Updated {result.items_synced} items from "
+                f"{resolved_entry.plugin.display_name} ({resolved_entry.source_id})"
+            )
+            for error in result.errors:
+                click.echo(f"    Warning: {error}", err=True)
+            total_count += result.items_synced
 
         if total_count == 0:
             click.echo(

--- a/src/ingestion/sync.py
+++ b/src/ingestion/sync.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -33,6 +34,39 @@ class SyncResult:
     items_synced: int = 0
     total_items: int = 0
     errors: list[str] = field(default_factory=list)
+
+
+# Hard ceiling on the parallel-sync worker pool. Bounds both the CLI flag
+# (via Click IntRange) and the config-file path so a malicious or
+# misconfigured config.yaml cannot exhaust OS thread limits.
+MAX_WORKERS_CEILING = 32
+
+
+def resolve_max_workers(
+    config: dict[str, Any] | None,
+    override: int | None = None,
+    default: int = 4,
+) -> int:
+    """Resolve the parallel-sync worker count from override + config + default.
+
+    Order of precedence: ``override`` (typically a CLI flag) wins; otherwise
+    ``config['sync']['max_workers']`` is used; otherwise ``default``. The
+    result is always clamped to ``[1, MAX_WORKERS_CEILING]``. Non-integer
+    config values fall back to ``default`` rather than raising — this path
+    runs on every sync invocation, so the function must not crash on a
+    malformed config.
+    """
+
+    def _clamp(value: int) -> int:
+        return max(1, min(MAX_WORKERS_CEILING, value))
+
+    if override is not None:
+        return _clamp(override)
+    sync_config = (config or {}).get("sync") or {}
+    try:
+        return _clamp(int(sync_config.get("max_workers", default)))
+    except (TypeError, ValueError):
+        return default
 
 
 def execute_sync(
@@ -190,29 +224,44 @@ def execute_multi_source_sync(
     error_callback: Callable[[str], None] | None = None,
     mark_for_enrichment: bool = False,
     user_id: int = 1,
+    max_workers: int = 1,
 ) -> list[SyncResult]:
-    """Execute sync for multiple plugin sources sequentially.
+    """Execute sync for multiple plugin sources, optionally in parallel.
+
+    With ``max_workers <= 1`` (default), sources sync sequentially.
+    With ``max_workers > 1``, sources run on a ThreadPoolExecutor, capped
+    at ``min(max_workers, len(sources))``. Per-source rate limiting is
+    enforced inside each plugin, so cross-source parallelism is safe.
+
+    Thread-safety contract: when ``max_workers > 1``, ``progress_callback``
+    and ``error_callback`` may be invoked concurrently from multiple worker
+    threads. Both callers in this codebase honour that contract — the web
+    ``SyncManager`` takes a lock internally, and the CLI ``cli_progress``
+    serialises ``click.echo`` via its own lock — but any future caller
+    must do the same.
 
     Args:
         sources: List of (plugin, plugin_config) tuples to sync.
         storage_manager: Storage manager for saving items.
         embedding_generator: Optional embedding generator.
         use_embeddings: Whether to generate embeddings.
-        progress_callback: Optional callback for progress updates.
-        error_callback: Optional callback for error reporting.
+        progress_callback: Optional callback for progress updates. Must be
+            thread-safe when ``max_workers > 1``.
+        error_callback: Optional callback for error reporting. Must be
+            thread-safe when ``max_workers > 1``.
         mark_for_enrichment: Whether to mark items as needing enrichment after save.
         user_id: User ID for credential storage (default 1).
+        max_workers: Maximum sources to sync concurrently. ``1`` (default)
+            preserves the legacy sequential behaviour.
 
     Returns:
-        List of SyncResult, one per source.
+        List of SyncResult, one per source, in the same order as ``sources``.
     """
-    results: list[SyncResult] = []
 
-    for plugin, plugin_config in sources:
+    def _run_one(plugin: SourcePlugin, plugin_config: dict[str, Any]) -> SyncResult:
         logger.info("[SYNC] === Starting sync for source: %s ===", plugin.name)
-
         try:
-            result = execute_sync(
+            return execute_sync(
                 plugin=plugin,
                 plugin_config=plugin_config,
                 storage_manager=storage_manager,
@@ -222,27 +271,36 @@ def execute_multi_source_sync(
                 mark_for_enrichment=mark_for_enrichment,
                 user_id=user_id,
             )
-            results.append(result)
-
-            if result.errors and error_callback:
-                for error_message in result.errors:
-                    error_callback(error_message)
-
         except Exception as error:
             error_message = f"Sync failed for {plugin.name}: {error}"
             logger.error("[SYNC] %s", error_message)
-            if error_callback:
-                error_callback(error_message)
             source_id = plugin_config.get("_source_id")
             error_source_name = (
                 humanize_source_id(source_id) if source_id else plugin.display_name
             )
-            results.append(
-                SyncResult(
-                    source_name=error_source_name,
-                    errors=[error_message],
-                )
+            return SyncResult(
+                source_name=error_source_name,
+                errors=[error_message],
             )
+
+    effective_workers = min(max_workers, len(sources)) if sources else 1
+
+    if effective_workers > 1:
+        with ThreadPoolExecutor(
+            max_workers=effective_workers, thread_name_prefix="sync"
+        ) as executor:
+            futures = [
+                executor.submit(_run_one, plugin, plugin_config)
+                for plugin, plugin_config in sources
+            ]
+            results = [future.result() for future in futures]
+    else:
+        results = [_run_one(plugin, cfg) for plugin, cfg in sources]
+
+    if error_callback:
+        for result in results:
+            for error_message in result.errors:
+                error_callback(error_message)
 
     total_synced = sum(result.items_synced for result in results)
     logger.info("[SYNC] === Completed. Total items processed: %d ===", total_synced)

--- a/src/ingestion/sync.py
+++ b/src/ingestion/sync.py
@@ -146,7 +146,10 @@ def execute_sync(
         content_type = get_enum_value(item.content_type)
         try:
             if progress_callback:
-                progress_callback(index, result.total_items, item.title, source_name)
+                # Report ``item_num`` (1-based) so the UI shows the current
+                # item number rather than the count of completed items.
+                # Final iteration produces ``items_processed == total_items``.
+                progress_callback(item_num, result.total_items, item.title, source_name)
 
             logger.debug(
                 "[SYNC] %s: Syncing %s %d/%d - %s",
@@ -195,9 +198,18 @@ def execute_sync(
                     )
 
         except Exception as error:
-            error_message = f"Failed to process '{item.title}': {error}"
-            logger.warning("[SYNC] %s: %s", source_name, error_message)
-            result.errors.append(error_message)
+            # Don't append the raw exception to ``result.errors`` — that
+            # list is exposed via /api/sync/status and plugin exceptions
+            # can carry credential text (e.g. an HTTP 401 echoing the
+            # Authorization header). Log the full detail server-side and
+            # return only the safe item-identifying summary to clients.
+            logger.warning(
+                "[SYNC] %s: Failed to process '%s': %s",
+                source_name,
+                item.title,
+                error,
+            )
+            result.errors.append(f"Failed to process '{item.title}'")
 
     embedding_summary = ""
     if use_embeddings and embedding_generator:
@@ -272,15 +284,17 @@ def execute_multi_source_sync(
                 user_id=user_id,
             )
         except Exception as error:
-            error_message = f"Sync failed for {plugin.name}: {error}"
-            logger.error("[SYNC] %s", error_message)
+            # See sibling note in execute_sync: keep raw exception text
+            # out of result.errors. Plugin failures can include
+            # credential bytes in their messages.
+            logger.error("[SYNC] Sync failed for %s: %s", plugin.name, error)
             source_id = plugin_config.get("_source_id")
             error_source_name = (
                 humanize_source_id(source_id) if source_id else plugin.display_name
             )
             return SyncResult(
                 source_name=error_source_name,
-                errors=[error_message],
+                errors=[f"Sync failed for {plugin.name}"],
             )
 
     effective_workers = min(max_workers, len(sources)) if sources else 1

--- a/src/storage/manager.py
+++ b/src/storage/manager.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import sqlite3
+import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -104,6 +105,12 @@ class StorageManager:
         self.conflict_strategy = conflict_strategy
         self.source_priority = source_priority or []
         self._credential_key_path = self._resolve_key_path(sqlite_path)
+        # Serialises the read-conflict-write sequence in save_content_item
+        # and the encrypt-then-write sequence in save_credential. SQLite
+        # WAL allows concurrent readers but the cross-source dedup path
+        # and the credential rotation path both have a read-then-write
+        # gap that can race under parallel sync (max_workers > 1).
+        self._save_lock = threading.Lock()
 
         # Only initialize vector DB if AI is enabled and path provided.
         # Deferred import: chromadb is heavy (~500 MB+) and should not load
@@ -183,38 +190,39 @@ class StorageManager:
         Returns:
             Database ID of the saved item
         """
-        # Apply conflict resolution if item has an external ID
-        resolved_item = item
-        if item.id:
-            existing = self.get_content_item_by_external_id(
-                external_id=item.id,
-                content_type=ContentType(item.content_type),
-                user_id=user_id if user_id is not None else item.user_id,
-            )
-            if existing is not None:
-                resolved_item = resolve_conflict(
-                    existing=existing,
-                    incoming=item,
-                    strategy=self.conflict_strategy,
-                    source_priority=self.source_priority,
+        with self._save_lock:
+            # Apply conflict resolution if item has an external ID
+            resolved_item = item
+            if item.id:
+                existing = self.get_content_item_by_external_id(
+                    external_id=item.id,
+                    content_type=ContentType(item.content_type),
+                    user_id=user_id if user_id is not None else item.user_id,
                 )
+                if existing is not None:
+                    resolved_item = resolve_conflict(
+                        existing=existing,
+                        incoming=item,
+                        strategy=self.conflict_strategy,
+                        source_priority=self.source_priority,
+                    )
 
-        # Save to SQLite
-        db_id = self.sqlite_db.save_content_item(resolved_item, user_id=user_id)
+            # Save to SQLite
+            db_id = self.sqlite_db.save_content_item(resolved_item, user_id=user_id)
 
-        # Save embedding if provided and vector DB is enabled
-        if embedding is not None and self.vector_db:
-            # Use external_id if available, otherwise use db_id as string
-            content_id = item.id if item.id else f"db_{db_id}"
+            # Save embedding if provided and vector DB is enabled
+            if embedding is not None and self.vector_db:
+                # Use external_id if available, otherwise use db_id as string
+                content_id = item.id if item.id else f"db_{db_id}"
 
-            metadata = {
-                "content_type": get_enum_value(item.content_type),
-                "title": item.title,
-                "author": item.author or "",
-                "status": get_enum_value(item.status),
-                "user_id": str(user_id or item.user_id),
-            }
-            self.vector_db.add_embedding(content_id, embedding, metadata)
+                metadata = {
+                    "content_type": get_enum_value(item.content_type),
+                    "title": item.title,
+                    "author": item.author or "",
+                    "status": get_enum_value(item.status),
+                    "user_id": str(user_id or item.user_id),
+                }
+                self.vector_db.add_embedding(content_id, embedding, metadata)
 
         return db_id
 
@@ -1009,7 +1017,7 @@ class StorageManager:
             value: Plaintext value to encrypt and store.
         """
         encrypted = self._encryptor.encrypt(value)
-        with self.sqlite_db.connection() as conn:
+        with self._save_lock, self.sqlite_db.connection() as conn:
             save_credential(conn, user_id, source_id, key, encrypted)
 
     def get_credentials_for_source(

--- a/src/storage/sqlite_db.py
+++ b/src/storage/sqlite_db.py
@@ -124,6 +124,10 @@ class SQLiteDB:
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA foreign_keys = ON")
+        # Block (rather than raising SQLITE_BUSY) when another writer holds
+        # the lock — required for parallel multi-source sync where two
+        # workers may attempt BEGIN IMMEDIATE concurrently.
+        conn.execute("PRAGMA busy_timeout = 5000")
         return conn
 
     @contextmanager

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -14,7 +14,11 @@ from pydantic import BaseModel, Field
 from src import __version__ as APP_VERSION
 from src.cli.config import get_feature_flags
 from src.ingestion.plugin_base import SourcePlugin
-from src.ingestion.sync import execute_multi_source_sync
+from src.ingestion.sync import (
+    MAX_WORKERS_CEILING,
+    execute_multi_source_sync,
+    resolve_max_workers,
+)
 from src.models.content import (
     ConsumptionStatus,
     ContentItem,
@@ -95,6 +99,15 @@ class UpdateRequest(BaseModel):
     source: str = Field(
         ...,
         description="Data source (e.g. goodreads, steam, sonarr, radarr, or 'all')",
+    )
+    max_workers: int | None = Field(
+        None,
+        ge=1,
+        le=MAX_WORKERS_CEILING,
+        description=(
+            "Override config['sync']['max_workers'] for this invocation. "
+            "Mirrors the CLI's --workers flag."
+        ),
     )
 
 
@@ -188,6 +201,16 @@ class UserPreferenceResponse(BaseModel):
     theme: str = ""
 
 
+class SyncSourceProgressResponse(BaseModel):
+    """Per-source progress slot for a multi-source sync job."""
+
+    source: str
+    items_processed: int
+    total_items: int | None
+    current_item: str | None
+    progress_percent: int | None
+
+
 class SyncJobResponse(BaseModel):
     """Response model for sync job status."""
 
@@ -202,6 +225,7 @@ class SyncJobResponse(BaseModel):
     error_message: str | None
     progress_percent: int | None
     error_count: int
+    sources: list[SyncSourceProgressResponse] = []
 
 
 class SyncStatusResponse(BaseModel):
@@ -1191,6 +1215,8 @@ async def update_data(request: UpdateRequest) -> dict[str, Any]:
                 current_source=current_source,
             )
 
+        max_workers = resolve_max_workers(config, override=request.max_workers)
+
         results = execute_multi_source_sync(
             sources=source_pairs,
             storage_manager=storage,
@@ -1200,6 +1226,7 @@ async def update_data(request: UpdateRequest) -> dict[str, Any]:
             error_callback=sync_manager.add_error,
             mark_for_enrichment=auto_enrich,
             user_id=1,
+            max_workers=max_workers,
         )
         return sum(result.items_synced for result in results)
 

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -225,14 +225,15 @@ class SyncJobResponse(BaseModel):
     error_message: str | None
     progress_percent: int | None
     error_count: int
+    errors: list[str] = []
     sources: list[SyncSourceProgressResponse] = []
 
 
 class SyncStatusResponse(BaseModel):
-    """Response model for overall sync status."""
+    """Response model for the aggregate sync status across every job."""
 
     status: str
-    job: SyncJobResponse | None = None
+    jobs: list[SyncJobResponse] = []
 
 
 class UserPreferenceUpdateRequest(BaseModel):
@@ -1125,7 +1126,8 @@ async def update_data(request: UpdateRequest) -> dict[str, Any]:
     """Start a background sync job for the specified data source.
 
     The sync runs in the background. Use GET /sync/status to monitor progress.
-    Only one sync job can run at a time.
+    Multiple sources can sync concurrently — only a duplicate request for
+    the same source label (while still running) is rejected with 409.
 
     Args:
         request: Update request specifying the source to sync.
@@ -1141,19 +1143,15 @@ async def update_data(request: UpdateRequest) -> dict[str, Any]:
         raise HTTPException(status_code=500, detail="Components not initialized")
 
     sync_manager = get_sync_manager()
-
-    # Check if a sync is already running
-    if sync_manager.is_running():
-        status = sync_manager.get_status()
-        job = status.get("job", {})
-        raise HTTPException(
-            status_code=409,
-            detail=f"Sync already in progress for {job.get('source', 'unknown')}. "
-            "Please wait for it to complete.",
-        )
-
-    # Validate source configuration before starting
     source = request.source
+    source_label = humanize_source_id(source) if source != "all" else "All Sources"
+
+    # Multiple sources can sync concurrently; the duplicate check happens
+    # atomically inside ``sync_manager.start_sync`` further down. Two
+    # POSTs racing to start the same source-label would both pass any
+    # pre-check here, so don't bother with one — let start_sync's
+    # check-and-set be the single source of truth.
+
     inputs_config = config.get("inputs", {})
 
     # Resolve which sources to sync (dynamic from config)
@@ -1209,11 +1207,15 @@ async def update_data(request: UpdateRequest) -> dict[str, Any]:
             current_source: str | None,
         ) -> None:
             sync_manager.update_progress(
+                source=source_label,
                 items_processed=items_processed,
                 total_items=total_items,
                 current_item=current_item,
                 current_source=current_source,
             )
+
+        def error_callback(error_message: str) -> None:
+            sync_manager.add_error(source_label, error_message)
 
         max_workers = resolve_max_workers(config, override=request.max_workers)
 
@@ -1223,7 +1225,7 @@ async def update_data(request: UpdateRequest) -> dict[str, Any]:
             embedding_generator=embedding_gen,
             use_embeddings=use_embeddings,
             progress_callback=progress_callback,
-            error_callback=sync_manager.add_error,
+            error_callback=error_callback,
             mark_for_enrichment=auto_enrich,
             user_id=1,
             max_workers=max_workers,
@@ -1261,7 +1263,6 @@ async def update_data(request: UpdateRequest) -> dict[str, Any]:
                 logger.info("[ENRICHMENT] Auto-start skipped: %s", message)
 
     # Start background sync
-    source_label = humanize_source_id(source) if source != "all" else "All Sources"
     success, message = sync_manager.start_sync(
         source_label, run_sync, on_complete=on_sync_complete
     )
@@ -1559,22 +1560,19 @@ async def set_source_enabled_endpoint(
 
 @router.get("/sync/status", response_model=SyncStatusResponse)
 async def get_sync_status() -> SyncStatusResponse:
-    """Get current sync job status.
+    """Get the current status of every tracked sync job.
 
     Returns:
-        Current sync status including job progress if running.
+        Aggregate sync status with one entry per job in the
+        ``jobs`` list. ``status`` is ``"running"`` when at least one job
+        is still running, otherwise ``"idle"``.
     """
     sync_manager = get_sync_manager()
     status_dict = sync_manager.get_status()
 
-    job_data = status_dict.get("job")
-    job_response = None
-    if job_data:
-        job_response = SyncJobResponse(**job_data)
-
     return SyncStatusResponse(
         status=status_dict["status"],
-        job=job_response,
+        jobs=[SyncJobResponse(**job) for job in status_dict.get("jobs", [])],
     )
 
 

--- a/src/web/sync_manager.py
+++ b/src/web/sync_manager.py
@@ -25,6 +25,15 @@ class SyncStatus(str, Enum):
 
 
 @dataclass
+class _SourceProgress:
+    """Per-source progress slot for a multi-source sync job."""
+
+    items_processed: int = 0
+    total_items: int | None = None
+    current_item: str | None = None
+
+
+@dataclass
 class SyncJob:
     """Represents a sync job with its status and progress."""
 
@@ -38,9 +47,25 @@ class SyncJob:
     current_source: str | None = None  # Currently syncing source (for multi-source)
     error_message: str | None = None
     errors: list[str] = field(default_factory=list)
+    # Keyed by humanised source name so the UI can render one row per source.
+    source_progress: dict[str, _SourceProgress] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert job to dictionary for API response."""
+        sources = [
+            {
+                "source": name,
+                "items_processed": progress.items_processed,
+                "total_items": progress.total_items,
+                "current_item": progress.current_item,
+                "progress_percent": (
+                    int(progress.items_processed * 100 / progress.total_items)
+                    if progress.total_items and progress.total_items > 0
+                    else None
+                ),
+            }
+            for name, progress in sorted(self.source_progress.items())
+        ]
         return {
             "source": self.source,
             "status": self.status.value,
@@ -59,6 +84,7 @@ class SyncJob:
                 else None
             ),
             "error_count": len(self.errors),
+            "sources": sources,
         }
 
 
@@ -208,6 +234,11 @@ class SyncManager:
         """Update progress of the current job.
 
         Thread-safe method to update job progress from the sync function.
+        When ``current_source`` is provided, the per-source slot in
+        ``source_progress`` is updated and the top-level ``items_processed``
+        / ``total_items`` are recomputed as the sum across all sources.
+        When ``current_source`` is not provided, the top-level fields are
+        written directly (legacy single-source path).
 
         Args:
             items_processed: Number of items processed so far.
@@ -218,14 +249,44 @@ class SyncManager:
         with self._lock:
             if self._current_job is None:
                 return
-            if items_processed is not None:
-                self._current_job.items_processed = items_processed
-            if total_items is not None:
-                self._current_job.total_items = total_items
-            if current_item is not None:
-                self._current_job.current_item = current_item
+
             if current_source is not None:
+                slot = self._current_job.source_progress.setdefault(
+                    current_source, _SourceProgress()
+                )
+                if items_processed is not None:
+                    slot.items_processed = items_processed
+                if total_items is not None:
+                    slot.total_items = total_items
+                if current_item is not None:
+                    slot.current_item = current_item
                 self._current_job.current_source = current_source
+                # Top-level current_item is intentionally last-write-wins
+                # for the single-line "Currently syncing X" status banner;
+                # source_progress[*].current_item holds the per-source view.
+                if current_item is not None:
+                    self._current_job.current_item = current_item
+                # Recompute aggregates from the per-source map so the
+                # top-level counters reflect the sum across all sources
+                # rather than racing on the most recent worker's update.
+                self._current_job.items_processed = sum(
+                    progress.items_processed
+                    for progress in self._current_job.source_progress.values()
+                )
+                total_sum = sum(
+                    progress.total_items or 0
+                    for progress in self._current_job.source_progress.values()
+                )
+                # None until at least one source reported a known total —
+                # avoids divide-by-zero in progress_percent rendering.
+                self._current_job.total_items = total_sum if total_sum > 0 else None
+            else:
+                if items_processed is not None:
+                    self._current_job.items_processed = items_processed
+                if total_items is not None:
+                    self._current_job.total_items = total_items
+                if current_item is not None:
+                    self._current_job.current_item = current_item
 
     def add_error(self, error: str) -> None:
         """Add an error message to the current job.

--- a/src/web/sync_manager.py
+++ b/src/web/sync_manager.py
@@ -1,7 +1,9 @@
 """Background sync job manager for data source synchronization.
 
-Manages sync jobs that run in background threads, tracking status and
-preventing concurrent sync operations.
+Manages sync jobs that run in background threads. Multiple jobs can run
+concurrently as long as each is keyed by a distinct ``source`` label;
+the manager rejects a duplicate start request for a source whose job is
+still running.
 """
 
 import logging
@@ -84,6 +86,7 @@ class SyncJob:
                 else None
             ),
             "error_count": len(self.errors),
+            "errors": list(self.errors),
             "sources": sources,
         }
 
@@ -91,41 +94,53 @@ class SyncJob:
 class SyncManager:
     """Manages background sync jobs for data sources.
 
-    Only one sync job can run at a time. The manager tracks job status
-    and provides methods to start jobs and check their progress.
+    Multiple jobs can run at the same time as long as each is keyed by a
+    distinct ``source`` label. ``start_sync`` rejects a duplicate start
+    request for a source whose job is still in ``RUNNING`` state. Newer
+    completed/failed entries replace older ones for the same source so
+    ``get_status`` always reflects the latest result per source.
     """
 
+    # Cap on retained completed/failed jobs. Running jobs are never
+    # evicted (see ``_evict_history_locked``). Prevents an unauthenticated
+    # /api/update caller from growing ``_jobs`` without bound by
+    # triggering syncs with arbitrary source labels.
+    _MAX_TERMINAL_HISTORY = 50
+
     def __init__(self) -> None:
-        """Initialize the sync manager."""
         self._lock = threading.Lock()
-        self._current_job: SyncJob | None = None
-        self._thread: threading.Thread | None = None
+        self._jobs: dict[str, SyncJob] = {}
 
-    def is_running(self) -> bool:
-        """Check if a sync job is currently running.
+    def is_running(self, source: str | None = None) -> bool:
+        """Check whether a sync job is running.
 
-        Returns:
-            True if a job is running, False otherwise.
+        Args:
+            source: When provided, check only the job for this source label.
+                When omitted, return ``True`` if any job is currently running.
         """
         with self._lock:
-            return (
-                self._current_job is not None
-                and self._current_job.status == SyncStatus.RUNNING
-            )
+            if source is not None:
+                job = self._jobs.get(source)
+                return job is not None and job.status == SyncStatus.RUNNING
+            return any(job.status == SyncStatus.RUNNING for job in self._jobs.values())
 
     def get_status(self) -> dict[str, Any]:
-        """Get the current sync status.
-
-        Returns:
-            Dictionary with sync status information.
-        """
+        """Get the aggregate sync status across every tracked job."""
+        # Compute the running flag inside the lock so a concurrent
+        # ``_run_sync`` cannot transition a job between this snapshot and
+        # the status decision and make the response say "idle" while a
+        # job is still RUNNING. ``to_dict`` runs outside the lock — it
+        # reads but does not mutate, and the brief drift between snapshot
+        # and serialisation is acceptable for a polling endpoint.
         with self._lock:
-            if self._current_job is None:
-                return {"status": SyncStatus.IDLE.value, "job": None}
-            return {
-                "status": self._current_job.status.value,
-                "job": self._current_job.to_dict(),
-            }
+            jobs = list(self._jobs.values())
+            any_running = any(job.status == SyncStatus.RUNNING for job in jobs)
+        return {
+            "status": (
+                SyncStatus.RUNNING.value if any_running else SyncStatus.IDLE.value
+            ),
+            "jobs": [job.to_dict() for job in sorted(jobs, key=lambda j: j.source)],
+        }
 
     def start_sync(
         self,
@@ -133,52 +148,80 @@ class SyncManager:
         sync_function: Callable[[SyncJob], int],
         on_complete: Callable[[], None] | None = None,
     ) -> tuple[bool, str]:
-        """Start a background sync job.
+        """Start a background sync job keyed by ``source``.
+
+        A second start with the same ``source`` while the previous job is
+        still running is rejected. Different ``source`` values can run
+        concurrently.
 
         Args:
-            source: Name of the source being synced (e.g., "steam", "goodreads").
-            sync_function: Function that performs the sync. Should accept a SyncJob
-                parameter for progress updates and return the count of items processed.
-            on_complete: Optional callback to run after sync completes successfully.
+            source: Label that identifies the job (e.g. ``"Steam"`` or
+                ``"All Sources"``). Used as the dict key.
+            sync_function: Function that performs the sync. Should accept a
+                SyncJob parameter for progress updates and return the count
+                of items processed.
+            on_complete: Optional callback to run after sync completes
+                successfully.
 
         Returns:
-            Tuple of (success, message). Success is False if a job is already running.
+            Tuple of ``(success, message)``. Success is ``False`` if a job
+            for the same ``source`` is still running.
         """
         with self._lock:
-            if (
-                self._current_job is not None
-                and self._current_job.status == SyncStatus.RUNNING
-            ):
-                return False, f"Sync already in progress for {self._current_job.source}"
+            existing = self._jobs.get(source)
+            if existing is not None and existing.status == SyncStatus.RUNNING:
+                return False, f"Sync already in progress for {source}"
 
-            self._current_job = SyncJob(
+            self._jobs[source] = SyncJob(
                 source=source,
                 status=SyncStatus.RUNNING,
                 started_at=datetime.now(),
             )
+            # Eviction runs AFTER the new RUNNING job is inserted. The
+            # eviction filter excludes RUNNING jobs by status, so the
+            # freshly inserted entry cannot be the one removed even at
+            # cap. This ordering is load-bearing — moving the eviction
+            # call earlier or relaxing the RUNNING filter would risk
+            # evicting the job whose thread is about to read it.
+            self._evict_history_locked()
 
-        # Start background thread
-        self._thread = threading.Thread(
+        thread = threading.Thread(
             target=self._run_sync,
-            args=(sync_function, on_complete),
+            args=(source, sync_function, on_complete),
             daemon=True,
         )
-        self._thread.start()
+        thread.start()
 
         return True, f"Started sync for {source}"
 
+    def _evict_history_locked(self) -> None:
+        """Drop the oldest non-running jobs once history exceeds the cap.
+
+        Caller must already hold ``self._lock``.
+        """
+        terminal = [
+            (label, job)
+            for label, job in self._jobs.items()
+            if job.status != SyncStatus.RUNNING
+        ]
+        excess = len(terminal) - self._MAX_TERMINAL_HISTORY
+        if excess <= 0:
+            return
+        terminal.sort(
+            key=lambda pair: pair[1].completed_at or datetime.min,
+        )
+        for label, _ in terminal[:excess]:
+            self._jobs.pop(label, None)
+
     def _run_sync(
         self,
+        source: str,
         sync_function: Callable[[SyncJob], int],
         on_complete: Callable[[], None] | None = None,
     ) -> None:
-        """Run the sync function in a background thread.
-
-        Args:
-            sync_function: Function that performs the sync.
-            on_complete: Optional callback to run after sync completes successfully.
-        """
-        job = self._current_job
+        """Run the sync function in a background thread for ``source``."""
+        with self._lock:
+            job = self._jobs.get(source)
         if job is None:
             return
 
@@ -200,10 +243,7 @@ class SyncManager:
                 error_count = len(job.errors)
 
             if final_status == SyncStatus.COMPLETED:
-                logger.info(
-                    "Sync completed for %s: %d items processed", job.source, count
-                )
-                # Run completion callback only on true success
+                logger.info("Sync completed for %s: %d items processed", source, count)
                 if on_complete is not None:
                     try:
                         on_complete()
@@ -214,7 +254,7 @@ class SyncManager:
             else:
                 logger.warning(
                     "Sync for %s produced no items; marking failed (%d errors)",
-                    job.source,
+                    source,
                     error_count,
                 )
         except Exception:
@@ -222,81 +262,80 @@ class SyncManager:
                 job.status = SyncStatus.FAILED
                 job.completed_at = datetime.now()
                 job.error_message = "Sync failed due to an internal error"
-            logger.error("Sync failed for %s", job.source, exc_info=True)
+            logger.error("Sync failed for %s", source, exc_info=True)
 
     def update_progress(
         self,
+        source: str,
         items_processed: int | None = None,
         total_items: int | None = None,
         current_item: str | None = None,
         current_source: str | None = None,
     ) -> None:
-        """Update progress of the current job.
+        """Update progress on the job keyed by ``source``.
 
-        Thread-safe method to update job progress from the sync function.
-        When ``current_source`` is provided, the per-source slot in
-        ``source_progress`` is updated and the top-level ``items_processed``
-        / ``total_items`` are recomputed as the sum across all sources.
-        When ``current_source`` is not provided, the top-level fields are
-        written directly (legacy single-source path).
+        When ``current_source`` is provided, the per-source slot in the
+        job's ``source_progress`` map is updated and the top-level
+        ``items_processed`` / ``total_items`` are recomputed as the sum
+        across that job's sources. When ``current_source`` is not provided,
+        the top-level fields are written directly (legacy single-source
+        path).
 
         Args:
+            source: The job key (matches the ``source`` passed to
+                ``start_sync``).
             items_processed: Number of items processed so far.
             total_items: Total number of items to process.
             current_item: Name of the item currently being processed.
-            current_source: Name of the source currently being synced.
+            current_source: Name of the per-source slot within this job.
         """
         with self._lock:
-            if self._current_job is None:
+            job = self._jobs.get(source)
+            if job is None:
                 return
 
             if current_source is not None:
-                slot = self._current_job.source_progress.setdefault(
-                    current_source, _SourceProgress()
-                )
+                slot = job.source_progress.setdefault(current_source, _SourceProgress())
                 if items_processed is not None:
                     slot.items_processed = items_processed
                 if total_items is not None:
                     slot.total_items = total_items
                 if current_item is not None:
                     slot.current_item = current_item
-                self._current_job.current_source = current_source
+                job.current_source = current_source
                 # Top-level current_item is intentionally last-write-wins
-                # for the single-line "Currently syncing X" status banner;
+                # for the single-line "Currently syncing X" banner;
                 # source_progress[*].current_item holds the per-source view.
                 if current_item is not None:
-                    self._current_job.current_item = current_item
+                    job.current_item = current_item
                 # Recompute aggregates from the per-source map so the
                 # top-level counters reflect the sum across all sources
                 # rather than racing on the most recent worker's update.
-                self._current_job.items_processed = sum(
+                job.items_processed = sum(
                     progress.items_processed
-                    for progress in self._current_job.source_progress.values()
+                    for progress in job.source_progress.values()
                 )
                 total_sum = sum(
                     progress.total_items or 0
-                    for progress in self._current_job.source_progress.values()
+                    for progress in job.source_progress.values()
                 )
                 # None until at least one source reported a known total —
                 # avoids divide-by-zero in progress_percent rendering.
-                self._current_job.total_items = total_sum if total_sum > 0 else None
+                job.total_items = total_sum if total_sum > 0 else None
             else:
                 if items_processed is not None:
-                    self._current_job.items_processed = items_processed
+                    job.items_processed = items_processed
                 if total_items is not None:
-                    self._current_job.total_items = total_items
+                    job.total_items = total_items
                 if current_item is not None:
-                    self._current_job.current_item = current_item
+                    job.current_item = current_item
 
-    def add_error(self, error: str) -> None:
-        """Add an error message to the current job.
-
-        Args:
-            error: Error message to add.
-        """
+    def add_error(self, source: str, error: str) -> None:
+        """Append an error message to the job keyed by ``source``."""
         with self._lock:
-            if self._current_job is not None:
-                self._current_job.errors.append(error)
+            job = self._jobs.get(source)
+            if job is not None:
+                job.errors.append(error)
 
 
 # Global sync manager instance

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from src.cli.main import cli
+from src.ingestion.sync import SyncResult
 from src.llm.client import OllamaClient
 from src.llm.embeddings import EmbeddingGenerator
 from src.llm.recommendations import RecommendationGenerator
@@ -429,6 +430,289 @@ def test_update_command_steam_api_error(mock_components):
 
         assert result.exit_code == 0
         assert "Error" in result.output or "error" in result.output.lower()
+
+
+class TestUpdateWorkersFlag:
+    """Tests for the parallel-sync --workers flag (issue #45).
+
+    The CLI must (1) accept --workers N to override the worker pool size,
+    (2) fall back to config['sync']['max_workers'] when the flag is
+    omitted, (3) default to 4 when neither is configured, and (4) forward
+    the resolved value to execute_multi_source_sync so the underlying
+    ThreadPoolExecutor sizes correctly.
+    """
+
+    @staticmethod
+    def _config_with_sources(
+        sync_block: dict | None = None,
+    ) -> dict:
+        config: dict = {
+            "ollama": {
+                "base_url": "http://localhost:11434",
+                "model": "mistral:7b",
+                "embedding_model": "nomic-embed-text",
+            },
+            "storage": {
+                "database_path": "data/test.db",
+                "vector_db_path": "data/test_chroma",
+            },
+            "inputs": {
+                "steam": {
+                    "plugin": "steam",
+                    "api_key": "test_api_key",
+                    "steam_id": "76561198000000000",
+                    "enabled": True,
+                },
+                "goodreads": {
+                    "plugin": "goodreads",
+                    "path": "/tmp/goodreads.csv",
+                    "enabled": True,
+                },
+            },
+            "recommendations": {
+                "min_rating_for_preference": 4,
+            },
+        }
+        if sync_block is not None:
+            config["sync"] = sync_block
+        return config
+
+    def test_workers_flag_appears_in_help(self, mock_components: dict) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update", "--help"])
+
+        assert result.exit_code == 0
+        assert "--workers" in result.output
+
+    def test_workers_flag_overrides_config(self) -> None:
+        """--workers overrides config['sync']['max_workers']."""
+        config = self._config_with_sources(sync_block={"max_workers": 2})
+
+        captured: dict = {}
+
+        def fake_execute(
+            **kwargs: object,
+        ) -> list:
+            captured.update(kwargs)
+            sources_arg = kwargs.get("sources") or []
+            return [
+                SyncResult(source_name=plugin.display_name)
+                for plugin, _config in sources_arg  # type: ignore[misc]
+            ]
+
+        with (
+            patch("src.cli.main.load_config", return_value=config),
+            patch(
+                "src.cli.commands.execute_multi_source_sync",
+                side_effect=fake_execute,
+            ),
+            patch(
+                "src.ingestion.sources.steam.SteamPlugin.validate_config",
+                return_value=[],
+            ),
+            patch(
+                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                return_value=[],
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["update", "--workers", "8"])
+
+        assert result.exit_code == 0, result.output
+        assert captured["max_workers"] == 8
+
+    def test_workers_falls_back_to_config(self) -> None:
+        """Without --workers, config['sync']['max_workers'] is used."""
+        config = self._config_with_sources(sync_block={"max_workers": 6})
+
+        captured: dict = {}
+
+        def fake_execute(**kwargs: object) -> list:
+            captured.update(kwargs)
+            sources_arg = kwargs.get("sources") or []
+            return [
+                SyncResult(source_name=plugin.display_name)
+                for plugin, _config in sources_arg  # type: ignore[misc]
+            ]
+
+        with (
+            patch("src.cli.main.load_config", return_value=config),
+            patch(
+                "src.cli.commands.execute_multi_source_sync",
+                side_effect=fake_execute,
+            ),
+            patch(
+                "src.ingestion.sources.steam.SteamPlugin.validate_config",
+                return_value=[],
+            ),
+            patch(
+                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                return_value=[],
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["update"])
+
+        assert result.exit_code == 0, result.output
+        assert captured["max_workers"] == 6
+
+    def test_workers_defaults_to_four_when_unset(self) -> None:
+        """No --workers and no config => default 4."""
+        config = self._config_with_sources()  # no sync block
+
+        captured: dict = {}
+
+        def fake_execute(**kwargs: object) -> list:
+            captured.update(kwargs)
+            sources_arg = kwargs.get("sources") or []
+            return [
+                SyncResult(source_name=plugin.display_name)
+                for plugin, _config in sources_arg  # type: ignore[misc]
+            ]
+
+        with (
+            patch("src.cli.main.load_config", return_value=config),
+            patch(
+                "src.cli.commands.execute_multi_source_sync",
+                side_effect=fake_execute,
+            ),
+            patch(
+                "src.ingestion.sources.steam.SteamPlugin.validate_config",
+                return_value=[],
+            ),
+            patch(
+                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                return_value=[],
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["update"])
+
+        assert result.exit_code == 0, result.output
+        assert captured["max_workers"] == 4
+
+    def test_workers_zero_rejected_by_click(self, mock_components: dict) -> None:
+        """Click's IntRange rejects values below 1."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update", "--workers", "0"])
+
+        assert result.exit_code != 0
+        assert "Invalid value" in result.output or "out of range" in result.output
+
+    def test_workers_above_ceiling_rejected_by_click(
+        self, mock_components: dict
+    ) -> None:
+        """Click's IntRange(1,32) rejects values above 32."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update", "--workers", "33"])
+
+        assert result.exit_code != 0
+        assert "Invalid value" in result.output or "out of range" in result.output
+
+    def test_workers_one_overrides_config_to_force_sequential(self) -> None:
+        """--workers 1 overrides a parallel config to force sequential sync."""
+        config = self._config_with_sources(sync_block={"max_workers": 8})
+
+        captured: dict = {}
+
+        def fake_execute(**kwargs: object) -> list:
+            captured.update(kwargs)
+            sources_arg = kwargs.get("sources") or []
+            return [
+                SyncResult(source_name=plugin.display_name)
+                for plugin, _config in sources_arg  # type: ignore[misc]
+            ]
+
+        with (
+            patch("src.cli.main.load_config", return_value=config),
+            patch(
+                "src.cli.commands.execute_multi_source_sync",
+                side_effect=fake_execute,
+            ),
+            patch(
+                "src.ingestion.sources.steam.SteamPlugin.validate_config",
+                return_value=[],
+            ),
+            patch(
+                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                return_value=[],
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["update", "--workers", "1"])
+
+        assert result.exit_code == 0, result.output
+        assert captured["max_workers"] == 1
+
+    def test_workers_non_integer_config_falls_back_to_default(self) -> None:
+        """Non-integer config['sync']['max_workers'] falls back to 4."""
+        config = self._config_with_sources(sync_block={"max_workers": "banana"})
+
+        captured: dict = {}
+
+        def fake_execute(**kwargs: object) -> list:
+            captured.update(kwargs)
+            sources_arg = kwargs.get("sources") or []
+            return [
+                SyncResult(source_name=plugin.display_name)
+                for plugin, _config in sources_arg  # type: ignore[misc]
+            ]
+
+        with (
+            patch("src.cli.main.load_config", return_value=config),
+            patch(
+                "src.cli.commands.execute_multi_source_sync",
+                side_effect=fake_execute,
+            ),
+            patch(
+                "src.ingestion.sources.steam.SteamPlugin.validate_config",
+                return_value=[],
+            ),
+            patch(
+                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                return_value=[],
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["update"])
+
+        assert result.exit_code == 0, result.output
+        assert captured["max_workers"] == 4
+
+    def test_workers_config_above_ceiling_clamped(self) -> None:
+        """A config-driven max_workers above 32 is clamped to 32."""
+        config = self._config_with_sources(sync_block={"max_workers": 9999})
+
+        captured: dict = {}
+
+        def fake_execute(**kwargs: object) -> list:
+            captured.update(kwargs)
+            sources_arg = kwargs.get("sources") or []
+            return [
+                SyncResult(source_name=plugin.display_name)
+                for plugin, _config in sources_arg  # type: ignore[misc]
+            ]
+
+        with (
+            patch("src.cli.main.load_config", return_value=config),
+            patch(
+                "src.cli.commands.execute_multi_source_sync",
+                side_effect=fake_execute,
+            ),
+            patch(
+                "src.ingestion.sources.steam.SteamPlugin.validate_config",
+                return_value=[],
+            ),
+            patch(
+                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                return_value=[],
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["update"])
+
+        assert result.exit_code == 0, result.output
+        assert captured["max_workers"] == 32
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -429,7 +429,11 @@ def test_update_command_steam_api_error(mock_components):
         result = runner.invoke(cli, ["update", "--source", "steam"])
 
         assert result.exit_code == 0
-        assert "Error" in result.output or "error" in result.output.lower()
+        # The plugin error surfaces via the per-source warning. The raw
+        # exception message is intentionally omitted (it can carry
+        # credential bytes — see src/ingestion/sync.py).
+        assert "Sync failed for steam" in result.output
+        assert "No items were updated" in result.output
 
 
 class TestUpdateWorkersFlag:

--- a/tests/test_storage_manager.py
+++ b/tests/test_storage_manager.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
@@ -425,3 +426,114 @@ def test_chromadb_import_error_sqlite_still_works(tmp_path: Path) -> None:
     assert retrieved is not None
     assert retrieved.title == "Test Book"
     assert retrieved.content_type == ContentType.BOOK
+
+
+class TestConcurrentSaveContentItem:
+    """Thread-safety contract for parallel multi-source sync (issue #45).
+
+    Bug: when execute_multi_source_sync runs sources on multiple threads,
+    two workers can call save_content_item concurrently with overlapping
+    normalized titles. The read-conflict-write sequence is non-atomic, so
+    interleaved cross-source dedup merges could merge the same row twice
+    or lose data.
+
+    Fix: a per-StorageManager threading.Lock serialises save_content_item
+    so the dedup sequence is atomic; a SQLite busy_timeout PRAGMA blocks
+    rather than raising on writer contention.
+    """
+
+    def test_concurrent_distinct_items_all_persisted(
+        self, temp_storage_manager: StorageManager
+    ) -> None:
+        """All items saved exactly once when many threads write distinct items."""
+        item_count = 50
+        items = [
+            ContentItem(
+                id=f"ext_{i}",
+                title=f"Distinct Title {i}",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.UNREAD,
+            )
+            for i in range(item_count)
+        ]
+
+        barrier = threading.Barrier(item_count)
+        errors: list[Exception] = []
+        db_ids: list[int] = []
+        ids_lock = threading.Lock()
+
+        def save(item: ContentItem) -> None:
+            barrier.wait()
+            try:
+                db_id = temp_storage_manager.save_content_item(item)
+                with ids_lock:
+                    db_ids.append(db_id)
+            except Exception as error:
+                errors.append(error)
+
+        threads = [threading.Thread(target=save, args=(item,)) for item in items]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert errors == []
+        assert len(db_ids) == item_count
+        assert len(set(db_ids)) == item_count
+        assert temp_storage_manager.count_items() == item_count
+
+    def test_concurrent_overlapping_titles_dedupes_safely(
+        self, temp_storage_manager: StorageManager
+    ) -> None:
+        """Concurrent writes for the same normalized title produce one row, no errors.
+
+        Two sources independently importing the same book trigger the
+        cross-source dedup path inside save_content_item. The sequence
+        must not interleave to a state where both writers create rows
+        and neither merges them.
+        """
+        thread_count = 16
+        shared_title = "The Same Book"
+        items = [
+            ContentItem(
+                id=f"src_a_{i}" if i % 2 == 0 else f"src_b_{i}",
+                title=shared_title,
+                source="source_a" if i % 2 == 0 else "source_b",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.UNREAD,
+            )
+            for i in range(thread_count)
+        ]
+
+        barrier = threading.Barrier(thread_count)
+        errors: list[Exception] = []
+
+        def save(item: ContentItem) -> None:
+            barrier.wait()
+            try:
+                temp_storage_manager.save_content_item(item)
+            except Exception as error:
+                errors.append(error)
+
+        threads = [threading.Thread(target=save, args=(item,)) for item in items]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert errors == []
+        # Each unique external_id keeps its own row (dedup-by-title only
+        # merges when titles match AND no row matches the external_id).
+        # The contract is "no exceptions, no lost data", not "everything
+        # collapses to one row" — that depends on insertion order.
+        assert temp_storage_manager.count_items() <= thread_count
+        assert temp_storage_manager.count_items() >= 1
+
+    def test_busy_timeout_pragma_set_on_connections(
+        self, temp_storage_manager: StorageManager
+    ) -> None:
+        """PRAGMA busy_timeout is applied so writers block instead of raising."""
+        with temp_storage_manager.connection() as conn:
+            row = conn.execute("PRAGMA busy_timeout").fetchone()
+        assert row is not None
+        assert row[0] >= 5000

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,6 +1,7 @@
 """Tests for the shared sync executor."""
 
 import logging
+import threading
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock
@@ -8,11 +9,80 @@ from unittest.mock import MagicMock
 import pytest
 
 from src.ingestion.plugin_base import SourceError, SourcePlugin
-from src.ingestion.sync import SyncResult, execute_multi_source_sync, execute_sync
+from src.ingestion.sync import (
+    MAX_WORKERS_CEILING,
+    SyncResult,
+    execute_multi_source_sync,
+    execute_sync,
+    resolve_max_workers,
+)
 from src.llm.embeddings import EmbeddingGenerator
 from src.models.content import ContentItem
 from src.storage.manager import StorageManager
 from tests.factories import make_item
+
+
+class TestResolveMaxWorkers:
+    """Unit tests for the shared max_workers resolution helper."""
+
+    def test_override_wins_over_config(self) -> None:
+        assert resolve_max_workers({"sync": {"max_workers": 9}}, override=2) == 2
+
+    def test_override_clamps_to_floor(self) -> None:
+        # Belt-and-braces: Click's IntRange already enforces this on the
+        # CLI side, but the helper must remain safe if any future caller
+        # passes a non-Click-validated value.
+        assert resolve_max_workers({}, override=0) == 1
+        assert resolve_max_workers({}, override=-5) == 1
+
+    def test_override_clamps_to_ceiling(self) -> None:
+        assert (
+            resolve_max_workers({}, override=MAX_WORKERS_CEILING + 100)
+            == MAX_WORKERS_CEILING
+        )
+
+    def test_config_value_used_when_no_override(self) -> None:
+        assert resolve_max_workers({"sync": {"max_workers": 12}}, override=None) == 12
+
+    def test_config_value_clamped_to_ceiling(self) -> None:
+        assert (
+            resolve_max_workers({"sync": {"max_workers": 9999}}, override=None)
+            == MAX_WORKERS_CEILING
+        )
+
+    def test_config_value_clamped_to_floor(self) -> None:
+        assert resolve_max_workers({"sync": {"max_workers": 0}}, override=None) == 1
+
+    def test_default_used_when_config_missing(self) -> None:
+        assert resolve_max_workers({}, override=None, default=6) == 6
+
+    def test_default_used_when_config_is_none(self) -> None:
+        assert resolve_max_workers(None, override=None, default=4) == 4
+
+    def test_non_integer_config_falls_back_to_default(self) -> None:
+        assert (
+            resolve_max_workers(
+                {"sync": {"max_workers": "banana"}}, override=None, default=4
+            )
+            == 4
+        )
+
+    def test_none_config_value_falls_back_to_default(self) -> None:
+        assert (
+            resolve_max_workers(
+                {"sync": {"max_workers": None}}, override=None, default=4
+            )
+            == 4
+        )
+
+    def test_float_config_value_truncates(self) -> None:
+        # int(7.9) = 7. Documents the cast behaviour rather than promises.
+        assert (
+            resolve_max_workers(
+                {"sync": {"max_workers": 7.9}}, override=None, default=4
+            )
+            == 7
+        )
 
 
 class TestSyncResult:
@@ -307,8 +377,12 @@ class TestExecuteMultiSourceSync:
         assert len(results) == 2
         assert results[0].items_synced == 0
         assert len(results[0].errors) == 1
+        assert "boom" in results[0].errors[0]
         assert results[1].items_synced == 1
-        error_callback.assert_called()
+        error_callback.assert_called_once()
+        (callback_message,), _ = error_callback.call_args
+        assert "failing" in callback_message
+        assert "boom" in callback_message
 
     def test_empty_sources(self) -> None:
         """Empty source list returns empty results."""
@@ -320,6 +394,143 @@ class TestExecuteMultiSourceSync:
         )
 
         assert results == []
+
+    def test_max_workers_default_runs_sequentially(self) -> None:
+        """Default max_workers=1 keeps the legacy sequential ordering."""
+        order: list[str] = []
+
+        def fetch_a(*_args: object, **_kwargs: object) -> Iterator[ContentItem]:
+            order.append("a")
+            return iter([make_item("A1")])
+
+        def fetch_b(*_args: object, **_kwargs: object) -> Iterator[ContentItem]:
+            order.append("b")
+            return iter([make_item("B1")])
+
+        plugin_a = MagicMock(spec=SourcePlugin)
+        plugin_a.name = "source_a"
+        plugin_a.display_name = "Source A"
+        plugin_a.fetch.side_effect = fetch_a
+
+        plugin_b = MagicMock(spec=SourcePlugin)
+        plugin_b.name = "source_b"
+        plugin_b.display_name = "Source B"
+        plugin_b.fetch.side_effect = fetch_b
+
+        storage = MagicMock(spec=StorageManager)
+
+        results = execute_multi_source_sync(
+            sources=[(plugin_a, {}), (plugin_b, {})],
+            storage_manager=storage,
+        )
+
+        assert order == ["a", "b"]
+        assert [result.source_name for result in results] == ["Source A", "Source B"]
+
+    def test_max_workers_runs_sources_concurrently(self) -> None:
+        """With max_workers>1, sources fetch in parallel via a thread pool."""
+        thread_count = 3
+        barrier = threading.Barrier(thread_count, timeout=5.0)
+
+        def make_fetch(label: str) -> Any:
+            def fetch(*_args: object, **_kwargs: object) -> Iterator[ContentItem]:
+                # Each source blocks until ALL sources reach the barrier;
+                # if execution were sequential, the second/third source
+                # would never start and the barrier would time out.
+                barrier.wait()
+                return iter([make_item(f"{label}1")])
+
+            return fetch
+
+        plugins = []
+        for index in range(thread_count):
+            plugin = MagicMock(spec=SourcePlugin)
+            plugin.name = f"src_{index}"
+            plugin.display_name = f"Src {index}"
+            plugin.fetch.side_effect = make_fetch(f"src_{index}")
+            plugins.append(plugin)
+
+        storage = MagicMock(spec=StorageManager)
+
+        results = execute_multi_source_sync(
+            sources=[(plugin, {}) for plugin in plugins],
+            storage_manager=storage,
+            max_workers=thread_count,
+        )
+
+        assert len(results) == thread_count
+        # Result ordering matches input ordering even though fetches ran
+        # concurrently and may have completed in any order.
+        assert [result.source_name for result in results] == [
+            f"Src {index}" for index in range(thread_count)
+        ]
+        assert all(result.items_synced == 1 for result in results)
+
+    def test_max_workers_capped_to_source_count(self) -> None:
+        """max_workers larger than len(sources) does not spawn extra threads."""
+        plugin = MagicMock(spec=SourcePlugin)
+        plugin.name = "only"
+        plugin.display_name = "Only"
+        plugin.fetch.return_value = iter([make_item("Solo")])
+
+        storage = MagicMock(spec=StorageManager)
+
+        results = execute_multi_source_sync(
+            sources=[(plugin, {})],
+            storage_manager=storage,
+            max_workers=99,
+        )
+
+        assert len(results) == 1
+        assert results[0].items_synced == 1
+
+    def test_parallel_isolates_per_source_failures(self) -> None:
+        """A failing source under parallel execution does not break others."""
+        # Both fetches block on the same barrier so we know they ran
+        # concurrently — neither runs until both have started.
+        barrier = threading.Barrier(2, timeout=5.0)
+
+        def fetch_failing(*_args: object, **_kwargs: object) -> Iterator[ContentItem]:
+            barrier.wait()
+            raise SourceError("failing", "boom")
+
+        def fetch_ok(*_args: object, **_kwargs: object) -> Iterator[ContentItem]:
+            barrier.wait()
+            return iter([make_item("ok")])
+
+        plugin_a = MagicMock(spec=SourcePlugin)
+        plugin_a.name = "failing"
+        plugin_a.display_name = "Failing"
+        plugin_a.fetch.side_effect = fetch_failing
+
+        plugin_b = MagicMock(spec=SourcePlugin)
+        plugin_b.name = "working"
+        plugin_b.display_name = "Working"
+        plugin_b.fetch.side_effect = fetch_ok
+
+        storage = MagicMock(spec=StorageManager)
+        error_callback = MagicMock()
+
+        results = execute_multi_source_sync(
+            sources=[(plugin_a, {}), (plugin_b, {})],
+            storage_manager=storage,
+            error_callback=error_callback,
+            max_workers=2,
+        )
+
+        assert len(results) == 2
+        # Order preserved despite parallel execution
+        assert results[0].source_name == "Failing"
+        assert results[1].source_name == "Working"
+        assert results[0].items_synced == 0
+        assert len(results[0].errors) == 1
+        assert "boom" in results[0].errors[0]
+        assert results[1].items_synced == 1
+        # Exactly one error was reported, and its message is the failing one.
+        error_callback.assert_called_once()
+        (callback_message,), _ = error_callback.call_args
+        assert "failing" in callback_message
+        assert "boom" in callback_message
 
     def test_mark_for_enrichment_passed_through(self) -> None:
         """mark_for_enrichment flag is passed to execute_sync."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -245,7 +245,37 @@ class TestExecuteSync:
         assert result.items_synced == 2
         assert result.total_items == 3
         assert len(result.errors) == 1
+        # Item-identifying summary is safe to expose; raw exception text
+        # ("db error") must NOT appear because plugin exceptions can carry
+        # credential bytes.
         assert "Bad" in result.errors[0]
+        assert "db error" not in result.errors[0]
+
+    def test_progress_callback_reports_one_based_item_number(self) -> None:
+        """Progress callback emits ``index + 1`` so the final iteration
+        shows ``items_processed == total_items`` instead of N-1/N."""
+        items = [make_item(f"Item {i}") for i in range(3)]
+        plugin = MagicMock(spec=SourcePlugin)
+        plugin.display_name = "TestPlugin"
+        plugin.fetch.return_value = iter(items)
+
+        storage = MagicMock(spec=StorageManager)
+        progress = MagicMock()
+
+        execute_sync(
+            plugin=plugin,
+            plugin_config={},
+            storage_manager=storage,
+            progress_callback=progress,
+        )
+
+        # In-loop calls report (1, 3, ...), (2, 3, ...), (3, 3, ...).
+        in_loop_counts = [
+            call.args[0]
+            for call in progress.call_args_list
+            if len(call.args) >= 2 and call.args[1] == 3 and call.args[2] is not None
+        ]
+        assert in_loop_counts == [1, 2, 3]
 
     def test_progress_callback_called(self) -> None:
         """Progress callback receives updates during sync."""
@@ -377,12 +407,15 @@ class TestExecuteMultiSourceSync:
         assert len(results) == 2
         assert results[0].items_synced == 0
         assert len(results[0].errors) == 1
-        assert "boom" in results[0].errors[0]
+        # The error mentions the plugin name but NOT the raw exception
+        # message — that text might carry credentials when plugins fail.
+        assert "failing" in results[0].errors[0]
+        assert "boom" not in results[0].errors[0]
         assert results[1].items_synced == 1
         error_callback.assert_called_once()
         (callback_message,), _ = error_callback.call_args
         assert "failing" in callback_message
-        assert "boom" in callback_message
+        assert "boom" not in callback_message
 
     def test_empty_sources(self) -> None:
         """Empty source list returns empty results."""
@@ -524,13 +557,16 @@ class TestExecuteMultiSourceSync:
         assert results[1].source_name == "Working"
         assert results[0].items_synced == 0
         assert len(results[0].errors) == 1
-        assert "boom" in results[0].errors[0]
+        # The error names the plugin but does NOT carry the raw exception
+        # message — credentials in plugin exceptions must not leak into
+        # /api/sync/status.
+        assert "failing" in results[0].errors[0]
+        assert "boom" not in results[0].errors[0]
         assert results[1].items_synced == 1
-        # Exactly one error was reported, and its message is the failing one.
         error_callback.assert_called_once()
         (callback_message,), _ = error_callback.call_args
         assert "failing" in callback_message
-        assert "boom" in callback_message
+        assert "boom" not in callback_message
 
     def test_mark_for_enrichment_passed_through(self) -> None:
         """mark_for_enrichment flag is passed to execute_sync."""

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1,6 +1,8 @@
 """Tests for web API endpoints."""
 
 import json
+import threading
+from collections.abc import Callable
 from dataclasses import fields
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -8,6 +10,7 @@ from unittest.mock import Mock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from src.ingestion.sync import SyncResult
 from src.llm.client import OllamaClient
 from src.llm.embeddings import EmbeddingGenerator
 from src.llm.recommendations import RecommendationGenerator
@@ -21,7 +24,11 @@ from src.web.enrichment_manager import WebEnrichmentManager
 from src.web.epic_auth import EpicAuthError
 from src.web.gog_auth import GogAuthError
 from src.web.state import AppState, app_state
-from src.web.sync_manager import SyncManager, reset_sync_manager
+from src.web.sync_manager import (
+    SyncManager,
+    get_sync_manager,
+    reset_sync_manager,
+)
 
 
 @pytest.fixture
@@ -1615,6 +1622,162 @@ class TestUpdateEndpoint409Conflict:
             detail = response.json()["detail"]
             assert "Sync already in progress" in detail
             assert "goodreads" in detail
+
+
+class TestUpdateEndpointParallelSync:
+    """Tests for max_workers wiring in POST /api/update (issue #45).
+
+    The endpoint must read ``config['sync']['max_workers']`` and forward
+    it to ``execute_multi_source_sync`` so the underlying ThreadPoolExecutor
+    sizes correctly. ``GET /api/sync/status`` must include the per-source
+    progress map in its response so the UI can render parallel progress.
+    """
+
+    @staticmethod
+    def _make_capture(
+        captured_kwargs: dict, completion: threading.Event
+    ) -> Callable[..., list[SyncResult]]:
+        """Build a fake execute_multi_source_sync that signals completion.
+
+        The endpoint hands the real call off to a daemon thread, so the
+        test must wait for that thread to invoke the patched function
+        before asserting on captured kwargs. A ``threading.Event`` set
+        from inside the fake is deterministic — no time-budget polling.
+        """
+
+        def fake_execute(**kwargs: object) -> list:
+            try:
+                captured_kwargs.update(kwargs)
+                sources_arg = kwargs.get("sources") or []
+                return [
+                    SyncResult(source_name=plugin.display_name)
+                    for plugin, _config in sources_arg  # type: ignore[misc]
+                ]
+            finally:
+                completion.set()
+
+        return fake_execute
+
+    def test_config_max_workers_forwarded_to_executor(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """config['sync']['max_workers'] is passed to execute_multi_source_sync."""
+        app_state.config["sync"] = {"max_workers": 7}
+
+        captured_kwargs: dict = {}
+        completion = threading.Event()
+        with (
+            patch(
+                "src.web.api.execute_multi_source_sync",
+                side_effect=self._make_capture(captured_kwargs, completion),
+            ),
+            patch(
+                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                return_value=[],
+            ),
+        ):
+            response = client.post("/api/update", json={"source": "all"})
+            assert completion.wait(timeout=5.0), "background sync did not run"
+
+        assert response.status_code == 200
+        assert captured_kwargs.get("max_workers") == 7
+
+    def test_default_max_workers_is_four_when_unset(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """No config['sync'] block => max_workers defaults to 4."""
+        app_state.config.pop("sync", None)
+
+        captured_kwargs: dict = {}
+        completion = threading.Event()
+        with (
+            patch(
+                "src.web.api.execute_multi_source_sync",
+                side_effect=self._make_capture(captured_kwargs, completion),
+            ),
+            patch(
+                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                return_value=[],
+            ),
+        ):
+            response = client.post("/api/update", json={"source": "all"})
+            assert completion.wait(timeout=5.0), "background sync did not run"
+
+        assert response.status_code == 200
+        assert captured_kwargs.get("max_workers") == 4
+
+    def test_request_body_max_workers_overrides_config(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """max_workers in the POST body overrides config (CLI parity)."""
+        app_state.config["sync"] = {"max_workers": 2}
+
+        captured_kwargs: dict = {}
+        completion = threading.Event()
+        with (
+            patch(
+                "src.web.api.execute_multi_source_sync",
+                side_effect=self._make_capture(captured_kwargs, completion),
+            ),
+            patch(
+                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                return_value=[],
+            ),
+        ):
+            response = client.post(
+                "/api/update", json={"source": "all", "max_workers": 8}
+            )
+            assert completion.wait(timeout=5.0), "background sync did not run"
+
+        assert response.status_code == 200, response.text
+        assert captured_kwargs.get("max_workers") == 8
+
+    def test_request_body_max_workers_above_ceiling_rejected(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """Pydantic le=MAX_WORKERS_CEILING rejects max_workers above the ceiling."""
+        response = client.post("/api/update", json={"source": "all", "max_workers": 99})
+        assert response.status_code == 422
+
+    def test_sync_status_includes_per_source_progress(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """GET /api/sync/status emits a `sources` array with per-source progress."""
+        manager = get_sync_manager()
+        # Patch Thread so start_sync's daemon thread never runs and the
+        # planted per-source progress survives until /sync/status is hit.
+        with patch("src.web.sync_manager.threading.Thread"):
+            success, _ = manager.start_sync(source="all", sync_function=lambda _job: 0)
+        assert success
+
+        manager.update_progress(
+            items_processed=12,
+            total_items=20,
+            current_item="Book 12",
+            current_source="goodreads",
+        )
+        manager.update_progress(
+            items_processed=3,
+            total_items=10,
+            current_item="Game 3",
+            current_source="steam",
+        )
+
+        response = client.get("/api/sync/status")
+        assert response.status_code == 200
+        body = response.json()
+        sources = body["job"]["sources"]
+        # End-to-end serialisation contract: exactly the two sources we
+        # planted, sorted alphabetically (the SyncJob.to_dict guarantee).
+        assert len(sources) == 2
+        assert [entry["source"] for entry in sources] == ["goodreads", "steam"]
+        by_source = {entry["source"]: entry for entry in sources}
+        assert by_source["goodreads"]["items_processed"] == 12
+        assert by_source["goodreads"]["total_items"] == 20
+        assert by_source["goodreads"]["current_item"] == "Book 12"
+        assert by_source["goodreads"]["progress_percent"] == 60
+        assert by_source["steam"]["items_processed"] == 3
+        assert by_source["steam"]["progress_percent"] == 30
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1597,31 +1597,75 @@ class TestExportEndpoint:
 
 
 class TestUpdateEndpoint409Conflict:
-    """Tests for POST /api/update 409 Conflict when sync is already running."""
+    """POST /api/update returns 409 when the SAME source is already syncing.
 
-    def test_update_returns_409_when_sync_already_running(
+    Distinct sources can run concurrently after issue #45, so the 409
+    only fires when ``is_running(<source_label>)`` reports True.
+    """
+
+    def test_update_returns_409_when_same_source_already_running(
         self, client: TestClient, mock_components: dict
     ) -> None:
-        """POST /api/update returns 409 when a sync job is already in progress.
-
-        Bug coverage: The 409 conflict response path was untested.
-        This verifies that when the SyncManager reports a running job,
-        the endpoint returns HTTP 409 with an informative error message.
-        """
+        """409 surfaces start_sync's atomic check-and-set rejection."""
         with patch("src.web.api.get_sync_manager") as mock_get_sync_manager:
             mock_manager = Mock(spec=SyncManager)
-            mock_manager.is_running.return_value = True
-            mock_manager.get_status.return_value = {
-                "job": {"source": "goodreads"},
-            }
+            mock_manager.start_sync.return_value = (
+                False,
+                "Sync already in progress for Goodreads",
+            )
             mock_get_sync_manager.return_value = mock_manager
 
-            response = client.post("/api/update", json={"source": "steam"})
+            with patch(
+                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                return_value=[],
+            ):
+                response = client.post("/api/update", json={"source": "goodreads"})
 
             assert response.status_code == 409
             detail = response.json()["detail"]
             assert "Sync already in progress" in detail
-            assert "goodreads" in detail
+            assert "Goodreads" in detail
+            assert mock_manager.start_sync.call_args.args[0] == "Goodreads"
+
+    def test_update_allows_different_sources_concurrently(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """A second source is accepted while a different source is running.
+
+        Plants a real RUNNING job for Steam in the global SyncManager
+        before triggering a Goodreads sync. The endpoint must reject
+        only when the SAME label is running — different labels return
+        200 even with another sync still in flight.
+        """
+        # Plant a running Steam job so the manager genuinely has work in
+        # progress when the second POST lands.
+        from src.web.sync_manager import SyncJob, SyncStatus, get_sync_manager
+
+        manager = get_sync_manager()
+        with patch("src.web.sync_manager.threading.Thread"):
+            # Start Steam to keep the daemon thread out of the way; the
+            # real start_sync transition gives us a RUNNING job.
+            manager.start_sync(source="Steam", sync_function=lambda _job: 0)
+        assert manager.is_running("Steam") is True
+
+        with patch(
+            "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+            return_value=[],
+        ):
+            # Drop the captured execute_multi_source_sync into a no-op so
+            # the second sync's daemon doesn't try to actually run.
+            with patch(
+                "src.web.api.execute_multi_source_sync",
+                return_value=[SyncJob(source="Goodreads", status=SyncStatus.RUNNING)],
+            ):
+                response = client.post("/api/update", json={"source": "goodreads"})
+
+        assert response.status_code == 200, response.text
+        assert "Sync started" in response.json()["message"]
+        # Manager now tracks both jobs; the Steam one is still running
+        # and the Goodreads one was added on top.
+        assert manager.is_running("Steam") is True
+        assert "Goodreads" in {job["source"] for job in manager.get_status()["jobs"]}
 
 
 class TestUpdateEndpointParallelSync:
@@ -1742,21 +1786,25 @@ class TestUpdateEndpointParallelSync:
     def test_sync_status_includes_per_source_progress(
         self, client: TestClient, mock_components: dict
     ) -> None:
-        """GET /api/sync/status emits a `sources` array with per-source progress."""
+        """GET /api/sync/status emits a `jobs[]` array with per-source progress."""
         manager = get_sync_manager()
         # Patch Thread so start_sync's daemon thread never runs and the
         # planted per-source progress survives until /sync/status is hit.
         with patch("src.web.sync_manager.threading.Thread"):
-            success, _ = manager.start_sync(source="all", sync_function=lambda _job: 0)
+            success, _ = manager.start_sync(
+                source="All Sources", sync_function=lambda _job: 0
+            )
         assert success
 
         manager.update_progress(
+            source="All Sources",
             items_processed=12,
             total_items=20,
             current_item="Book 12",
             current_source="goodreads",
         )
         manager.update_progress(
+            source="All Sources",
             items_processed=3,
             total_items=10,
             current_item="Game 3",
@@ -1766,9 +1814,10 @@ class TestUpdateEndpointParallelSync:
         response = client.get("/api/sync/status")
         assert response.status_code == 200
         body = response.json()
-        sources = body["job"]["sources"]
-        # End-to-end serialisation contract: exactly the two sources we
-        # planted, sorted alphabetically (the SyncJob.to_dict guarantee).
+        # New shape: top-level status + jobs[] (multi-job model).
+        assert body["status"] == "running"
+        assert len(body["jobs"]) == 1
+        sources = body["jobs"][0]["sources"]
         assert len(sources) == 2
         assert [entry["source"] for entry in sources] == ["goodreads", "steam"]
         by_source = {entry["source"]: entry for entry in sources}
@@ -1778,6 +1827,45 @@ class TestUpdateEndpointParallelSync:
         assert by_source["goodreads"]["progress_percent"] == 60
         assert by_source["steam"]["items_processed"] == 3
         assert by_source["steam"]["progress_percent"] == 30
+
+    def test_sync_status_idle_response_shape(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """GET /api/sync/status with no jobs returns the empty-list shape."""
+        # Ensure no leftover jobs from earlier tests in this suite.
+        from src.web.sync_manager import reset_sync_manager
+
+        reset_sync_manager()
+
+        response = client.get("/api/sync/status")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "idle"
+        assert body["jobs"] == []
+
+    def test_sync_status_lists_multiple_concurrent_jobs(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """Two jobs keyed by different sources are both reported,
+        regardless of insertion order — proves the sort is applied."""
+        manager = get_sync_manager()
+        with patch("src.web.sync_manager.threading.Thread"):
+            # Insert in REVERSE alphabetical order so the assertion
+            # below proves sorting, not insertion order.
+            ok_steam, _ = manager.start_sync(
+                source="Steam", sync_function=lambda _job: 0
+            )
+            ok_goodreads, _ = manager.start_sync(
+                source="Goodreads", sync_function=lambda _job: 0
+            )
+        assert ok_steam and ok_goodreads
+
+        response = client.get("/api/sync/status")
+        assert response.status_code == 200
+        body = response.json()
+        sources_in_play = [job["source"] for job in body["jobs"]]
+        assert sources_in_play == ["Goodreads", "Steam"]
+        assert body["status"] == "running"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/test_sync_manager.py
+++ b/tests/web/test_sync_manager.py
@@ -1,5 +1,7 @@
 """Tests for background sync job manager."""
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -769,6 +771,203 @@ class TestSyncJobDefaults:
         assert job.current_item is None
         assert job.current_source is None
         assert job.error_message is None
+
+
+class TestSyncManagerPerSourceProgress:
+    """Per-source progress tracking for parallel multi-source sync (issue #45).
+
+    With max_workers > 1 in execute_multi_source_sync, multiple worker
+    threads call update_progress concurrently with different
+    ``current_source`` names. The single-slot current_item/current_source
+    pair raced and flickered. The fix maintains a per-source progress map
+    so each source has its own slot, the aggregate items_processed is the
+    sum across sources, and to_dict exposes a ``sources`` list.
+    """
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_per_source_slot_isolated(self, mock_thread_class: MagicMock) -> None:
+        """Two sources can have their own current_item without overwriting each other."""
+        mock_thread_class.return_value = MagicMock()
+        manager = SyncManager()
+        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
+
+        manager.update_progress(
+            items_processed=3,
+            total_items=10,
+            current_item="Book A",
+            current_source="goodreads",
+        )
+        manager.update_progress(
+            items_processed=7,
+            total_items=20,
+            current_item="Game B",
+            current_source="steam",
+        )
+
+        status = manager.get_status()
+        sources = status["job"]["sources"]
+        by_source = {entry["source"]: entry for entry in sources}
+
+        assert by_source["goodreads"]["items_processed"] == 3
+        assert by_source["goodreads"]["total_items"] == 10
+        assert by_source["goodreads"]["current_item"] == "Book A"
+        assert by_source["steam"]["items_processed"] == 7
+        assert by_source["steam"]["total_items"] == 20
+        assert by_source["steam"]["current_item"] == "Game B"
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_aggregate_items_processed_is_sum(
+        self, mock_thread_class: MagicMock
+    ) -> None:
+        """items_processed at the job level is the sum across sources."""
+        mock_thread_class.return_value = MagicMock()
+        manager = SyncManager()
+        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
+
+        manager.update_progress(items_processed=4, current_source="goodreads")
+        manager.update_progress(items_processed=11, current_source="steam")
+
+        status = manager.get_status()
+        assert status["job"]["items_processed"] == 15
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_aggregate_total_items_is_sum(self, mock_thread_class: MagicMock) -> None:
+        """total_items at the job level is the sum of per-source totals."""
+        mock_thread_class.return_value = MagicMock()
+        manager = SyncManager()
+        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
+
+        manager.update_progress(total_items=10, current_source="goodreads")
+        manager.update_progress(total_items=25, current_source="steam")
+
+        status = manager.get_status()
+        assert status["job"]["total_items"] == 35
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_progress_percent_uses_aggregate(
+        self, mock_thread_class: MagicMock
+    ) -> None:
+        """progress_percent reflects aggregate items_processed / total_items."""
+        mock_thread_class.return_value = MagicMock()
+        manager = SyncManager()
+        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
+
+        manager.update_progress(
+            items_processed=2, total_items=10, current_source="goodreads"
+        )
+        manager.update_progress(
+            items_processed=8, total_items=10, current_source="steam"
+        )
+
+        status = manager.get_status()
+        # 10 of 20 = 50%
+        assert status["job"]["progress_percent"] == 50
+
+    def test_concurrent_per_source_updates_no_loss(self) -> None:
+        """Concurrent per-source updates from many threads all land in the map.
+
+        No ``@patch`` here: the test workers run in a real thread pool and
+        patching ``threading.Thread`` would replace pool threads with
+        MagicMocks, deadlocking on the barrier.
+        """
+        manager = SyncManager()
+        # Plant a job directly so update_progress has a target without
+        # racing the spawned background thread or running through start_sync.
+        manager._current_job = SyncJob(
+            source="all", status=SyncStatus.RUNNING, started_at=datetime.now()
+        )
+
+        source_count = 8
+        items_per_source = 25
+        barrier = threading.Barrier(source_count)
+
+        def worker(source_name: str) -> None:
+            barrier.wait()
+            for index in range(items_per_source):
+                manager.update_progress(
+                    items_processed=index + 1,
+                    total_items=items_per_source,
+                    current_item=f"{source_name}_item_{index}",
+                    current_source=source_name,
+                )
+
+        # ThreadPoolExecutor's threads are unaffected by the
+        # ``src.web.sync_manager.threading.Thread`` patch (which would
+        # otherwise turn our test threads into MagicMocks because Python
+        # shares a single ``threading`` module across imports).
+        with ThreadPoolExecutor(max_workers=source_count) as pool:
+            futures = [pool.submit(worker, f"source_{i}") for i in range(source_count)]
+            for future in futures:
+                future.result()
+
+        status = manager.get_status()
+        assert len(status["job"]["sources"]) == source_count
+        # Final state: each source reached items_per_source
+        assert status["job"]["items_processed"] == source_count * items_per_source
+        assert status["job"]["total_items"] == source_count * items_per_source
+
+        # Each source's per-slot current_item must equal its own last
+        # write — proving the slots are isolated and not clobbering each
+        # other across threads.
+        by_source = {entry["source"]: entry for entry in status["job"]["sources"]}
+        for index in range(source_count):
+            source_name = f"source_{index}"
+            expected_item = f"{source_name}_item_{items_per_source - 1}"
+            assert by_source[source_name]["current_item"] == expected_item
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_legacy_update_without_current_source_still_works(
+        self, mock_thread_class: MagicMock
+    ) -> None:
+        """Updates with no current_source set top-level fields directly."""
+        mock_thread_class.return_value = MagicMock()
+        manager = SyncManager()
+        manager.start_sync(source="steam", sync_function=MagicMock(return_value=0))
+
+        manager.update_progress(items_processed=42, total_items=100)
+
+        status = manager.get_status()
+        assert status["job"]["items_processed"] == 42
+        assert status["job"]["total_items"] == 100
+        assert status["job"]["sources"] == []
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_per_source_progress_percent_over_100(
+        self, mock_thread_class: MagicMock
+    ) -> None:
+        """Per-source progress_percent reflects actual ratio, even if >100.
+
+        Some sources (e.g. paginated APIs that report a stale total) emit
+        more items than their initial total estimate. The contract is that
+        progress_percent reports what actually happened — clamping would
+        hide the discrepancy from observers.
+        """
+        mock_thread_class.return_value = MagicMock()
+        manager = SyncManager()
+        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
+
+        manager.update_progress(
+            items_processed=15, total_items=10, current_source="estimated"
+        )
+
+        status = manager.get_status()
+        sources = {entry["source"]: entry for entry in status["job"]["sources"]}
+        assert sources["estimated"]["progress_percent"] == 150
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_sources_list_is_sorted(self, mock_thread_class: MagicMock) -> None:
+        """The ``sources`` list is sorted by source name for stable UI rendering."""
+        mock_thread_class.return_value = MagicMock()
+        manager = SyncManager()
+        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
+
+        manager.update_progress(items_processed=1, current_source="zeta")
+        manager.update_progress(items_processed=1, current_source="alpha")
+        manager.update_progress(items_processed=1, current_source="middle")
+
+        status = manager.get_status()
+        names = [entry["source"] for entry in status["job"]["sources"]]
+        assert names == ["alpha", "middle", "zeta"]
 
 
 class TestSyncManagerZeroItemsWithErrorsRegression:

--- a/tests/web/test_sync_manager.py
+++ b/tests/web/test_sync_manager.py
@@ -14,18 +14,25 @@ from src.web.sync_manager import (
 )
 
 
+def _planted(manager: SyncManager, source: str = "steam") -> SyncJob:
+    """Create a job entry directly so tests can drive update_progress
+    without spawning the daemon thread that ``start_sync`` would launch.
+    """
+    job = SyncJob(source=source, status=SyncStatus.RUNNING, started_at=datetime.now())
+    manager._jobs[source] = job
+    return job
+
+
 class TestSyncStatus:
     """Tests for SyncStatus enum."""
 
     def test_status_values(self) -> None:
-        """Test that all expected status values exist."""
         assert SyncStatus.IDLE.value == "idle"
         assert SyncStatus.RUNNING.value == "running"
         assert SyncStatus.COMPLETED.value == "completed"
         assert SyncStatus.FAILED.value == "failed"
 
     def test_status_is_string_enum(self) -> None:
-        """Test that SyncStatus values are strings."""
         for status in SyncStatus:
             assert isinstance(status.value, str)
 
@@ -34,7 +41,6 @@ class TestSyncJobToDict:
     """Tests for SyncJob.to_dict() serialization."""
 
     def test_to_dict_defaults(self) -> None:
-        """Test to_dict with default field values."""
         job = SyncJob(source="steam")
 
         result = job.to_dict()
@@ -50,9 +56,10 @@ class TestSyncJobToDict:
         assert result["error_message"] is None
         assert result["progress_percent"] is None
         assert result["error_count"] == 0
+        assert result["errors"] == []
+        assert result["sources"] == []
 
     def test_to_dict_with_all_fields_populated(self) -> None:
-        """Test to_dict with all fields set."""
         started = datetime(2026, 2, 21, 10, 0, 0)
         completed = datetime(2026, 2, 21, 10, 5, 0)
         job = SyncJob(
@@ -81,731 +88,320 @@ class TestSyncJobToDict:
         assert result["error_message"] == "Some warning"
         assert result["progress_percent"] == 50
         assert result["error_count"] == 2
+        assert result["errors"] == ["Error 1", "Error 2"]
 
-    def test_to_dict_progress_percent_calculation(self) -> None:
-        """Test progress percent is calculated correctly."""
+    def test_progress_percent_calculation(self) -> None:
         job = SyncJob(source="steam", items_processed=75, total_items=200)
+        assert job.to_dict()["progress_percent"] == 37
 
-        result = job.to_dict()
-
-        assert result["progress_percent"] == 37  # int(75 * 100 / 200) = 37
-
-    def test_to_dict_progress_percent_when_total_is_zero(self) -> None:
-        """Test progress percent is None when total_items is zero."""
+    def test_progress_percent_when_total_is_zero(self) -> None:
         job = SyncJob(source="steam", items_processed=5, total_items=0)
+        assert job.to_dict()["progress_percent"] is None
 
-        result = job.to_dict()
-
-        assert result["progress_percent"] is None
-
-    def test_to_dict_progress_percent_when_total_is_none(self) -> None:
-        """Test progress percent is None when total_items is not set."""
+    def test_progress_percent_when_total_is_none(self) -> None:
         job = SyncJob(source="steam", items_processed=10)
+        assert job.to_dict()["progress_percent"] is None
 
-        result = job.to_dict()
-
-        assert result["progress_percent"] is None
-
-    def test_to_dict_progress_percent_at_100(self) -> None:
-        """Test progress percent at 100% completion."""
+    def test_progress_percent_at_100(self) -> None:
         job = SyncJob(source="steam", items_processed=50, total_items=50)
+        assert job.to_dict()["progress_percent"] == 100
 
-        result = job.to_dict()
-
-        assert result["progress_percent"] == 100
-
-    def test_to_dict_serializes_status_as_string_value(self) -> None:
-        """Test that status is serialized as its string value, not the enum."""
+    def test_status_serialised_as_string_value(self) -> None:
+        """to_dict emits ``status.value`` (a str), not the Enum instance."""
         job = SyncJob(source="steam", status=SyncStatus.RUNNING)
-
         result = job.to_dict()
-
         assert result["status"] == "running"
         assert isinstance(result["status"], str)
 
-    def test_to_dict_datetime_serialized_as_isoformat(self) -> None:
-        """Test that datetime fields are serialized as ISO format strings."""
+    def test_datetime_fields_serialised_as_isoformat(self) -> None:
         timestamp = datetime(2026, 1, 15, 14, 30, 45)
-        job = SyncJob(source="steam", started_at=timestamp)
-
+        job = SyncJob(source="steam", started_at=timestamp, completed_at=timestamp)
         result = job.to_dict()
-
         assert result["started_at"] == "2026-01-15T14:30:45"
+        assert result["completed_at"] == "2026-01-15T14:30:45"
 
 
 class TestSyncManagerStateMachine:
-    """Tests for SyncManager state transitions."""
+    """State transitions for a single tracked job."""
 
     def test_initial_state_is_not_running(self) -> None:
-        """Test that a new SyncManager reports not running."""
         manager = SyncManager()
-
         assert manager.is_running() is False
 
     @patch("src.web.sync_manager.threading.Thread")
-    def test_start_sync_transitions_to_running(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Test that start_sync transitions state to RUNNING."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+    def test_start_sync_marks_source_running(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
 
         success, message = manager.start_sync(
-            source="steam", sync_function=sync_function
+            source="steam", sync_function=MagicMock(return_value=10)
         )
 
         assert success is True
         assert "steam" in message
+        assert manager.is_running("steam") is True
         assert manager.is_running() is True
 
     @patch("src.web.sync_manager.threading.Thread")
     def test_successful_sync_transitions_to_completed(
-        self, mock_thread_class: MagicMock
+        self, mock_thread: MagicMock
     ) -> None:
-        """Test that a successful sync transitions state to COMPLETED."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
         sync_function = MagicMock(return_value=42)
 
         manager.start_sync(source="goodreads", sync_function=sync_function)
-
-        # Manually invoke _run_sync to simulate thread execution
-        manager._run_sync(sync_function)
+        manager._run_sync("goodreads", sync_function)
 
         status = manager.get_status()
-        assert status["status"] == "completed"
-        assert status["job"] is not None
-        assert status["job"]["items_processed"] == 42
+        assert status["status"] == "idle"
+        assert len(status["jobs"]) == 1
+        assert status["jobs"][0]["status"] == "completed"
+        assert status["jobs"][0]["items_processed"] == 42
 
     @patch("src.web.sync_manager.threading.Thread")
-    def test_failed_sync_transitions_to_failed(
-        self, mock_thread_class: MagicMock
+    def test_zero_items_no_errors_is_completed_not_failed(
+        self, mock_thread: MagicMock
     ) -> None:
-        """Test that a sync raising an exception transitions to FAILED."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+        """An empty source returning 0 items with no errors completes
+        cleanly; only zero-items-WITH-errors transitions to FAILED."""
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        sync_function = MagicMock(return_value=0)
+
+        manager.start_sync(source="empty", sync_function=sync_function)
+        manager._run_sync("empty", sync_function)
+
+        job = manager.get_status()["jobs"][0]
+        assert job["status"] == "completed"
+        assert job["items_processed"] == 0
+        assert job["error_count"] == 0
+        assert job["error_message"] is None
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_failed_sync_transitions_to_failed(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
         sync_function = MagicMock(side_effect=RuntimeError("Connection timeout"))
 
         manager.start_sync(source="steam", sync_function=sync_function)
-
-        # Manually invoke _run_sync to simulate thread execution
-        manager._run_sync(sync_function)
+        manager._run_sync("steam", sync_function)
 
         status = manager.get_status()
-        assert status["status"] == "failed"
-        assert status["job"] is not None
-        assert status["job"]["error_message"] == "Sync failed due to an internal error"
-        assert status["job"]["completed_at"] is not None
+        assert status["status"] == "idle"
+        job = status["jobs"][0]
+        assert job["status"] == "failed"
+        assert job["error_message"] == "Sync failed due to an internal error"
+        assert job["completed_at"] is not None
 
 
-class TestSyncManagerConcurrentPrevention:
-    """Tests for preventing concurrent sync operations."""
+class TestSyncManagerConcurrentJobs:
+    """Multiple jobs can run concurrently when keyed by distinct sources."""
 
     @patch("src.web.sync_manager.threading.Thread")
-    def test_start_sync_rejected_when_already_running(
-        self, mock_thread_class: MagicMock
+    def test_duplicate_source_rejected_while_running(
+        self, mock_thread: MagicMock
     ) -> None:
-        """Test that a second sync is rejected when one is already running."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
         sync_function = MagicMock(return_value=10)
 
-        first_success, _ = manager.start_sync(
+        first, _ = manager.start_sync(source="steam", sync_function=sync_function)
+        second, message = manager.start_sync(
             source="steam", sync_function=sync_function
         )
-        second_success, second_message = manager.start_sync(
-            source="goodreads", sync_function=sync_function
-        )
 
-        assert first_success is True
-        assert second_success is False
-        assert "already in progress" in second_message
-        assert "steam" in second_message
+        assert first is True
+        assert second is False
+        assert "already in progress" in message
+        assert "steam" in message
 
     @patch("src.web.sync_manager.threading.Thread")
-    def test_start_sync_allowed_after_previous_completes(
-        self, mock_thread_class: MagicMock
+    def test_distinct_sources_run_concurrently(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        sync_function = MagicMock(return_value=10)
+
+        first, _ = manager.start_sync(source="steam", sync_function=sync_function)
+        second, _ = manager.start_sync(source="goodreads", sync_function=sync_function)
+
+        assert first is True
+        assert second is True
+        assert manager.is_running("steam") is True
+        assert manager.is_running("goodreads") is True
+        assert manager.is_running() is True
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_restart_allowed_after_previous_completes(
+        self, mock_thread: MagicMock
     ) -> None:
-        """Test that a new sync can start after the previous one completes."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
         sync_function = MagicMock(return_value=10)
 
         manager.start_sync(source="steam", sync_function=sync_function)
-        # Simulate completion by running _run_sync directly
-        manager._run_sync(sync_function)
+        manager._run_sync("steam", sync_function)
 
-        second_success, second_message = manager.start_sync(
-            source="goodreads", sync_function=sync_function
-        )
-
-        assert second_success is True
-        assert "goodreads" in second_message
+        success, _ = manager.start_sync(source="steam", sync_function=sync_function)
+        assert success is True
 
     @patch("src.web.sync_manager.threading.Thread")
-    def test_start_sync_allowed_after_previous_fails(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Test that a new sync can start after the previous one fails."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+    def test_restart_allowed_after_previous_fails(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
-        failing_function = MagicMock(side_effect=ValueError("parse error"))
-        working_function = MagicMock(return_value=5)
+        failing = MagicMock(side_effect=ValueError("parse error"))
+        working = MagicMock(return_value=5)
 
-        manager.start_sync(source="steam", sync_function=failing_function)
-        # Simulate failure
-        manager._run_sync(failing_function)
+        manager.start_sync(source="steam", sync_function=failing)
+        manager._run_sync("steam", failing)
 
-        second_success, _ = manager.start_sync(
-            source="goodreads", sync_function=working_function
-        )
-
-        assert second_success is True
+        success, _ = manager.start_sync(source="steam", sync_function=working)
+        assert success is True
 
 
 class TestSyncManagerGetStatus:
-    """Tests for SyncManager.get_status()."""
+    """get_status() shape and contents."""
 
-    def test_get_status_when_idle(self) -> None:
-        """Test get_status returns idle when no job has been started."""
+    def test_idle_when_no_jobs(self) -> None:
         manager = SyncManager()
-
         status = manager.get_status()
-
         assert status["status"] == "idle"
-        assert status["job"] is None
+        assert status["jobs"] == []
 
     @patch("src.web.sync_manager.threading.Thread")
-    def test_get_status_when_running(self, mock_thread_class: MagicMock) -> None:
-        """Test get_status returns running job details when sync is in progress."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+    def test_running_when_any_job_running(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
-
-        manager.start_sync(source="steam", sync_function=sync_function)
+        manager.start_sync(source="steam", sync_function=MagicMock(return_value=10))
 
         status = manager.get_status()
-
         assert status["status"] == "running"
-        assert status["job"] is not None
-        assert status["job"]["source"] == "steam"
-        assert status["job"]["status"] == "running"
-        assert status["job"]["started_at"] is not None
+        assert len(status["jobs"]) == 1
+        assert status["jobs"][0]["source"] == "steam"
 
     @patch("src.web.sync_manager.threading.Thread")
-    def test_get_status_when_completed(self, mock_thread_class: MagicMock) -> None:
-        """Test get_status returns completed job details after sync finishes."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+    def test_idle_when_all_jobs_completed(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
         sync_function = MagicMock(return_value=25)
 
         manager.start_sync(source="goodreads", sync_function=sync_function)
-        manager._run_sync(sync_function)
+        manager._run_sync("goodreads", sync_function)
 
         status = manager.get_status()
-
-        assert status["status"] == "completed"
-        assert status["job"]["items_processed"] == 25
-        assert status["job"]["completed_at"] is not None
+        assert status["status"] == "idle"
+        assert status["jobs"][0]["items_processed"] == 25
+        assert status["jobs"][0]["completed_at"] is not None
 
     @patch("src.web.sync_manager.threading.Thread")
-    def test_get_status_when_failed(self, mock_thread_class: MagicMock) -> None:
-        """Test get_status returns failure details after sync fails."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+    def test_jobs_sorted_by_source(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
-        sync_function = MagicMock(side_effect=Exception("network error"))
+        sync_function = MagicMock(return_value=0)
 
-        manager.start_sync(source="steam", sync_function=sync_function)
-        manager._run_sync(sync_function)
+        manager.start_sync(source="zeta", sync_function=sync_function)
+        manager.start_sync(source="alpha", sync_function=sync_function)
+        manager.start_sync(source="middle", sync_function=sync_function)
 
-        status = manager.get_status()
-
-        assert status["status"] == "failed"
-        assert status["job"]["error_message"] is not None
+        names = [j["source"] for j in manager.get_status()["jobs"]]
+        assert names == ["alpha", "middle", "zeta"]
 
 
 class TestSyncManagerUpdateProgress:
-    """Tests for SyncManager.update_progress() thread-safe updates."""
+    """update_progress writes to the job keyed by ``source``."""
 
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_update_items_processed(self, mock_thread_class: MagicMock) -> None:
-        """Test updating items_processed field."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+    def test_update_items_processed(self) -> None:
         manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
+        _planted(manager, "steam")
 
-        manager.start_sync(source="steam", sync_function=sync_function)
-        manager.update_progress(items_processed=15)
+        manager.update_progress(source="steam", items_processed=15)
 
-        status = manager.get_status()
-        assert status["job"]["items_processed"] == 15
+        assert manager.get_status()["jobs"][0]["items_processed"] == 15
 
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_update_total_items(self, mock_thread_class: MagicMock) -> None:
-        """Test updating total_items field."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+    def test_update_total_items(self) -> None:
         manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
+        _planted(manager, "steam")
 
-        manager.start_sync(source="steam", sync_function=sync_function)
-        manager.update_progress(total_items=200)
+        manager.update_progress(source="steam", total_items=200)
 
-        status = manager.get_status()
-        assert status["job"]["total_items"] == 200
+        assert manager.get_status()["jobs"][0]["total_items"] == 200
 
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_update_current_item(self, mock_thread_class: MagicMock) -> None:
-        """Test updating current_item field."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+    def test_update_current_item(self) -> None:
         manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
+        _planted(manager, "goodreads")
 
-        manager.start_sync(source="goodreads", sync_function=sync_function)
-        manager.update_progress(current_item="The Way of Kings")
+        manager.update_progress(source="goodreads", current_item="The Way of Kings")
 
-        status = manager.get_status()
-        assert status["job"]["current_item"] == "The Way of Kings"
+        assert manager.get_status()["jobs"][0]["current_item"] == "The Way of Kings"
 
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_update_current_source(self, mock_thread_class: MagicMock) -> None:
-        """Test updating current_source field."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+    def test_update_current_source(self) -> None:
         manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
+        _planted(manager, "all")
 
-        manager.start_sync(source="all", sync_function=sync_function)
-        manager.update_progress(current_source="steam")
+        manager.update_progress(source="all", current_source="steam")
 
-        status = manager.get_status()
-        assert status["job"]["current_source"] == "steam"
+        assert manager.get_status()["jobs"][0]["current_source"] == "steam"
 
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_update_multiple_fields_at_once(self, mock_thread_class: MagicMock) -> None:
-        """Test updating multiple progress fields in a single call."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+    def test_update_multiple_fields_at_once(self) -> None:
         manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
+        _planted(manager, "all")
 
-        manager.start_sync(source="all", sync_function=sync_function)
         manager.update_progress(
+            source="all",
             items_processed=30,
             total_items=100,
             current_item="Portal 2",
             current_source="steam",
         )
 
-        status = manager.get_status()
-        assert status["job"]["items_processed"] == 30
-        assert status["job"]["total_items"] == 100
-        assert status["job"]["current_item"] == "Portal 2"
-        assert status["job"]["current_source"] == "steam"
+        job = manager.get_status()["jobs"][0]
+        assert job["items_processed"] == 30
+        assert job["total_items"] == 100
+        assert job["current_item"] == "Portal 2"
+        assert job["current_source"] == "steam"
 
     def test_update_progress_when_no_job(self) -> None:
-        """Test that update_progress is a no-op when no job exists."""
         manager = SyncManager()
+        manager.update_progress(source="steam", items_processed=10)
+        assert manager.get_status()["jobs"] == []
 
-        # Should not raise any exception
-        manager.update_progress(items_processed=10)
-
-        status = manager.get_status()
-        assert status["job"] is None
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_update_only_specified_fields(self, mock_thread_class: MagicMock) -> None:
-        """Test that only specified fields are updated, others remain unchanged."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
+    def test_only_specified_fields_overwrite(self) -> None:
         manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
+        _planted(manager, "steam")
 
-        manager.start_sync(source="steam", sync_function=sync_function)
-        manager.update_progress(items_processed=5, current_item="Game A")
-        manager.update_progress(items_processed=10)
-
-        status = manager.get_status()
-        # items_processed should be updated to 10
-        assert status["job"]["items_processed"] == 10
-        # current_item should remain as "Game A" (not reset to None)
-        assert status["job"]["current_item"] == "Game A"
-
-
-class TestSyncManagerAddError:
-    """Tests for SyncManager.add_error() error collection."""
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_add_single_error(self, mock_thread_class: MagicMock) -> None:
-        """Test adding a single error to the current job."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
-
-        manager.start_sync(source="steam", sync_function=sync_function)
-        manager.add_error("Failed to fetch game: Portal 2")
-
-        status = manager.get_status()
-        assert status["job"]["error_count"] == 1
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_add_multiple_errors(self, mock_thread_class: MagicMock) -> None:
-        """Test adding multiple errors to the current job."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
-
-        manager.start_sync(source="steam", sync_function=sync_function)
-        manager.add_error("Failed to fetch game: Portal 2")
-        manager.add_error("Rate limit exceeded")
-        manager.add_error("Invalid response for game: Half-Life")
-
-        status = manager.get_status()
-        assert status["job"]["error_count"] == 3
-
-    def test_add_error_when_no_job(self) -> None:
-        """Test that add_error is a no-op when no job exists."""
-        manager = SyncManager()
-
-        # Should not raise any exception
-        manager.add_error("Some error")
-
-        status = manager.get_status()
-        assert status["job"] is None
-
-
-class TestSyncManagerOnCompleteCallback:
-    """Tests for on_complete callback invocation."""
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_on_complete_called_on_success(self, mock_thread_class: MagicMock) -> None:
-        """Test that on_complete callback is called when sync succeeds."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
-        on_complete = MagicMock()
-
-        manager.start_sync(
-            source="steam",
-            sync_function=sync_function,
-            on_complete=on_complete,
+        manager.update_progress(
+            source="steam", items_processed=5, current_item="Game A"
         )
-        manager._run_sync(sync_function, on_complete=on_complete)
+        manager.update_progress(source="steam", items_processed=10)
 
-        on_complete.assert_called_once()
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_on_complete_not_called_on_failure(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Test that on_complete callback is not called when sync fails."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(side_effect=RuntimeError("sync error"))
-        on_complete = MagicMock()
-
-        manager.start_sync(
-            source="steam",
-            sync_function=sync_function,
-            on_complete=on_complete,
-        )
-        manager._run_sync(sync_function, on_complete=on_complete)
-
-        on_complete.assert_not_called()
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_on_complete_failure_does_not_affect_job_status(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Test that a failing on_complete callback does not change job status to FAILED."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
-        on_complete = MagicMock(side_effect=RuntimeError("callback error"))
-
-        manager.start_sync(
-            source="steam",
-            sync_function=sync_function,
-            on_complete=on_complete,
-        )
-        manager._run_sync(sync_function, on_complete=on_complete)
-
-        status = manager.get_status()
-        # Job should still be COMPLETED even though callback failed
-        assert status["status"] == "completed"
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_sync_without_on_complete(self, mock_thread_class: MagicMock) -> None:
-        """Test that sync works fine without an on_complete callback."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
-
-        manager.start_sync(source="steam", sync_function=sync_function)
-        manager._run_sync(sync_function, on_complete=None)
-
-        status = manager.get_status()
-        assert status["status"] == "completed"
-
-
-class TestSyncManagerRunSync:
-    """Tests for _run_sync internal method behavior."""
-
-    def test_run_sync_when_no_current_job(self) -> None:
-        """Test that _run_sync returns early when no current job exists."""
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
-
-        # Should not raise an exception
-        manager._run_sync(sync_function)
-
-        sync_function.assert_not_called()
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_run_sync_sets_completed_at_timestamp(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Test that completed_at is set when sync finishes."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=5)
-
-        manager.start_sync(source="steam", sync_function=sync_function)
-        manager._run_sync(sync_function)
-
-        status = manager.get_status()
-        assert status["job"]["completed_at"] is not None
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_run_sync_sets_completed_at_on_failure(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Test that completed_at is set even when sync fails."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(side_effect=Exception("failure"))
-
-        manager.start_sync(source="steam", sync_function=sync_function)
-        manager._run_sync(sync_function)
-
-        status = manager.get_status()
-        assert status["job"]["completed_at"] is not None
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_run_sync_passes_job_to_sync_function(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Test that _run_sync passes the current SyncJob to the sync function."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
-
-        manager.start_sync(source="steam", sync_function=sync_function)
-        manager._run_sync(sync_function)
-
-        sync_function.assert_called_once()
-        passed_job = sync_function.call_args[0][0]
-        assert isinstance(passed_job, SyncJob)
-        assert passed_job.source == "steam"
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_run_sync_updates_items_processed_from_return_value(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Test that the return value of sync_function sets items_processed."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=99)
-
-        manager.start_sync(source="steam", sync_function=sync_function)
-        manager._run_sync(sync_function)
-
-        status = manager.get_status()
-        assert status["job"]["items_processed"] == 99
-
-
-class TestSyncManagerThreadCreation:
-    """Tests for thread creation in start_sync."""
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_start_sync_creates_daemon_thread(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Test that start_sync creates a daemon thread."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
-
-        manager.start_sync(source="steam", sync_function=sync_function)
-
-        mock_thread_class.assert_called_once()
-        call_kwargs = mock_thread_class.call_args
-        assert call_kwargs.kwargs["daemon"] is True
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_start_sync_starts_thread(self, mock_thread_class: MagicMock) -> None:
-        """Test that start_sync calls thread.start()."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
-
-        manager.start_sync(source="steam", sync_function=sync_function)
-
-        mock_thread_instance.start.assert_called_once()
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_start_sync_thread_target_is_run_sync(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Test that the thread target is _run_sync."""
-        mock_thread_instance = MagicMock()
-        mock_thread_class.return_value = mock_thread_instance
-        manager = SyncManager()
-        sync_function = MagicMock(return_value=10)
-
-        manager.start_sync(source="steam", sync_function=sync_function)
-
-        call_kwargs = mock_thread_class.call_args
-        assert call_kwargs.kwargs["target"] == manager._run_sync
-
-
-class TestSingletonGetterAndReset:
-    """Tests for get_sync_manager() and reset_sync_manager() functions."""
-
-    def setup_method(self) -> None:
-        """Reset global state before each test."""
-        reset_sync_manager()
-
-    def teardown_method(self) -> None:
-        """Reset global state after each test."""
-        reset_sync_manager()
-
-    def test_get_sync_manager_returns_sync_manager_instance(self) -> None:
-        """Test that get_sync_manager returns a SyncManager."""
-        manager = get_sync_manager()
-
-        assert isinstance(manager, SyncManager)
-
-    def test_get_sync_manager_returns_same_instance(self) -> None:
-        """Test that get_sync_manager returns the same instance on multiple calls."""
-        first = get_sync_manager()
-        second = get_sync_manager()
-
-        assert first is second
-
-    def test_reset_sync_manager_clears_instance(self) -> None:
-        """Test that reset_sync_manager causes next call to return a new instance."""
-        first = get_sync_manager()
-        reset_sync_manager()
-        second = get_sync_manager()
-
-        assert first is not second
-
-    def test_reset_sync_manager_is_safe_when_no_instance(self) -> None:
-        """Test that reset_sync_manager does not raise when no instance exists."""
-        reset_sync_manager()  # Already reset in setup
-        reset_sync_manager()  # Should not raise
-
-
-class TestSyncJobDefaults:
-    """Tests for SyncJob default field values."""
-
-    def test_default_status_is_idle(self) -> None:
-        """Test that default status is IDLE."""
-        job = SyncJob(source="test")
-
-        assert job.status == SyncStatus.IDLE
-
-    def test_default_errors_list_is_empty(self) -> None:
-        """Test that default errors list is empty."""
-        job = SyncJob(source="test")
-
-        assert job.errors == []
-
-    def test_errors_list_is_not_shared_between_instances(self) -> None:
-        """Test that each SyncJob gets its own errors list."""
-        job_a = SyncJob(source="a")
-        job_b = SyncJob(source="b")
-
-        job_a.errors.append("error in a")
-
-        assert len(job_b.errors) == 0
-
-    def test_default_items_processed_is_zero(self) -> None:
-        """Test that default items_processed is zero."""
-        job = SyncJob(source="test")
-
-        assert job.items_processed == 0
-
-    def test_default_optional_fields_are_none(self) -> None:
-        """Test that optional datetime and string fields default to None."""
-        job = SyncJob(source="test")
-
-        assert job.started_at is None
-        assert job.completed_at is None
-        assert job.total_items is None
-        assert job.current_item is None
-        assert job.current_source is None
-        assert job.error_message is None
+        job = manager.get_status()["jobs"][0]
+        assert job["items_processed"] == 10
+        assert job["current_item"] == "Game A"
 
 
 class TestSyncManagerPerSourceProgress:
-    """Per-source progress tracking for parallel multi-source sync (issue #45).
+    """Per-source progress tracking inside one job (issue #45)."""
 
-    With max_workers > 1 in execute_multi_source_sync, multiple worker
-    threads call update_progress concurrently with different
-    ``current_source`` names. The single-slot current_item/current_source
-    pair raced and flickered. The fix maintains a per-source progress map
-    so each source has its own slot, the aggregate items_processed is the
-    sum across sources, and to_dict exposes a ``sources`` list.
-    """
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_per_source_slot_isolated(self, mock_thread_class: MagicMock) -> None:
-        """Two sources can have their own current_item without overwriting each other."""
-        mock_thread_class.return_value = MagicMock()
+    def test_per_source_slot_isolated(self) -> None:
         manager = SyncManager()
-        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
+        _planted(manager, "all")
 
         manager.update_progress(
+            source="all",
             items_processed=3,
             total_items=10,
             current_item="Book A",
             current_source="goodreads",
         )
         manager.update_progress(
+            source="all",
             items_processed=7,
             total_items=20,
             current_item="Game B",
             current_source="steam",
         )
 
-        status = manager.get_status()
-        sources = status["job"]["sources"]
+        sources = manager.get_status()["jobs"][0]["sources"]
         by_source = {entry["source"]: entry for entry in sources}
 
         assert by_source["goodreads"]["items_processed"] == 3
@@ -815,67 +411,71 @@ class TestSyncManagerPerSourceProgress:
         assert by_source["steam"]["total_items"] == 20
         assert by_source["steam"]["current_item"] == "Game B"
 
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_aggregate_items_processed_is_sum(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """items_processed at the job level is the sum across sources."""
-        mock_thread_class.return_value = MagicMock()
+    def test_aggregate_items_processed_is_sum(self) -> None:
         manager = SyncManager()
-        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
-
-        manager.update_progress(items_processed=4, current_source="goodreads")
-        manager.update_progress(items_processed=11, current_source="steam")
-
-        status = manager.get_status()
-        assert status["job"]["items_processed"] == 15
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_aggregate_total_items_is_sum(self, mock_thread_class: MagicMock) -> None:
-        """total_items at the job level is the sum of per-source totals."""
-        mock_thread_class.return_value = MagicMock()
-        manager = SyncManager()
-        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
-
-        manager.update_progress(total_items=10, current_source="goodreads")
-        manager.update_progress(total_items=25, current_source="steam")
-
-        status = manager.get_status()
-        assert status["job"]["total_items"] == 35
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_progress_percent_uses_aggregate(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """progress_percent reflects aggregate items_processed / total_items."""
-        mock_thread_class.return_value = MagicMock()
-        manager = SyncManager()
-        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
+        _planted(manager, "all")
 
         manager.update_progress(
-            items_processed=2, total_items=10, current_source="goodreads"
+            source="all", items_processed=4, current_source="goodreads"
         )
         manager.update_progress(
-            items_processed=8, total_items=10, current_source="steam"
+            source="all", items_processed=11, current_source="steam"
         )
 
-        status = manager.get_status()
-        # 10 of 20 = 50%
-        assert status["job"]["progress_percent"] == 50
+        assert manager.get_status()["jobs"][0]["items_processed"] == 15
+
+    def test_aggregate_total_items_is_sum(self) -> None:
+        manager = SyncManager()
+        _planted(manager, "all")
+
+        manager.update_progress(
+            source="all", total_items=10, current_source="goodreads"
+        )
+        manager.update_progress(source="all", total_items=25, current_source="steam")
+
+        assert manager.get_status()["jobs"][0]["total_items"] == 35
+
+    def test_progress_percent_uses_aggregate(self) -> None:
+        manager = SyncManager()
+        _planted(manager, "all")
+
+        manager.update_progress(
+            source="all",
+            items_processed=2,
+            total_items=10,
+            current_source="goodreads",
+        )
+        manager.update_progress(
+            source="all",
+            items_processed=8,
+            total_items=10,
+            current_source="steam",
+        )
+
+        assert manager.get_status()["jobs"][0]["progress_percent"] == 50
+
+    def test_per_source_progress_percent_over_100(self) -> None:
+        """Per-source progress_percent is not clamped — over-100 is honest."""
+        manager = SyncManager()
+        _planted(manager, "all")
+
+        manager.update_progress(
+            source="all",
+            items_processed=15,
+            total_items=10,
+            current_source="estimated",
+        )
+
+        sources = {
+            entry["source"]: entry
+            for entry in manager.get_status()["jobs"][0]["sources"]
+        }
+        assert sources["estimated"]["progress_percent"] == 150
 
     def test_concurrent_per_source_updates_no_loss(self) -> None:
-        """Concurrent per-source updates from many threads all land in the map.
-
-        No ``@patch`` here: the test workers run in a real thread pool and
-        patching ``threading.Thread`` would replace pool threads with
-        MagicMocks, deadlocking on the barrier.
-        """
+        """Concurrent updates from many threads all land in the slot map."""
         manager = SyncManager()
-        # Plant a job directly so update_progress has a target without
-        # racing the spawned background thread or running through start_sync.
-        manager._current_job = SyncJob(
-            source="all", status=SyncStatus.RUNNING, started_at=datetime.now()
-        )
+        _planted(manager, "all")
 
         source_count = 8
         items_per_source = 25
@@ -885,158 +485,482 @@ class TestSyncManagerPerSourceProgress:
             barrier.wait()
             for index in range(items_per_source):
                 manager.update_progress(
+                    source="all",
                     items_processed=index + 1,
                     total_items=items_per_source,
                     current_item=f"{source_name}_item_{index}",
                     current_source=source_name,
                 )
 
-        # ThreadPoolExecutor's threads are unaffected by the
-        # ``src.web.sync_manager.threading.Thread`` patch (which would
-        # otherwise turn our test threads into MagicMocks because Python
-        # shares a single ``threading`` module across imports).
+        # ThreadPoolExecutor's threads bypass any patches to threading.Thread,
+        # which would otherwise replace pool threads with MagicMocks and
+        # deadlock the barrier.
         with ThreadPoolExecutor(max_workers=source_count) as pool:
             futures = [pool.submit(worker, f"source_{i}") for i in range(source_count)]
             for future in futures:
                 future.result()
 
-        status = manager.get_status()
-        assert len(status["job"]["sources"]) == source_count
-        # Final state: each source reached items_per_source
-        assert status["job"]["items_processed"] == source_count * items_per_source
-        assert status["job"]["total_items"] == source_count * items_per_source
-
-        # Each source's per-slot current_item must equal its own last
-        # write — proving the slots are isolated and not clobbering each
-        # other across threads.
-        by_source = {entry["source"]: entry for entry in status["job"]["sources"]}
+        job = manager.get_status()["jobs"][0]
+        assert len(job["sources"]) == source_count
+        assert job["items_processed"] == source_count * items_per_source
+        assert job["total_items"] == source_count * items_per_source
+        by_source = {entry["source"]: entry for entry in job["sources"]}
         for index in range(source_count):
             source_name = f"source_{index}"
-            expected_item = f"{source_name}_item_{items_per_source - 1}"
-            assert by_source[source_name]["current_item"] == expected_item
+            expected = f"{source_name}_item_{items_per_source - 1}"
+            assert by_source[source_name]["current_item"] == expected
 
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_legacy_update_without_current_source_still_works(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Updates with no current_source set top-level fields directly."""
-        mock_thread_class.return_value = MagicMock()
+    def test_legacy_update_without_current_source_writes_top_level(self) -> None:
+        """Updates with no ``current_source`` set top-level fields directly."""
         manager = SyncManager()
-        manager.start_sync(source="steam", sync_function=MagicMock(return_value=0))
+        _planted(manager, "steam")
 
-        manager.update_progress(items_processed=42, total_items=100)
+        manager.update_progress(source="steam", items_processed=42, total_items=100)
 
-        status = manager.get_status()
-        assert status["job"]["items_processed"] == 42
-        assert status["job"]["total_items"] == 100
-        assert status["job"]["sources"] == []
+        job = manager.get_status()["jobs"][0]
+        assert job["items_processed"] == 42
+        assert job["total_items"] == 100
+        assert job["sources"] == []
 
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_per_source_progress_percent_over_100(
-        self, mock_thread_class: MagicMock
-    ) -> None:
-        """Per-source progress_percent reflects actual ratio, even if >100.
-
-        Some sources (e.g. paginated APIs that report a stale total) emit
-        more items than their initial total estimate. The contract is that
-        progress_percent reports what actually happened — clamping would
-        hide the discrepancy from observers.
-        """
-        mock_thread_class.return_value = MagicMock()
+    def test_per_source_slots_sorted_by_name(self) -> None:
         manager = SyncManager()
-        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
+        _planted(manager, "all")
 
+        manager.update_progress(source="all", items_processed=1, current_source="zeta")
+        manager.update_progress(source="all", items_processed=1, current_source="alpha")
         manager.update_progress(
-            items_processed=15, total_items=10, current_source="estimated"
+            source="all", items_processed=1, current_source="middle"
         )
 
-        status = manager.get_status()
-        sources = {entry["source"]: entry for entry in status["job"]["sources"]}
-        assert sources["estimated"]["progress_percent"] == 150
-
-    @patch("src.web.sync_manager.threading.Thread")
-    def test_sources_list_is_sorted(self, mock_thread_class: MagicMock) -> None:
-        """The ``sources`` list is sorted by source name for stable UI rendering."""
-        mock_thread_class.return_value = MagicMock()
-        manager = SyncManager()
-        manager.start_sync(source="all", sync_function=MagicMock(return_value=0))
-
-        manager.update_progress(items_processed=1, current_source="zeta")
-        manager.update_progress(items_processed=1, current_source="alpha")
-        manager.update_progress(items_processed=1, current_source="middle")
-
-        status = manager.get_status()
-        names = [entry["source"] for entry in status["job"]["sources"]]
+        names = [
+            entry["source"] for entry in manager.get_status()["jobs"][0]["sources"]
+        ]
         assert names == ["alpha", "middle", "zeta"]
 
 
-class TestSyncManagerZeroItemsWithErrorsRegression:
-    """Regression tests for sync status when a plugin catches all errors.
+class TestSyncManagerAddError:
+    """add_error appends to the job keyed by ``source``."""
 
-    Bug: plugins like the Epic Games source catch their own exceptions and
-    report them via the sync manager's add_error callback, then return 0.
-    _run_sync used to mark the job COMPLETED, so the UI rendered a green
-    "Completed: 0 items synced (1 errors)" banner for what was clearly a
-    failed sync. Fix: when zero items were produced and errors
-    accumulated, surface the sync as FAILED so the UI renders the correct
-    error banner, seed error_message from the first recorded error, and
-    skip the on_complete callback so downstream enrichment isn't kicked
-    off for a failed sync.
-    """
+    def test_add_single_error(self) -> None:
+        manager = SyncManager()
+        _planted(manager, "steam")
+
+        manager.add_error("steam", "Failed to fetch game: Portal 2")
+
+        job = manager.get_status()["jobs"][0]
+        assert job["error_count"] == 1
+        assert job["errors"] == ["Failed to fetch game: Portal 2"]
+
+    def test_add_multiple_errors(self) -> None:
+        manager = SyncManager()
+        _planted(manager, "steam")
+
+        manager.add_error("steam", "Failed to fetch game: Portal 2")
+        manager.add_error("steam", "Rate limit exceeded")
+        manager.add_error("steam", "Invalid response for game: Half-Life")
+
+        job = manager.get_status()["jobs"][0]
+        assert job["error_count"] == 3
+        assert "Rate limit exceeded" in job["errors"]
+
+    def test_add_error_when_no_job(self) -> None:
+        manager = SyncManager()
+        manager.add_error("steam", "Some error")
+        assert manager.get_status()["jobs"] == []
+
+    def test_errors_are_per_job(self) -> None:
+        manager = SyncManager()
+        _planted(manager, "steam")
+        _planted(manager, "goodreads")
+
+        manager.add_error("steam", "Steam error")
+        manager.add_error("goodreads", "Goodreads error")
+
+        jobs = {j["source"]: j for j in manager.get_status()["jobs"]}
+        assert jobs["steam"]["errors"] == ["Steam error"]
+        assert jobs["goodreads"]["errors"] == ["Goodreads error"]
+
+
+class TestSyncManagerOnCompleteCallback:
+    """on_complete fires only on successful syncs."""
 
     @patch("src.web.sync_manager.threading.Thread")
-    def test_zero_items_with_errors_marks_failed(
-        self, mock_thread_class: MagicMock
+    def test_on_complete_called_on_success(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        sync_function = MagicMock(return_value=10)
+        on_complete = MagicMock()
+
+        manager.start_sync(
+            source="steam", sync_function=sync_function, on_complete=on_complete
+        )
+        manager._run_sync("steam", sync_function, on_complete=on_complete)
+
+        on_complete.assert_called_once()
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_on_complete_not_called_on_failure(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        sync_function = MagicMock(side_effect=RuntimeError("sync error"))
+        on_complete = MagicMock()
+
+        manager.start_sync(
+            source="steam", sync_function=sync_function, on_complete=on_complete
+        )
+        manager._run_sync("steam", sync_function, on_complete=on_complete)
+
+        on_complete.assert_not_called()
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_on_complete_failure_does_not_change_job_status(
+        self, mock_thread: MagicMock
     ) -> None:
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        sync_function = MagicMock(return_value=10)
+        on_complete = MagicMock(side_effect=RuntimeError("callback error"))
+
+        manager.start_sync(
+            source="steam", sync_function=sync_function, on_complete=on_complete
+        )
+        manager._run_sync("steam", sync_function, on_complete=on_complete)
+
+        assert manager.get_status()["jobs"][0]["status"] == "completed"
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_sync_without_on_complete(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        sync_function = MagicMock(return_value=10)
+
+        manager.start_sync(source="steam", sync_function=sync_function)
+        manager._run_sync("steam", sync_function, on_complete=None)
+
+        assert manager.get_status()["jobs"][0]["status"] == "completed"
+
+
+class TestSyncManagerRunSync:
+    """_run_sync internal behaviour."""
+
+    def test_returns_early_when_no_job(self) -> None:
+        manager = SyncManager()
+        sync_function = MagicMock(return_value=10)
+
+        manager._run_sync("steam", sync_function)
+
+        sync_function.assert_not_called()
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_sets_completed_at_on_success(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        sync_function = MagicMock(return_value=5)
+
+        manager.start_sync(source="steam", sync_function=sync_function)
+        manager._run_sync("steam", sync_function)
+
+        assert manager.get_status()["jobs"][0]["completed_at"] is not None
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_sets_completed_at_on_failure(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        sync_function = MagicMock(side_effect=Exception("failure"))
+
+        manager.start_sync(source="steam", sync_function=sync_function)
+        manager._run_sync("steam", sync_function)
+
+        assert manager.get_status()["jobs"][0]["completed_at"] is not None
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_passes_job_to_sync_function(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        sync_function = MagicMock(return_value=10)
+
+        manager.start_sync(source="steam", sync_function=sync_function)
+        manager._run_sync("steam", sync_function)
+
+        sync_function.assert_called_once()
+        passed_job = sync_function.call_args[0][0]
+        assert isinstance(passed_job, SyncJob)
+        assert passed_job.source == "steam"
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_items_processed_set_from_return_value(
+        self, mock_thread: MagicMock
+    ) -> None:
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        sync_function = MagicMock(return_value=99)
+
+        manager.start_sync(source="steam", sync_function=sync_function)
+        manager._run_sync("steam", sync_function)
+
+        assert manager.get_status()["jobs"][0]["items_processed"] == 99
+
+
+class TestSyncManagerThreadCreation:
+    """start_sync spawns a daemon thread."""
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_creates_daemon_thread(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        manager.start_sync(source="steam", sync_function=MagicMock(return_value=10))
+
+        mock_thread.assert_called_once()
+        assert mock_thread.call_args.kwargs["daemon"] is True
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_starts_thread(self, mock_thread: MagicMock) -> None:
+        instance = MagicMock()
+        mock_thread.return_value = instance
+        manager = SyncManager()
+        manager.start_sync(source="steam", sync_function=MagicMock(return_value=10))
+
+        instance.start.assert_called_once()
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_target_is_run_sync(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        manager.start_sync(source="steam", sync_function=MagicMock(return_value=10))
+
+        assert mock_thread.call_args.kwargs["target"] == manager._run_sync
+
+
+class TestSingletonGetterAndReset:
+    def setup_method(self) -> None:
+        reset_sync_manager()
+
+    def teardown_method(self) -> None:
+        reset_sync_manager()
+
+    def test_returns_sync_manager_instance(self) -> None:
+        assert isinstance(get_sync_manager(), SyncManager)
+
+    def test_returns_same_instance(self) -> None:
+        assert get_sync_manager() is get_sync_manager()
+
+    def test_reset_clears_instance(self) -> None:
+        first = get_sync_manager()
+        reset_sync_manager()
+        assert get_sync_manager() is not first
+
+    def test_reset_safe_when_no_instance(self) -> None:
+        reset_sync_manager()
+        reset_sync_manager()
+
+
+class TestSyncJobDefaults:
+    def test_default_status_is_idle(self) -> None:
+        assert SyncJob(source="test").status == SyncStatus.IDLE
+
+    def test_default_errors_list_is_empty(self) -> None:
+        assert SyncJob(source="test").errors == []
+
+    def test_errors_list_is_not_shared_between_instances(self) -> None:
+        a = SyncJob(source="a")
+        b = SyncJob(source="b")
+        a.errors.append("error in a")
+        assert b.errors == []
+
+    def test_default_items_processed_is_zero(self) -> None:
+        assert SyncJob(source="test").items_processed == 0
+
+    def test_default_optional_fields_are_none(self) -> None:
+        job = SyncJob(source="test")
+        assert job.started_at is None
+        assert job.completed_at is None
+        assert job.total_items is None
+        assert job.current_item is None
+        assert job.current_source is None
+        assert job.error_message is None
+
+
+class TestSyncManagerHistoryEviction:
+    """Cap on retained terminal jobs prevents unbounded ``_jobs`` growth.
+
+    Without this, an unauthenticated /api/update caller could grow the
+    SyncManager's job dict indefinitely by triggering syncs with arbitrary
+    source labels, exhausting process memory.
+    """
+
+    def _make_terminal_job(
+        self,
+        source: str,
+        completed_at: datetime,
+        status: SyncStatus = SyncStatus.COMPLETED,
+    ) -> SyncJob:
+        return SyncJob(
+            source=source,
+            status=status,
+            started_at=completed_at,
+            completed_at=completed_at,
+        )
+
+    def test_no_eviction_below_cap(self) -> None:
+        manager = SyncManager()
+        cap = manager._MAX_TERMINAL_HISTORY
+        # Plant cap-1 terminal jobs directly so we don't depend on
+        # start_sync's thread spawn.
+        for index in range(cap - 1):
+            manager._jobs[f"src_{index}"] = self._make_terminal_job(
+                f"src_{index}", datetime(2026, 1, 1, 0, index)
+            )
+
+        with manager._lock:
+            manager._evict_history_locked()
+
+        assert len(manager._jobs) == cap - 1
+
+    def test_eviction_drops_oldest_terminal_job(self) -> None:
+        manager = SyncManager()
+        cap = manager._MAX_TERMINAL_HISTORY
+        # cap+1 terminal jobs: oldest at minute 0, newest at minute cap.
+        for index in range(cap + 1):
+            manager._jobs[f"src_{index}"] = self._make_terminal_job(
+                f"src_{index}", datetime(2026, 1, 1, 0, index)
+            )
+
+        with manager._lock:
+            manager._evict_history_locked()
+
+        assert len(manager._jobs) == cap
+        # The single oldest terminal job (src_0) is gone; everything
+        # newer survives.
+        assert "src_0" not in manager._jobs
+        for index in range(1, cap + 1):
+            assert f"src_{index}" in manager._jobs
+
+    def test_eviction_only_drops_terminal_jobs(self) -> None:
+        manager = SyncManager()
+        cap = manager._MAX_TERMINAL_HISTORY
+        # One running job (must always be retained) plus cap+1 terminal
+        # jobs to push history over the cap.
+        manager._jobs["running"] = SyncJob(
+            source="running",
+            status=SyncStatus.RUNNING,
+            started_at=datetime(2026, 1, 1),
+        )
+        for index in range(cap + 1):
+            manager._jobs[f"done_{index}"] = self._make_terminal_job(
+                f"done_{index}", datetime(2026, 1, 1, 0, index)
+            )
+
+        with manager._lock:
+            manager._evict_history_locked()
+
+        # Running job preserved; one terminal job evicted to bring
+        # terminals back down to the cap.
+        assert "running" in manager._jobs
+        terminals = [
+            label
+            for label, job in manager._jobs.items()
+            if job.status != SyncStatus.RUNNING
+        ]
+        assert len(terminals) == cap
+
+    def test_eviction_handles_completed_at_none(self) -> None:
+        """Terminal jobs without completed_at sort to the start (oldest)."""
+        manager = SyncManager()
+        cap = manager._MAX_TERMINAL_HISTORY
+        # One terminal job with completed_at=None plus cap others with
+        # known timestamps. The None job must be the one evicted because
+        # it sorts to the front under the ``or datetime.min`` fallback.
+        manager._jobs["no_timestamp"] = SyncJob(
+            source="no_timestamp",
+            status=SyncStatus.COMPLETED,
+            started_at=datetime(2026, 1, 1),
+            completed_at=None,
+        )
+        for index in range(cap):
+            manager._jobs[f"src_{index}"] = self._make_terminal_job(
+                f"src_{index}", datetime(2026, 1, 1, 0, index + 10)
+            )
+
+        with manager._lock:
+            manager._evict_history_locked()
+
+        assert "no_timestamp" not in manager._jobs
+        assert len(manager._jobs) == cap
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_start_sync_triggers_eviction(self, mock_thread: MagicMock) -> None:
+        """``start_sync`` calls eviction so callers don't have to."""
+        mock_thread.return_value = MagicMock()
+        manager = SyncManager()
+        cap = manager._MAX_TERMINAL_HISTORY
+        # Pre-populate with cap+1 terminals so eviction must drop one.
+        # The newly inserted RUNNING job is excluded from eviction, so
+        # without these extra terminals the cap wouldn't be breached.
+        for index in range(cap + 1):
+            manager._jobs[f"src_{index}"] = self._make_terminal_job(
+                f"src_{index}", datetime(2026, 1, 1, 0, index)
+            )
+
+        manager.start_sync(source="new", sync_function=MagicMock(return_value=0))
+
+        assert "src_0" not in manager._jobs
+        assert "new" in manager._jobs
+        assert manager._jobs["new"].status == SyncStatus.RUNNING
+        # Exactly one terminal evicted, so the dict is at cap + the
+        # newly added running job.
+        assert len(manager._jobs) == cap + 1
+
+
+class TestSyncManagerZeroItemsWithErrorsRegression:
+    """When a sync produces zero items but logged errors, mark it FAILED."""
+
+    @patch("src.web.sync_manager.threading.Thread")
+    def test_zero_items_with_errors_marks_failed(self, mock_thread: MagicMock) -> None:
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
 
         def sync_function(job: SyncJob) -> int:
-            manager.add_error("Epic Games API returned 401")
+            manager.add_error("Epic Games", "Epic Games API returned 401")
             return 0
 
         manager.start_sync(source="Epic Games", sync_function=sync_function)
-        manager._run_sync(sync_function)
+        manager._run_sync("Epic Games", sync_function)
 
-        status = manager.get_status()
-        assert status["status"] == "failed"
-        assert status["job"]["items_processed"] == 0
-        assert status["job"]["error_count"] == 1
-        assert status["job"]["error_message"] == "Epic Games API returned 401"
+        job = manager.get_status()["jobs"][0]
+        assert job["status"] == "failed"
+        assert job["items_processed"] == 0
+        assert job["error_count"] == 1
+        assert job["error_message"] == "Epic Games API returned 401"
 
     @patch("src.web.sync_manager.threading.Thread")
     def test_partial_success_with_errors_stays_completed(
-        self, mock_thread_class: MagicMock
+        self, mock_thread: MagicMock
     ) -> None:
-        """Partial success keeps COMPLETED — the banner honestly reports errors."""
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
 
         def sync_function(job: SyncJob) -> int:
-            manager.add_error("Item 3 failed to parse")
+            manager.add_error("steam", "Item 3 failed to parse")
             return 5
 
         manager.start_sync(source="steam", sync_function=sync_function)
-        manager._run_sync(sync_function)
+        manager._run_sync("steam", sync_function)
 
-        status = manager.get_status()
-        assert status["status"] == "completed"
-        assert status["job"]["items_processed"] == 5
-        assert status["job"]["error_count"] == 1
+        job = manager.get_status()["jobs"][0]
+        assert job["status"] == "completed"
+        assert job["items_processed"] == 5
+        assert job["error_count"] == 1
 
     @patch("src.web.sync_manager.threading.Thread")
     def test_on_complete_not_called_when_zero_items_with_errors(
-        self, mock_thread_class: MagicMock
+        self, mock_thread: MagicMock
     ) -> None:
-        """The on_complete callback must be skipped for the FAILED path.
-
-        Downstream work like enrichment triggering should not fire when a
-        sync produced nothing and reported errors — otherwise the UI shows
-        a failure banner while side effects still run as if it succeeded.
-        """
+        mock_thread.return_value = MagicMock()
         manager = SyncManager()
         on_complete = MagicMock()
 
         def sync_function(job: SyncJob) -> int:
-            manager.add_error("Epic Games API returned 401")
+            manager.add_error("Epic Games", "Epic Games API returned 401")
             return 0
 
         manager.start_sync(
@@ -1044,7 +968,7 @@ class TestSyncManagerZeroItemsWithErrorsRegression:
             sync_function=sync_function,
             on_complete=on_complete,
         )
-        manager._run_sync(sync_function, on_complete=on_complete)
+        manager._run_sync("Epic Games", sync_function, on_complete=on_complete)
 
-        assert manager.get_status()["status"] == "failed"
+        assert manager.get_status()["jobs"][0]["status"] == "failed"
         on_complete.assert_not_called()


### PR DESCRIPTION
## Summary

Implements parallel multi-source sync per issue #45. Each enabled data
source now runs on its own worker thread inside
`execute_multi_source_sync`; the total sync time is bounded by the
slowest source instead of the sum of all sources. Per-source rate
limits remain enforced inside each plugin so cross-source parallelism
is safe.

## What Changed

- **Parallel executor**: `execute_multi_source_sync(..., max_workers)`
  uses a `concurrent.futures.ThreadPoolExecutor` capped at
  `min(max_workers, len(sources))`. Result ordering matches input.
- **Hard ceiling**: `MAX_WORKERS_CEILING = 32`; a shared
  `resolve_max_workers` helper clamps every code path to `[1, 32]`
  and falls back to the default on malformed config.
- **Storage thread-safety**: SQLite `PRAGMA busy_timeout = 5000` plus a
  `threading.Lock` on `StorageManager` that serialises the read-resolve-
  write sequence in `save_content_item` and the encrypt-then-write
  sequence in `save_credential`.
- **Per-source progress**: `SyncJob.source_progress` map + sorted
  `sources[]` field on `SyncStatusResponse`; aggregate
  `items_processed` / `total_items` reflect the sum across sources.
- **CLI**: `python3.11 -m src.cli update --workers N`
  (`click.IntRange(1, MAX_WORKERS_CEILING)`).
- **Web API**: optional `max_workers` field on `UpdateRequest` (Pydantic-bounded).
- **Config**: new `sync.max_workers: 4` block in `config/example.yaml`.
- **Docs**: README, ARCHITECTURE, PLUGIN_DEVELOPMENT.

Closes #45

## Test Plan

- [x] `command make check` passes (2852 backend + 324 frontend tests, mypy strict, black, ruff)
- [x] New `TestConcurrentSaveContentItem` exercises the storage lock with overlapping titles
- [x] New `TestExecuteMultiSourceSync` parallel tests use `threading.Barrier` to prove concurrency
- [x] `TestResolveMaxWorkers` covers the helper directly (override/clamp/default/non-integer)
- [x] CLI `--workers` flag tests cover override, fallback, default 4, IntRange bounds, sequential override
- [x] Web `/api/update` tests cover config-driven workers, body-field override, Pydantic 422
- [x] `/api/sync/status` test asserts the per-source `sources[]` shape end-to-end
- [x] All six review agents (security, code, test, document, parity, accessibility) approved on the final tree
- [x] commit-hygiene approved the 5-commit atomic split

🤖 Generated with [Claude Code](https://claude.com/claude-code)