### PR TITLE
fix: resolve runtime version from pyproject.toml in dev/Docker (fixes #68)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ config = load_config(Path("config/config.yaml"))
 The project uses **python-semantic-release** for automatic semantic versioning driven by conventional commits.
 
 - **Version source of truth**: `pyproject.toml` `[project] version` field — written by python-semantic-release, never edit manually
-- **Runtime version**: `src/__init__.py` reads the version via `importlib.metadata.version("recommendinator")` — never hardcode versions
+- **Runtime version**: `src/__init__.py` resolves the version by preferring an adjacent `pyproject.toml` (dev and Docker source layouts) and falling back to `importlib.metadata.version("recommendinator")` for wheel installs — never hardcode versions. The pyproject.toml preference keeps editable installs and Docker dev containers in sync after `python-semantic-release` bumps the version without requiring a reinstall.
 - **CHANGELOG.md**: Auto-generated from commit messages — **do not edit manually** (edits will be silently overwritten on the next release)
 - **Version bump rules**: `feat` → minor, `fix`/`perf` → patch, `BREAKING CHANGE` footer → major (but `major_on_zero = false` while pre-1.0)
 - **Release workflow**: GitHub Actions on push to `main` → analyzes commits → bumps version → updates CHANGELOG.md → creates version commit and tag → regenerates and commits `uv.lock`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,10 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 What the override does:
 - **Builds locally** instead of pulling from GHCR, so changes to `Dockerfile`,
   `pyproject.toml`, or the frontend build are reflected.
-- **Bind-mounts `./src` and `./templates`** into the container so Python edits
-  are visible immediately without a rebuild.
+- **Bind-mounts `./src`, `./templates`, and `./pyproject.toml`** into the container
+  so Python edits are visible immediately without a rebuild. The `pyproject.toml`
+  mount keeps the runtime `__version__` in sync with `python-semantic-release`
+  bumps without rebuilding the image.
 - **Starts uvicorn with `--reload`**, watching `src/` and `templates/` — backend
   changes restart in ~1 second.
 
@@ -194,7 +196,7 @@ Follow **Conventional Commits**:
 The project uses **automatic semantic versioning**:
 
 - **Version source of truth**: `pyproject.toml` `[project] version` field, written by python-semantic-release
-- **Runtime version**: `src/__init__.py` reads the version via `importlib.metadata` — never hardcode versions
+- **Runtime version**: `src/__init__.py` resolves the version by preferring an adjacent `pyproject.toml` (dev and Docker source layouts) and falling back to `importlib.metadata.version("recommendinator")` for wheel installs — never hardcode versions. The pyproject.toml preference keeps editable installs and Docker dev containers in sync after `python-semantic-release` bumps the version without requiring a reinstall.
 - **CHANGELOG.md**: Auto-generated from commit messages — **do not edit manually** (edits will be overwritten on the next release)
 - **Release workflow**: A GitHub Actions workflow on push to `main` analyzes commits, bumps the version, updates CHANGELOG.md, and creates a version commit and tag. A follow-up step regenerates `uv.lock` and commits it separately
 - **No manual version bumps**: Never edit the version in `pyproject.toml` by hand — let the release workflow handle it

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,6 +14,9 @@
 #   - Bind-mounts ./src and ./templates into the container so Python edits
 #     are visible immediately. Combined with --reload, uvicorn restarts in
 #     ~1s on file save — no rebuild needed.
+#   - Bind-mounts pyproject.toml so the runtime __version__ reflects the
+#     host's current value after semantic-release bumps it (without
+#     rebuilding the image). See src/__init__.py:_read_source_version.
 #   - Renames the local images so they don't shadow the GHCR cache when you
 #     switch back to the production compose.
 #
@@ -27,6 +30,7 @@ x-dev-common: &dev-common
   volumes:
     - ./src:/app/src
     - ./templates:/app/templates
+    - ./pyproject.toml:/app/pyproject.toml:ro
   command:
     - python
     - -m

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -312,8 +312,10 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile ai up -d app-ai
 ```
 
-This builds the image locally instead of pulling, bind-mounts `./src` and `./templates`
-into the container, and runs uvicorn with `--reload` so Python changes trigger a
-~1s restart. For frontend hot reload, run `pnpm dev` on the host (Vite serves on
-port 5173 and proxies API calls to the container). See [CONTRIBUTING.md](../CONTRIBUTING.md)
+This builds the image locally instead of pulling, bind-mounts `./src`, `./templates`,
+and `./pyproject.toml` into the container, and runs uvicorn with `--reload` so Python
+changes trigger a ~1s restart. The `pyproject.toml` mount keeps the runtime
+`__version__` in sync with semantic-release bumps without rebuilding the image.
+For frontend hot reload, run `pnpm dev` on the host (Vite serves on port 5173
+and proxies API calls to the container). See [CONTRIBUTING.md](../CONTRIBUTING.md)
 for the full developer workflow.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,10 +3,49 @@
 A privacy-focused recommendation engine for books, movies, TV shows, and video games.
 """
 
+from __future__ import annotations
+
+import tomllib
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
+from pathlib import Path
 
-try:
-    __version__: str = _pkg_version("recommendinator")
-except PackageNotFoundError:
-    __version__ = "0.0.0"
+
+def _read_source_version(source_file: str | None = None) -> str | None:
+    """Return the version from a pyproject.toml adjacent to this source tree.
+
+    Why: importlib.metadata caches the version at install time, so editable
+    installs and Docker dev containers report a stale version after
+    semantic-release bumps pyproject.toml. Reading the file directly when
+    it sits next to src/ keeps the dev/Docker version in sync with the
+    source of truth without requiring a reinstall.
+    """
+    base = Path(source_file if source_file is not None else __file__).resolve()
+    pyproject = base.parent.parent / "pyproject.toml"
+    try:
+        with pyproject.open("rb") as handle:
+            data = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    version = data.get("project", {}).get("version")
+    # Treat empty strings and non-string values as "not present" so the
+    # caller falls back to importlib.metadata instead of returning bogus data.
+    return version if isinstance(version, str) and version else None
+
+
+def _resolve_version() -> str:
+    """Return the package version, preferring adjacent pyproject.toml.
+
+    Precedence: pyproject.toml (dev/Docker source layout) -> importlib.metadata
+    (installed wheel) -> "0.0.0" sentinel (uninstalled clone).
+    """
+    source_version = _read_source_version()
+    if source_version is not None:
+        return source_version
+    try:
+        return _pkg_version("recommendinator")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+__version__: str = _resolve_version()

--- a/tests/test_package_version.py
+++ b/tests/test_package_version.py
@@ -1,46 +1,131 @@
 """Tests for package version resolution in src/__init__.py."""
 
-import importlib
 from importlib.metadata import PackageNotFoundError
+from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 import src
 
 
+def _make_source_tree(tmp_path: Path, pyproject_content: str | None) -> Path:
+    """Build a fake source tree with optional pyproject.toml; return src/__init__.py path."""
+    fake_init = tmp_path / "src" / "__init__.py"
+    fake_init.parent.mkdir()
+    fake_init.touch()
+    if pyproject_content is not None:
+        (tmp_path / "pyproject.toml").write_text(pyproject_content, encoding="utf-8")
+    return fake_init
+
+
 class TestPackageVersion:
-    """Tests for __version__ resolution via importlib.metadata."""
+    """Tests for __version__ resolution via pyproject.toml + importlib.metadata."""
 
-    def test_version_returns_metadata_value_when_installed(self) -> None:
-        """__version__ equals the value from importlib.metadata when available."""
-        try:
-            with patch(
-                "importlib.metadata.version",
-                return_value="1.2.3",
-            ):
-                importlib.reload(src)
-                assert (
-                    src.__version__ == "1.2.3"
-                ), f"Expected '1.2.3' from mocked metadata, got {src.__version__!r}"
-        finally:
-            importlib.reload(src)
+    def test_version_attribute_matches_resolved_value(self) -> None:
+        """__version__ resolves at import time and equals _resolve_version()'s output."""
+        assert (
+            isinstance(src.__version__, str) and src.__version__
+        ), f"Expected non-empty version string, got {src.__version__!r}"
+        # In any environment that loaded the module, __version__ must agree
+        # with the live resolver — guards against drift between the two.
+        assert src.__version__ == src._resolve_version()
 
-    def test_version_falls_back_to_sentinel_when_not_installed(self) -> None:
-        """__version__ falls back to '0.0.0' when package metadata is unavailable.
+    def test_resolve_prefers_pyproject_when_adjacent(self) -> None:
+        """_resolve_version uses pyproject.toml value when present."""
+        with patch("src._read_source_version", return_value="9.9.9"):
+            assert src._resolve_version() == "9.9.9"
 
-        Covers the PackageNotFoundError path for when the project is run
-        from a cloned repo without being installed via pip or uv.
-        """
-        try:
-            with patch(
-                "importlib.metadata.version",
+    def test_resolve_uses_metadata_when_no_pyproject(self) -> None:
+        """_resolve_version falls back to importlib.metadata when no pyproject.toml."""
+        with (
+            patch("src._read_source_version", return_value=None),
+            patch("src._pkg_version", return_value="1.2.3"),
+        ):
+            assert src._resolve_version() == "1.2.3"
+
+    def test_resolve_falls_back_to_sentinel_when_not_installed(self) -> None:
+        """_resolve_version returns '0.0.0' when both sources unavailable."""
+        with (
+            patch("src._read_source_version", return_value=None),
+            patch(
+                "src._pkg_version",
                 side_effect=PackageNotFoundError("recommendinator"),
-            ):
-                # Reload inside the patch context so the module re-executes
-                # its top-level try/except while the patch is active.
-                importlib.reload(src)
-                assert (
-                    src.__version__ == "0.0.0"
-                ), f"Expected fallback sentinel '0.0.0', got {src.__version__!r}"
-        finally:
-            # Restore the real version for subsequent tests.
-            importlib.reload(src)
+            ),
+        ):
+            assert src._resolve_version() == "0.0.0"
+
+
+class TestStaleEditableInstallRegression:
+    """Regression tests for issue #68.
+
+    Bug symptom: web UI shows old version (e.g., 0.7.0) on local dev instance
+    even after pulling new commits that bumped pyproject.toml.
+
+    Root cause: importlib.metadata.version() returns the version baked into
+    package metadata at install time. python-semantic-release bumps
+    pyproject.toml on every release commit, but editable installs do not
+    automatically refresh their metadata, so __version__ stays pinned to
+    whatever was installed.
+
+    Fix: src.__init__ now reads pyproject.toml when it sits adjacent to the
+    source tree (dev or Docker), and only falls back to importlib.metadata
+    for true wheel installs where pyproject.toml is not bundled alongside
+    the package.
+    """
+
+    def test_pyproject_version_overrides_stale_metadata(self) -> None:
+        """When pyproject.toml is adjacent, its version wins over metadata."""
+        with (
+            patch("src._read_source_version", return_value="0.11.0"),
+            patch("src._pkg_version", return_value="0.7.0"),
+        ):
+            assert src._resolve_version() == "0.11.0", (
+                "Expected pyproject.toml value '0.11.0' to win over stale "
+                "metadata '0.7.0'"
+            )
+
+    def test_real_pyproject_is_parseable_in_dev_tree(self) -> None:
+        """The dev tree's real pyproject.toml resolves to a SemVer-shaped string.
+
+        Skipped on wheel-only installs where pyproject.toml is not bundled
+        alongside the package, since that environment legitimately falls
+        back to importlib.metadata.
+        """
+        version = src._read_source_version()
+        if version is None:
+            pytest.skip("pyproject.toml not adjacent to src/ (wheel install)")
+        parts = version.split(".")
+        assert len(parts) >= 2, f"Expected dotted version, got {version!r}"
+        assert all(p for p in parts), f"Empty version segment in {version!r}"
+
+    def test_returns_none_when_no_pyproject(self, tmp_path: Path) -> None:
+        """Wheel-install layout: no pyproject.toml adjacent → fall through to metadata."""
+        fake_init = _make_source_tree(tmp_path, pyproject_content=None)
+        assert src._read_source_version(str(fake_init)) is None
+
+    def test_returns_none_for_malformed_pyproject(self, tmp_path: Path) -> None:
+        """Corrupted pyproject.toml must not crash module import — fall through cleanly."""
+        fake_init = _make_source_tree(tmp_path, "this is = = not valid toml [[[")
+        assert src._read_source_version(str(fake_init)) is None
+
+    def test_returns_none_when_project_table_missing(self, tmp_path: Path) -> None:
+        """pyproject.toml without a [project] table is not a packaging file we own."""
+        fake_init = _make_source_tree(tmp_path, "[build-system]\nrequires = []\n")
+        assert src._read_source_version(str(fake_init)) is None
+
+    def test_returns_none_when_version_is_empty_string(self, tmp_path: Path) -> None:
+        """Empty version string is treated as 'not set' so metadata fallback kicks in."""
+        fake_init = _make_source_tree(tmp_path, '[project]\nversion = ""\n')
+        assert src._read_source_version(str(fake_init)) is None
+
+    def test_returns_none_when_version_is_not_string(self, tmp_path: Path) -> None:
+        """Non-string TOML value (e.g., bare integer) must not be returned as a version."""
+        fake_init = _make_source_tree(tmp_path, "[project]\nversion = 123\n")
+        assert src._read_source_version(str(fake_init)) is None
+
+    def test_returns_none_on_permission_error(self, tmp_path: Path) -> None:
+        """OSError other than FileNotFoundError (e.g., permission denied) is caught."""
+        fake_init = _make_source_tree(tmp_path, '[project]\nversion = "1.0.0"\n')
+        with patch("pathlib.Path.open", side_effect=PermissionError("denied")):
+            assert src._read_source_version(str(fake_init)) is None


### PR DESCRIPTION
## Summary

Fixes #68 — the web UI's version display was stuck on a stale value (e.g., `0.7.0`) on local dev instances even after pulling new commits that bumped `pyproject.toml`.

**Root cause:** `importlib.metadata.version()` returns the version baked into package metadata at install time. `python-semantic-release` bumps `pyproject.toml` on every release commit, but editable installs and Docker dev containers do not refresh their metadata, so `__version__` stays pinned to whatever was installed.

**Fix:**

1. `src/__init__.py` now resolves the version by preferring an adjacent `pyproject.toml` (dev checkout / Docker source-mount layouts) and falling back to `importlib.metadata` for true wheel installs.
2. `docker-compose.dev.yml` now bind-mounts `./pyproject.toml` read-only so the container actually sees the host's current value (the dev compose previously only mounted `./src` and `./templates`).

Fixes #68

## What Changed

- `src/__init__.py` — new `_read_source_version` + `_resolve_version` helpers; precedence is `pyproject.toml` → `importlib.metadata` → `"0.0.0"` sentinel.
- `tests/test_package_version.py` — replaced the reload-based tests with direct unit tests; new `TestStaleEditableInstallRegression` class covers the bug, the precedence logic, and the file-absent / malformed / missing-[project] / empty / non-string / `PermissionError` edge cases.
- `docker-compose.dev.yml` — bind-mount `./pyproject.toml:/app/pyproject.toml:ro`.
- `CLAUDE.md`, `CONTRIBUTING.md`, `docs/DOCKER.md` — updated to describe the two-tier resolution and the new dev mount.

## Test Plan

- [x] `command make check` — 2874 python tests + 333 frontend tests, all pass
- [x] `python3.11 -c "import src; print(src.__version__)"` returns the value from `pyproject.toml` (was `0.6.0` before the fix on this machine, now `0.11.0`)
- [ ] On Docker dev, after pulling this branch, recreate the container (`docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --force-recreate`) — the bind-mount only takes effect for new containers — and confirm the sidebar shows the current `pyproject.toml` version.
- [x] Six review agents (security, code, test, document, parity, accessibility) all approve on the final tree.

## Notes for Reviewers

- Production GHCR images already published do not auto-fix; they will pick up the new resolver on the next image build (which is automatic on the next release tag).
- The `_read_source_version` helper takes an optional `source_file` parameter so tests can point at a `tmp_path` source tree without monkeypatching `__file__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)