### PR TITLE
fix(ui): keep stepper inline with content-type dropdown on mobile (#58)

### DIFF
--- a/resources/js/components/organisms/RecControls.test.ts
+++ b/resources/js/components/organisms/RecControls.test.ts
@@ -198,3 +198,60 @@ describe('RecControls', () => {
     expect(el.value).toBe('tv_show')
   })
 })
+
+describe('RecControls layout regression (issue #58)', () => {
+  /**
+   * Bug: on mobile (≤640px), the NumberStepper rendered on its own row below
+   * the content-type dropdown instead of on the same line.
+   *
+   * Root cause: NumberStepper was nested inside .rec-actions-row, which has
+   * width: 100% on mobile, forcing it (and its parent row) below the dropdown.
+   *
+   * Fix: lift NumberStepper to be a direct child of .rec-toolbar alongside
+   * TypePills/TypeSelect. Mobile CSS lets dropdown + stepper share the top row
+   * while .toolbar-actions wraps to its own full-width row below.
+   *
+   * These tests assert the structural invariant the CSS fix relies on:
+   * NumberStepper is a sibling of TypeSelect inside .rec-toolbar, and the
+   * action buttons sit in a separate .toolbar-actions wrapper that can wrap
+   * independently.
+   */
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('NumberStepper and TypeSelect are siblings under .rec-toolbar', () => {
+    const wrapper = mount(RecControls)
+
+    const stepper = wrapper.find('.number-stepper')
+    const select = wrapper.find('.rec-type-select')
+    expect(stepper.exists()).toBe(true)
+    expect(select.exists()).toBe(true)
+
+    const stepperParent = stepper.element.parentElement
+    const selectParent = select.element.parentElement
+    expect(stepperParent?.classList.contains('rec-toolbar')).toBe(true)
+    expect(selectParent?.classList.contains('rec-toolbar')).toBe(true)
+    expect(stepperParent).toBe(selectParent)
+  })
+
+  it('action buttons live in .toolbar-actions which is a direct child of .rec-toolbar', () => {
+    const app = useAppStore()
+    app.features.ai_enabled = true
+    app.features.llm_reasoning_enabled = true
+
+    const wrapper = mount(RecControls)
+
+    const genBtn = wrapper.findAll('.btn').find(b => b.text() === 'Generate')
+    const aiBtn = wrapper.findAll('.btn').find(b => b.text().includes('AI'))
+    expect(genBtn).toBeDefined()
+    expect(aiBtn).toBeDefined()
+
+    const actions = genBtn!.element.parentElement
+    expect(actions).not.toBeNull()
+    expect(actions!.classList.contains('toolbar-actions')).toBe(true)
+    expect(actions!.parentElement?.classList.contains('rec-toolbar')).toBe(true)
+
+    expect(aiBtn!.element.parentElement).toBe(actions)
+  })
+})

--- a/resources/js/components/organisms/RecControls.vue
+++ b/resources/js/components/organisms/RecControls.vue
@@ -18,32 +18,28 @@ const app = useAppStore()
       <!-- Mobile: dropdown replaces pills -->
       <TypeSelect v-model="recs.contentType" :include-all="false" class="toolbar-select rec-type-select" />
 
+      <NumberStepper
+        v-model="recs.count"
+        :min="1"
+        :max="app.recommendationsConfig.max_count"
+        class="rec-stepper"
+        aria-label="Number of recommendations"
+      />
+
       <div class="toolbar-divider" />
 
-      <!-- Stepper + action buttons (mobile: reflows to full-width row) -->
-      <div class="rec-actions-row">
-        <NumberStepper
-          v-model="recs.count"
-          :min="1"
-          :max="app.recommendationsConfig.max_count"
-          aria-label="Number of recommendations"
-        />
-
-        <div class="toolbar-divider" />
-
-        <div class="toolbar-zone toolbar-right">
-          <button
-            class="btn btn-secondary"
-            :disabled="recs.loading"
-            @click="recs.fetch(false)"
-          >Generate</button>
-          <button
-            v-if="app.aiReasoningEnabled"
-            class="btn btn-primary"
-            :disabled="recs.loading"
-            @click="recs.fetch(true)"
-          >&#10024; AI Recommendations</button>
-        </div>
+      <div class="toolbar-zone toolbar-actions">
+        <button
+          class="btn btn-secondary"
+          :disabled="recs.loading"
+          @click="recs.fetch(false)"
+        >Generate</button>
+        <button
+          v-if="app.aiReasoningEnabled"
+          class="btn btn-primary"
+          :disabled="recs.loading"
+          @click="recs.fetch(true)"
+        ><span aria-hidden="true">&#10024;</span> AI Recommendations</button>
       </div>
     </div>
   </div>
@@ -63,13 +59,7 @@ const app = useAppStore()
   gap: var(--space-2);
 }
 
-.rec-actions-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-}
-
-.toolbar-right {
+.toolbar-actions {
   margin-left: auto;
 }
 
@@ -77,7 +67,8 @@ const app = useAppStore()
   display: none;
 }
 
-/* Mobile: dropdown replaces pills, stepper stays in actions row */
+/* Mobile: dropdown replaces pills; dropdown + stepper share top row;
+   action buttons wrap to their own full-width row below. */
 @media (max-width: 640px) {
   .rec-pills,
   .rec-toolbar > .toolbar-divider {
@@ -86,20 +77,21 @@ const app = useAppStore()
 
   .rec-type-select {
     display: block;
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .rec-stepper {
+    flex: 0 0 auto;
+  }
+
+  .toolbar-actions {
     width: 100%;
-  }
-
-  .rec-actions-row {
-    width: 100%;
-    gap: var(--space-2);
-  }
-
-  .rec-actions-row > .toolbar-divider {
-    display: none;
-  }
-
-  .toolbar-right {
     margin-left: 0;
+  }
+
+  .toolbar-actions .btn {
+    flex: 1 1 0;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

On mobile (≤640px) the **Number to generate** stepper rendered on its own row below the content-type dropdown. The user expected it on the same line as the dropdown.

Root cause: `NumberStepper` was nested inside `.rec-actions-row`, which has `width: 100%` on mobile, forcing the entire row (and the stepper inside it) below the dropdown.

Fix: lift `NumberStepper` to be a direct sibling of `TypeSelect`/`TypePills` inside `.rec-toolbar`. Mobile CSS now lets the dropdown (`flex: 1`) and stepper (`flex: 0 0 auto`) share the top row, while the Generate / AI Recommendations buttons wrap to a full-width row below — each button `flex: 1` so they span the row evenly. Desktop layout is unchanged: `.toolbar-actions` keeps `margin-left: auto` to push the buttons to the right of the toolbar.

Also wraps the sparkle emoji on the AI Recommendations button in `<span aria-hidden="true">` so screen readers announce only the button text.

Fixes #58

## What Changed

- `resources/js/components/organisms/RecControls.vue` — template restructure, scoped CSS for mobile, `aria-hidden` on sparkle emoji
- `resources/js/components/organisms/RecControls.test.ts` — regression tests asserting the structural invariant the CSS fix depends on (stepper + select are siblings under `.rec-toolbar`, action buttons live in `.toolbar-actions`)

## Test Plan

- [ ] Open `/recommendations` on a mobile viewport (≤640px); confirm dropdown and stepper share the top row, Generate/AI buttons span the second row evenly
- [ ] Open `/recommendations` on a desktop viewport; confirm pills, divider, stepper, divider, buttons all render on a single row with buttons pushed right
- [ ] Screen reader announces "AI Recommendations" without "sparkle" prefix on the AI button
- [ ] `npm test` passes (337 frontend tests)
- [ ] `command make check` passes (2874 Python tests + black + mypy + ruff + frontend tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)