### PR TITLE
feat: variety-after-completion stepped genre-fatigue penalty (closes #74)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,6 +110,8 @@ RecommendationEngine
   |
   |-- UserPreferenceConfig (optional per-user weight overrides, diversity_weight)
   |-- Ranker (adaptation bonus, series bonus, diversity bonus, preference adjustments)
+  |-- Variety penalty (when variety_after_completion enabled) — stepped genre-fatigue
+  |     multiplier scoped to the recommended content type (see variety.py)
   |-- [LLM reasoning post-processing]  (when AI enabled)
 ```
 
@@ -125,8 +127,9 @@ RecommendationEngine
 4. Score all unconsumed candidates through the scoring pipeline
 5. Optionally blend vector-similarity scores when AI is enabled
 6. Apply series filtering with substitution (when `series_in_order` is enabled): candidates that fail series ordering rules are replaced with the earliest recommendable entry from the same series, using the substitute's own pipeline score. Duplicate substitutions per series are prevented. Also apply diversity bonus (genre-hopping) and ranking adjustments
-7. Filter out items marked as `ignored`
-8. Generate ranked recommendations with score breakdowns
+7. Apply the variety penalty (when `variety_after_completion` is enabled): build a stepped genre-fatigue ladder from the user's recently completed items **of the recommended content type**, then multiply each candidate's final score by `1 - penalty` where the penalty is the strongest among the candidate's recently finished genre clusters (`variety.py`). The applied penalty is surfaced per recommendation
+8. Filter out items marked as `ignored`
+9. Generate ranked recommendations with score breakdowns
 
 **Cross-Content-Type Recommendations:**
 - Preferences from all content types influence recommendations

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -339,6 +339,14 @@ python3.11 -m src.cli preferences set-length movie any
 python3.11 -m src.cli preferences set-length video_game long
 ```
 
+### Toggle variety after completion
+
+```bash
+# Demote genres you've recently finished so recommendations vary (per content
+# type) instead of marching through the next entry in a just-finished series.
+python3.11 -m src.cli preferences set-toggle variety_after_completion on
+```
+
 ## Optional: Enable AI Features
 
 If you want semantic similarity and LLM-powered explanations:

--- a/README.md
+++ b/README.md
@@ -396,6 +396,10 @@ python3.11 -m src.cli preferences get --format json
 python3.11 -m src.cli preferences set-weight genre_match 3.0
 python3.11 -m src.cli preferences set-length book short
 
+# Toggle boolean preferences (series_in_order, variety_after_completion)
+python3.11 -m src.cli preferences set-toggle variety_after_completion on
+python3.11 -m src.cli preferences set-toggle series_in_order off
+
 # Reset all preferences to defaults
 python3.11 -m src.cli preferences reset
 
@@ -510,15 +514,17 @@ Set length preferences per content type (`short`, `medium`, `long`, or `any`) vi
 
 Items without length metadata (common before enrichment) receive a small benefit-of-the-doubt score rather than being penalized.
 
-### Diversity Bonus
+### Variety After Completion
 
-The diversity bonus encourages genre variety in recommendations. When enabled, items with genres different from your recently completed content get a score boost (calculated via Jaccard distance on genre sets). Configure it per-user:
+Enable the **"Variety after completion"** preference (web UI toggle, or `preferences set-toggle variety_after_completion on` in the CLI) to stop the recommender from marching through the next entry in a genre you just finished — for example, finishing a fantasy book no longer makes the next fantasy book your automatic #1.
 
-- **0.0** (default) — Disabled
-- **0.1–0.3** — Subtle variety
-- **0.5+** — Strong genre-hopping
+When enabled, the genres you most recently *completed* are penalized on a stepped ladder by recency. The most recently finished genre cluster takes an **80%** penalty, and the penalty decays over your last **5 distinct** finished genres (80% → 64% → 48% → 32% → 16%, then nothing). A candidate is penalized by its freshest matching genre, and the penalty multiplies its final score, so a heavily-penalized item still keeps a fraction of its score rather than disappearing.
 
-You can also enable the **"Variety after completion"** preference, which applies a default diversity weight of 0.2 automatically.
+The penalty is **per content type** — finishing a fantasy *book* varies your book recommendations but leaves fantasy *movies* and *games* untouched. Each recommendation surfaces its applied penalty (CLI table/JSON and the web "Score Details" panel) so you can see why a recently finished genre was demoted.
+
+### Diversity Bonus (advanced)
+
+Independently of the variety toggle, an explicit per-user `diversity_weight` (0.0–1.0, default 0.0) adds a mild genre-hopping bonus in the ranker, boosting candidates whose genres differ from your recently completed content (Jaccard distance on genre sets). Leave it at 0.0 unless you want an extra nudge on top of the variety penalty.
 
 ### Ignored Items
 

--- a/resources/css/base.css
+++ b/resources/css/base.css
@@ -1102,6 +1102,17 @@ input[type="checkbox"] {
   transition: width 0.3s ease;
 }
 
+/* Variety penalty row: a deduction, not a positive score. Rendered with the
+   warning colour and a leading minus sign so it does not read as a high score
+   (the "-NN%" text label conveys the meaning without relying on colour). */
+.score-bar-fill-penalty {
+  background: var(--color-warning);
+}
+
+.score-row-penalty .score-value {
+  color: var(--color-warning);
+}
+
 .score-value {
   width: 40px;
   text-align: right;

--- a/resources/js/components/molecules/RecScoreDetails.test.ts
+++ b/resources/js/components/molecules/RecScoreDetails.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import RecScoreDetails from './RecScoreDetails.vue'
+import type { RecommendationResponse } from '@/types/api'
+
+function makeRec(overrides: Partial<RecommendationResponse> = {}): RecommendationResponse {
+  return {
+    db_id: 1,
+    title: 'Test',
+    author: 'Author',
+    score: 0.5,
+    similarity_score: 0,
+    preference_score: 0,
+    reasoning: 'Because',
+    llm_reasoning: null,
+    score_breakdown: { genre_match: 0.8 },
+    variety_penalty: 0,
+    ...overrides,
+  }
+}
+
+describe('RecScoreDetails', () => {
+  it('renders the variety penalty row with a negative percentage label', () => {
+    const wrapper = mount(RecScoreDetails, {
+      props: { rec: makeRec({ variety_penalty: 0.64 }), defaultOpen: true },
+    })
+    const penaltyRow = wrapper.find('.score-row-penalty')
+    expect(penaltyRow.exists()).toBe(true)
+    expect(penaltyRow.text()).toContain('Variety penalty')
+    // Minus sign (U+2212) plus the rounded percentage.
+    expect(penaltyRow.text()).toContain('−64%')
+    const fill = penaltyRow.find('.score-bar-fill-penalty')
+    expect(fill.attributes('style')).toContain('width: 64%')
+  })
+
+  it('omits the variety penalty row when there is no penalty', () => {
+    const wrapper = mount(RecScoreDetails, {
+      props: { rec: makeRec({ variety_penalty: 0 }), defaultOpen: true },
+    })
+    expect(wrapper.find('.score-row-penalty').exists()).toBe(false)
+  })
+
+  it('shows the breakdown details when only a variety penalty is present', () => {
+    const wrapper = mount(RecScoreDetails, {
+      props: {
+        rec: makeRec({ score_breakdown: {}, variety_penalty: 0.8 }),
+        defaultOpen: true,
+      },
+    })
+    expect(wrapper.find('.score-details').exists()).toBe(true)
+    expect(wrapper.find('.score-row-penalty').exists()).toBe(true)
+  })
+})

--- a/resources/js/components/molecules/RecScoreDetails.vue
+++ b/resources/js/components/molecules/RecScoreDetails.vue
@@ -9,11 +9,13 @@ const props = defineProps<{
 }>()
 
 const sortedKeys = computed(() => Object.keys(props.rec.score_breakdown).sort())
+const varietyPenalty = computed(() => props.rec.variety_penalty ?? 0)
+const varietyPenaltyPct = computed(() => Math.round(varietyPenalty.value * 100))
 </script>
 
 <template>
   <details
-    v-if="sortedKeys.length > 0 || (rec.llm_reasoning && rec.reasoning)"
+    v-if="sortedKeys.length > 0 || varietyPenalty > 0 || (rec.llm_reasoning && rec.reasoning)"
     class="score-details"
     :open="defaultOpen"
   >
@@ -21,13 +23,20 @@ const sortedKeys = computed(() => Object.keys(props.rec.score_breakdown).sort())
     <div v-if="rec.llm_reasoning && rec.reasoning" class="rec-reasoning rec-reasoning-folded">
       {{ rec.reasoning }}
     </div>
-    <div v-if="sortedKeys.length > 0" class="score-breakdown">
+    <div v-if="sortedKeys.length > 0 || varietyPenalty > 0" class="score-breakdown">
       <div v-for="key in sortedKeys" :key="key" class="score-row">
         <span class="score-label">{{ formatScorerName(key) }}</span>
-        <div class="score-bar-bg">
+        <div class="score-bar-bg" aria-hidden="true">
           <div class="score-bar-fill" :style="{ width: `${Math.round(rec.score_breakdown[key] * 100)}%` }" />
         </div>
         <span class="score-value">{{ rec.score_breakdown[key].toFixed(2) }}</span>
+      </div>
+      <div v-if="varietyPenalty > 0" class="score-row score-row-penalty">
+        <span class="score-label">Variety penalty</span>
+        <div class="score-bar-bg" aria-hidden="true">
+          <div class="score-bar-fill score-bar-fill-penalty" :style="{ width: `${varietyPenaltyPct}%` }" />
+        </div>
+        <span class="score-value">&minus;{{ varietyPenaltyPct }}%</span>
       </div>
     </div>
   </details>

--- a/resources/js/types/api.ts
+++ b/resources/js/types/api.ts
@@ -27,6 +27,7 @@ export interface RecommendationResponse {
   reasoning: string
   llm_reasoning: string | null
   score_breakdown: Record<string, number>
+  variety_penalty: number
 }
 
 // --- Users ---

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -250,6 +250,7 @@ def recommend(
                         "reasoning": rec["reasoning"],
                         "llm_reasoning": rec.get("llm_reasoning"),
                         "score_breakdown": rec.get("score_breakdown", {}),
+                        "variety_penalty": rec.get("variety_penalty", 0.0),
                     }
                 )
             click.echo(json.dumps(output, indent=2))
@@ -259,13 +260,21 @@ def recommend(
             for i, rec in enumerate(recommendations, 1):
                 item = rec["item"]
                 author = item.author or "N/A"
+                reasoning = rec["reasoning"]
+                penalty = rec.get("variety_penalty", 0.0)
+                if penalty > 0:
+                    # Surface the stepped variety penalty inline so CLI users
+                    # can see why a recently finished genre was demoted.
+                    reasoning = (
+                        f"{reasoning}\n(variety penalty -{round(penalty * 100)}%)"
+                    )
                 table_data.append(
                     [
                         i,
                         item.title,
                         author,
                         f"{rec['score']:.2f}",
-                        rec["reasoning"],
+                        reasoning,
                     ]
                 )
 
@@ -589,6 +598,46 @@ def preferences_set_weight(
     preference_config.scorer_weights[scorer_name] = weight
     storage.save_user_preference_config(user_id, preference_config)
     click.echo(f"Set {scorer_name} weight to {weight} for user {user_id}")
+
+
+# Boolean preference toggles settable from the CLI, mirroring the web UI's
+# TogglePrefs section.  Each name is also the UserPreferenceConfig attribute.
+_TOGGLE_NAMES: tuple[str, ...] = ("series_in_order", "variety_after_completion")
+
+
+@preferences.command("set-toggle")
+@click.argument("toggle_name", type=click.Choice(_TOGGLE_NAMES))
+@click.argument("value", type=click.Choice(["on", "off"], case_sensitive=False))
+@click.option(
+    "--user",
+    "user_id",
+    type=int,
+    default=1,
+    help="User ID",
+)
+@click.pass_context
+def preferences_set_toggle(
+    ctx: click.Context, toggle_name: str, value: str, user_id: int
+) -> None:
+    """Enable or disable a boolean preference toggle.
+
+    TOGGLE_NAME is the setting to change (series_in_order,
+    variety_after_completion).  VALUE is 'on' or 'off'.
+
+    'variety_after_completion' turns on the stepped genre-fatigue penalty:
+    genres you have recently finished are demoted so recommendations vary
+    instead of marching through the next entry in a just-completed series.
+    """
+    enabled = value.lower() == "on"
+    storage = ctx.obj["storage"]
+    preference_config = storage.get_user_preference_config(user_id)
+    # Guard against the allowlist drifting away from the model's bool fields.
+    if not isinstance(getattr(preference_config, toggle_name, None), bool):
+        raise click.ClickException(f"'{toggle_name}' is not a boolean preference")
+    setattr(preference_config, toggle_name, enabled)
+    storage.save_user_preference_config(user_id, preference_config)
+    state = "on" if enabled else "off"
+    click.echo(f"Set {toggle_name} {state} for user {user_id}")
 
 
 @preferences.command("reset")

--- a/src/recommendations/engine.py
+++ b/src/recommendations/engine.py
@@ -37,6 +37,7 @@ from src.recommendations.scorers import (
 )
 from src.recommendations.scoring_pipeline import ScoredCandidate, ScoringPipeline
 from src.recommendations.similarity import _MAX_SIMILARITY_CANDIDATES, SimilarityMatcher
+from src.recommendations.variety import build_variety_ladder, variety_penalty_for
 from src.storage.manager import StorageManager
 from src.utils.series import (
     build_series_tracking,
@@ -69,12 +70,6 @@ _CONTENT_TYPE_NATURAL_LABEL: dict[str, str] = {
     "tv_show": "the TV show",
     "video_game": "the video game",
 }
-
-
-# Default diversity weight applied when variety_after_completion is enabled
-# but the user hasn't set an explicit diversity_weight.  0.2 gives a subtle
-# genre-hopping nudge without overwhelming relevance scores.
-_DEFAULT_VARIETY_DIVERSITY_WEIGHT = 0.2
 
 
 def _shuffle_close_scores(
@@ -371,6 +366,21 @@ class RecommendationEngine:
             recently_completed=consumed_items_of_type,
         )
 
+        # Apply the stepped genre-fatigue variety penalty (issue #74) when the
+        # user has enabled variety_after_completion.  This multiplicatively
+        # demotes candidates whose genre cluster the user recently finished,
+        # so the next entry in a just-completed genre/series no longer
+        # automatically tops the list.  The ladder is built from completed
+        # items of the *same* content type, so finishing a fantasy book does
+        # not suppress fantasy movies or games — each type varies independently.
+        if (
+            user_preference_config is not None
+            and user_preference_config.variety_after_completion
+        ):
+            ranked_items = self._apply_variety_penalty(
+                ranked_items, consumed_items_of_type
+            )
+
         top_recommendations = ranked_items[:count]
 
         # Format recommendations
@@ -574,10 +584,12 @@ class RecommendationEngine:
         self,
         user_preference_config: UserPreferenceConfig | None,
     ) -> RecommendationRanker:
-        """Configure a ranker with per-user diversity weight if applicable.
+        """Configure a ranker with the user's explicit diversity weight.
 
-        Uses the user's explicit diversity_weight, or applies a sensible
-        default when variety_after_completion is enabled.
+        The ranker's additive genre-diversity bonus is only applied when the
+        user has explicitly set ``diversity_weight`` above zero.  The
+        ``variety_after_completion`` toggle drives the stepped genre-fatigue
+        penalty (see :meth:`_apply_variety_penalty`) rather than this bonus.
 
         Args:
             user_preference_config: Optional per-user preference config.
@@ -588,21 +600,52 @@ class RecommendationEngine:
         if user_preference_config is None:
             return self.ranker
 
-        effective_diversity_weight = user_preference_config.diversity_weight
-        if (
-            user_preference_config.variety_after_completion
-            and effective_diversity_weight == 0
-        ):
-            effective_diversity_weight = _DEFAULT_VARIETY_DIVERSITY_WEIGHT
-
-        if effective_diversity_weight > 0:
+        if user_preference_config.diversity_weight > 0:
             return RecommendationRanker(
                 similarity_weight=self.ranker.similarity_weight,
                 preference_weight=self.ranker.preference_weight,
-                diversity_weight=effective_diversity_weight,
+                diversity_weight=user_preference_config.diversity_weight,
             )
 
         return self.ranker
+
+    @staticmethod
+    def _apply_variety_penalty(
+        ranked_items: list[tuple[ContentItem, float, dict[str, Any]]],
+        completed_items_of_type: list[ContentItem],
+    ) -> list[tuple[ContentItem, float, dict[str, Any]]]:
+        """Apply the stepped genre-fatigue penalty and re-sort (issue #74).
+
+        Builds a cluster -> penalty ladder from the user's recently completed
+        items *of the content type being recommended*, then multiplies each
+        candidate's score by ``1 - penalty`` where the penalty is the strongest
+        among the candidate's recently finished genre clusters.  Scoping the
+        ladder to a single content type keeps genres varying independently per
+        type — finishing a fantasy book does not penalise fantasy movies or
+        games.  The applied penalty is recorded under ``"variety_penalty"`` in
+        each item's rank metadata for display.
+
+        Args:
+            ranked_items: ``(item, score, metadata)`` tuples from the ranker.
+            completed_items_of_type: Completed items of the recommended content
+                type, used to build the ladder.
+
+        Returns:
+            Re-sorted ``(item, score, metadata)`` tuples with the penalty
+            applied.  Returns the input unchanged when the ladder is empty.
+        """
+        ladder = build_variety_ladder(completed_items_of_type)
+        if not ladder:
+            return ranked_items
+
+        penalised: list[tuple[ContentItem, float, dict[str, Any]]] = []
+        for item, score, metadata in ranked_items:
+            penalty = variety_penalty_for(item, ladder)
+            updated_metadata = {**metadata, "variety_penalty": penalty}
+            penalised.append((item, score * (1.0 - penalty), updated_metadata))
+
+        penalised.sort(key=lambda entry: entry[1], reverse=True)
+        return penalised
 
     def _format_recommendations(
         self,
@@ -649,6 +692,7 @@ class RecommendationEngine:
                     contributing_list,
                 ),
                 "score_breakdown": breakdown_by_id.get(item.id, {}),
+                "variety_penalty": rank_metadata.get("variety_penalty", 0.0),
                 "contributing_items": contributing_list,
                 "adaptations": adaptations_list,
             }
@@ -753,6 +797,7 @@ class RecommendationEngine:
                                 "reasoning": llm_rec.get("reasoning", ""),
                                 "llm_reasoning": llm_rec.get("reasoning", ""),
                                 "score_breakdown": {},
+                                "variety_penalty": 0.0,
                             }
                         )
         except Exception as error:
@@ -823,6 +868,7 @@ class RecommendationEngine:
                         "preference_score": 0.0,
                         "reasoning": "Available in your library",
                         "score_breakdown": {},
+                        "variety_penalty": 0.0,
                     }
                 )
                 if len(recommendations) >= count:

--- a/src/recommendations/variety.py
+++ b/src/recommendations/variety.py
@@ -1,0 +1,126 @@
+"""Genre-fatigue variety penalty applied after completing content.
+
+When ``variety_after_completion`` is enabled, recently finished genres are
+penalised on a stepped ladder so the recommender hops between genres instead
+of marching through the next entry in the genre/series the user just finished.
+
+The ladder is built from the user's COMPLETED items ordered by completion date
+(newest first). Each distinct thematic genre cluster encountered claims the
+next rung; the most recently finished cluster receives the strongest penalty
+and the penalty decays linearly to zero over :data:`VARIETY_LADDER_STEPS`
+rungs. A candidate is penalised by the strongest penalty among the clusters it
+shares with the ladder (i.e. its freshest matching genre).
+
+The penalty is multiplicative on a candidate's final score: a penalty of
+``0.8`` multiplies the score by ``0.2``. Because the top penalty is below
+``1.0``, a fully-penalised candidate still keeps a fraction of its score, so a
+genre-homogeneous library never produces an empty recommendation list.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from src.models.content import ConsumptionStatus, ContentItem
+from src.recommendations.genre_clusters import get_clusters_for_terms
+from src.recommendations.genre_normalizer import extract_and_normalize_genres
+
+# Strongest penalty, applied to the most recently finished genre cluster.
+# 0.8 => candidates in that cluster keep 20% of their score: a hard but not
+# total suppression, so genre-homogeneous libraries never return an empty list.
+VARIETY_TOP_PENALTY = 0.8
+
+# Number of distinct recently finished clusters the penalty ladder spans.
+# Penalty decays linearly: rung 0 = TOP, rung STEPS-1 = TOP/STEPS, rung STEPS+ = 0.
+VARIETY_LADDER_STEPS = 5
+
+
+def _completion_sort_key(item: ContentItem) -> tuple[bool, date, int]:
+    """Sort key ordering completed items newest-first.
+
+    Items with a known ``date_completed`` sort before those without; among
+    dated items the most recent comes first; ``db_id`` breaks ties so the
+    ordering is deterministic. Used with ``reverse=True``.
+
+    Args:
+        item: A completed content item.
+
+    Returns:
+        Tuple ``(has_date, date, db_id)`` for descending sort.
+    """
+    return (
+        item.date_completed is not None,
+        item.date_completed or date.min,
+        item.db_id or 0,
+    )
+
+
+def build_variety_ladder(
+    completed_items: list[ContentItem],
+    *,
+    steps: int = VARIETY_LADDER_STEPS,
+    top_penalty: float = VARIETY_TOP_PENALTY,
+) -> dict[str, float]:
+    """Build a cluster -> penalty ladder from recently completed items.
+
+    Only items with status :attr:`ConsumptionStatus.COMPLETED` contribute —
+    items the user is actively consuming do not represent a *finished* genre.
+    Items are scanned newest-first; each distinct thematic cluster claims the
+    next rung until ``steps`` distinct clusters have been recorded. Rung ``i``
+    receives penalty ``top_penalty * (steps - i) / steps``.
+
+    Args:
+        completed_items: Consumed items (across content types). Non-completed
+            items are ignored.
+        steps: Number of distinct clusters the ladder spans.
+        top_penalty: Penalty for the most recently finished cluster.
+
+    Returns:
+        Mapping of cluster name to penalty in ``(0, top_penalty]``. Empty when
+        no completed items carry a recognised genre cluster.
+    """
+    if steps <= 0:
+        return {}
+
+    completed = [
+        item for item in completed_items if item.status == ConsumptionStatus.COMPLETED
+    ]
+    completed.sort(key=_completion_sort_key, reverse=True)
+
+    ladder: dict[str, float] = {}
+    for item in completed:
+        if len(ladder) >= steps:
+            break
+        clusters = get_clusters_for_terms(extract_and_normalize_genres(item.metadata))
+        # Sort for deterministic rung assignment when a single item belongs
+        # to several clusters (e.g. a fantasy-adventure novel).
+        for cluster in sorted(clusters):
+            if cluster in ladder:
+                continue
+            rung = len(ladder)
+            ladder[cluster] = top_penalty * (steps - rung) / steps
+            if len(ladder) >= steps:
+                break
+
+    return ladder
+
+
+def variety_penalty_for(item: ContentItem, ladder: dict[str, float]) -> float:
+    """Return the variety penalty for *item* given a penalty *ladder*.
+
+    The penalty is the strongest among the clusters the candidate shares with
+    the ladder — i.e. the candidate is judged by its freshest matching genre.
+
+    Args:
+        item: Candidate item being scored.
+        ladder: Cluster -> penalty mapping from :func:`build_variety_ladder`.
+
+    Returns:
+        Penalty in ``[0, top_penalty]``; ``0.0`` when no cluster matches.
+    """
+    if not ladder:
+        return 0.0
+    clusters = get_clusters_for_terms(extract_and_normalize_genres(item.metadata))
+    return max(
+        (ladder[cluster] for cluster in clusters if cluster in ladder), default=0.0
+    )

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -158,6 +158,37 @@ class RecommendationResponse(BaseModel):
     reasoning: str
     llm_reasoning: str | None = None
     score_breakdown: dict[str, float] = Field(default_factory=dict)
+    # Stepped genre-fatigue penalty applied when variety_after_completion is
+    # enabled (0.0 when off or the item's genre was not recently finished).
+    variety_penalty: float = Field(0.0, ge=0.0, le=1.0)
+
+
+def _recommendation_payload(rec: dict[str, Any]) -> dict[str, Any]:
+    """Build the common RecommendationResponse field mapping from a rec dict.
+
+    Shared by the synchronous endpoint and the SSE Phase 1 payload so the two
+    serialization paths cannot drift.  The caller supplies ``llm_reasoning``
+    separately: the synchronous endpoint passes the rec's value, while the SSE
+    Phase 1 payload forces ``None`` because blurbs stream in later.
+
+    Args:
+        rec: A recommendation dict produced by the engine.
+
+    Returns:
+        Mapping of RecommendationResponse fields (excluding ``llm_reasoning``).
+    """
+    item = rec["item"]
+    return {
+        "db_id": item.db_id,
+        "title": item.title,
+        "author": item.author,
+        "score": rec["score"],
+        "similarity_score": rec["similarity_score"],
+        "preference_score": rec["preference_score"],
+        "reasoning": rec["reasoning"],
+        "score_breakdown": rec.get("score_breakdown", {}),
+        "variety_penalty": rec.get("variety_penalty", 0.0),
+    }
 
 
 class FeaturesStatus(BaseModel):
@@ -550,18 +581,10 @@ async def get_recommendations(
         # Format response
         response = []
         for rec in recommendations:
-            item = rec["item"]
             response.append(
                 RecommendationResponse(
-                    db_id=item.db_id,
-                    title=item.title,
-                    author=item.author,
-                    score=rec["score"],
-                    similarity_score=rec["similarity_score"],
-                    preference_score=rec["preference_score"],
-                    reasoning=rec["reasoning"],
+                    **_recommendation_payload(rec),
                     llm_reasoning=rec.get("llm_reasoning"),
-                    score_breakdown=rec.get("score_breakdown", {}),
                 )
             )
 
@@ -645,19 +668,8 @@ async def stream_recommendations(
             # Phase 1: send recommendations immediately (no LLM reasoning)
             items_payload: list[dict[str, Any]] = []
             for rec in recommendations:
-                item = rec["item"]
                 items_payload.append(
-                    {
-                        "db_id": item.db_id,
-                        "title": item.title,
-                        "author": item.author,
-                        "score": rec["score"],
-                        "similarity_score": rec["similarity_score"],
-                        "preference_score": rec["preference_score"],
-                        "reasoning": rec["reasoning"],
-                        "llm_reasoning": None,
-                        "score_breakdown": rec.get("score_breakdown", {}),
-                    }
+                    {**_recommendation_payload(rec), "llm_reasoning": None}
                 )
             event: dict[str, Any] = {
                 "type": "recommendations",

--- a/src/web/static/themes/snowstorm/colors.css
+++ b/src/web/static/themes/snowstorm/colors.css
@@ -28,9 +28,11 @@
     --border-subtle: #d8dee9;
     --border-focus: var(--accent);
 
-    /* Semantic colors — adjusted for light backgrounds */
+    /* Semantic colors — adjusted for light backgrounds. Warning is a dark
+       amber so warning text clears 4.5:1 on the white card and warning bars
+       clear 3:1 on the default border track (WCAG 1.4.3 / 1.4.11). */
     --color-success: #5a8a4a;
-    --color-warning: #bf8c20;
+    --color-warning: #7a5a00;
     --color-error: #b04850;
     --color-info: var(--accent);
 

--- a/tests/cli/test_cli_recommend.py
+++ b/tests/cli/test_cli_recommend.py
@@ -168,6 +168,7 @@ class TestRecommendJsonOutput:
             "reasoning",
             "llm_reasoning",
             "score_breakdown",
+            "variety_penalty",
         }
         assert rec["db_id"] == 42
         assert rec["llm_reasoning"] == "LLM says so"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,6 +193,92 @@ def test_recommend_command_json(mock_components):
     assert '"score"' in result.output
 
 
+def test_recommend_command_surfaces_variety_penalty(mock_components):
+    """The variety penalty appears in JSON output and the table reasoning."""
+    mock_item = ContentItem(
+        id="1",
+        title="Penalised Book",
+        author="Author",
+        content_type=ContentType.BOOK,
+        status=ConsumptionStatus.UNREAD,
+    )
+    mock_recommendations = [
+        {
+            "item": mock_item,
+            "score": 0.2,
+            "similarity_score": 0.5,
+            "preference_score": 0.5,
+            "reasoning": "Recommended",
+            "variety_penalty": 0.64,
+        }
+    ]
+    mock_components["storage"].get_completed_items.return_value = [
+        ContentItem(
+            id="2",
+            title="Read",
+            author="Author",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+        )
+    ]
+    mock_components["storage"].get_unconsumed_items.return_value = [mock_item]
+    mock_components["engine"].generate_recommendations.return_value = (
+        mock_recommendations
+    )
+
+    runner = CliRunner()
+    json_result = runner.invoke(
+        cli, ["recommend", "--type", "book", "--count", "1", "--format", "json"]
+    )
+    assert json_result.exit_code == 0
+    assert '"variety_penalty": 0.64' in json_result.output
+
+    table_result = runner.invoke(cli, ["recommend", "--type", "book", "--count", "1"])
+    assert table_result.exit_code == 0
+    assert "variety penalty -64%" in table_result.output
+
+
+def test_recommend_command_omits_zero_variety_penalty_note(mock_components):
+    """A zero penalty adds no note to the table reasoning."""
+    mock_item = ContentItem(
+        id="1",
+        title="Plain Book",
+        author="Author",
+        content_type=ContentType.BOOK,
+        status=ConsumptionStatus.UNREAD,
+    )
+    mock_recommendations = [
+        {
+            "item": mock_item,
+            "score": 0.85,
+            "similarity_score": 0.5,
+            "preference_score": 0.5,
+            "reasoning": "Recommended",
+            "variety_penalty": 0.0,
+        }
+    ]
+    mock_components["storage"].get_completed_items.return_value = [
+        ContentItem(
+            id="2",
+            title="Read",
+            author="Author",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+        )
+    ]
+    mock_components["storage"].get_unconsumed_items.return_value = [mock_item]
+    mock_components["engine"].generate_recommendations.return_value = (
+        mock_recommendations
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["recommend", "--type", "book", "--count", "1"])
+    assert result.exit_code == 0
+    assert "variety penalty" not in result.output
+
+
 def test_update_command_help(mock_components):
     """Test update command help."""
     runner = CliRunner()
@@ -788,6 +874,45 @@ def test_preferences_set_weight(mock_components):
     assert result.exit_code == 0
     assert "Set genre_match weight to 3.0" in result.output
     mock_components["storage"].save_user_preference_config.assert_called_once()
+
+
+def test_preferences_set_toggle_on(mock_components):
+    """Test enabling variety_after_completion via set-toggle."""
+    config = UserPreferenceConfig()
+    mock_components["storage"].get_user_preference_config = Mock(return_value=config)
+    mock_components["storage"].save_user_preference_config = Mock()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["preferences", "set-toggle", "variety_after_completion", "on"]
+    )
+
+    assert result.exit_code == 0
+    assert "Set variety_after_completion on" in result.output
+    assert config.variety_after_completion is True
+    mock_components["storage"].save_user_preference_config.assert_called_once()
+
+
+def test_preferences_set_toggle_off(mock_components):
+    """Test disabling a toggle via set-toggle."""
+    config = UserPreferenceConfig(series_in_order=True)
+    mock_components["storage"].get_user_preference_config = Mock(return_value=config)
+    mock_components["storage"].save_user_preference_config = Mock()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["preferences", "set-toggle", "series_in_order", "off"])
+
+    assert result.exit_code == 0
+    assert "Set series_in_order off" in result.output
+    assert config.series_in_order is False
+
+
+def test_preferences_set_toggle_rejects_unknown_name(mock_components):
+    """An unknown toggle name is rejected by the Click choice."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["preferences", "set-toggle", "not_a_toggle", "on"])
+
+    assert result.exit_code != 0
 
 
 def test_preferences_reset(mock_components):

--- a/tests/test_recommendation_engine.py
+++ b/tests/test_recommendation_engine.py
@@ -1,5 +1,6 @@
 """Tests for recommendation engine cross-content-type recommendations."""
 
+from datetime import date
 from unittest.mock import Mock
 
 import pytest
@@ -1561,27 +1562,43 @@ class TestShuffleCloseScores:
             }
 
 
-class TestVarietyAfterCompletion:
-    """Tests for the variety_after_completion toggle wiring."""
+def _variety_score_for(recs: list[dict], item_id: str) -> float:
+    """Return the score of the recommendation with *item_id* (0.0 if absent)."""
+    for rec in recs:
+        if rec["item"].id == item_id:
+            return rec["score"]
+    return 0.0
 
-    def test_variety_toggle_enables_diversity_bonus(
+
+def _variety_rank_of(recs: list[dict], item_id: str) -> int:
+    """Return the index of *item_id* in *recs* (len(recs) if absent)."""
+    for index, rec in enumerate(recs):
+        if rec["item"].id == item_id:
+            return index
+    return len(recs)
+
+
+class TestVarietyAfterCompletion:
+    """Behavioural tests for the variety_after_completion genre-fatigue penalty.
+
+    The variety toggle drives a stepped penalty that demotes candidates whose
+    genre cluster the user recently finished. The issue #74 bug regression
+    lives in :class:`TestVarietyAfterCompletionRegression`.
+    """
+
+    def test_variety_penalty_demotes_recently_finished_genre(
         self, non_ai_engine, mock_storage
     ) -> None:
-        """variety_after_completion=True should boost genre-diverse items.
-
-        When a user has completed Sci-Fi items and variety is enabled,
-        a Mystery candidate should be boosted relative to another Sci-Fi
-        candidate compared to when variety is disabled.
-        """
+        """Enabling variety lowers a just-finished genre's candidate score."""
         consumed = ContentItem(
             id="consumed_1",
             title="Dune",
             content_type=ContentType.BOOK,
             status=ConsumptionStatus.COMPLETED,
             rating=5,
+            date_completed=date(2026, 1, 1),
             metadata={"genres": ["Science Fiction"]},
         )
-
         same_genre = ContentItem(
             id="same_genre",
             title="Foundation",
@@ -1590,9 +1607,227 @@ class TestVarietyAfterCompletion:
             metadata={"genres": ["Science Fiction"]},
         )
 
+        mock_storage.get_completed_items = Mock(
+            side_effect=lambda content_type=None, **kwargs: [consumed]
+        )
+        mock_storage.get_unconsumed_items = Mock(return_value=[same_genre])
+
+        recs_off = non_ai_engine.generate_recommendations(
+            content_type=ContentType.BOOK,
+            count=1,
+            user_preference_config=UserPreferenceConfig(variety_after_completion=False),
+        )
+        recs_on = non_ai_engine.generate_recommendations(
+            content_type=ContentType.BOOK,
+            count=1,
+            user_preference_config=UserPreferenceConfig(variety_after_completion=True),
+        )
+
+        score_off = _variety_score_for(recs_off, "same_genre")
+        score_on = _variety_score_for(recs_on, "same_genre")
+        # Top penalty 0.8 => ~20% of the original score retained.
+        assert score_on == pytest.approx(score_off * 0.2, rel=1e-6)
+        assert recs_on[0]["variety_penalty"] == pytest.approx(0.8)
+        assert recs_off[0]["variety_penalty"] == 0.0
+
+    def test_variety_penalty_steps_by_recency(
+        self, non_ai_engine, mock_storage
+    ) -> None:
+        """The most recently finished genre is penalised more than an older one.
+
+        Finishing fantasy then sci-fi puts sci-fi on the top rung (0.8) and
+        fantasy on the next rung (0.64), so a fantasy candidate outranks a
+        sci-fi candidate even though sci-fi was also recently finished.
+        """
+        finished_fantasy = ContentItem(
+            id="finished_fantasy",
+            title="The Hobbit",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            date_completed=date(2026, 1, 1),
+            metadata={"genres": ["Fantasy"]},
+        )
+        finished_scifi = ContentItem(
+            id="finished_scifi",
+            title="Dune",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            date_completed=date(2026, 1, 2),  # more recent
+            metadata={"genres": ["Science Fiction"]},
+        )
+        fantasy_candidate = ContentItem(
+            id="fantasy_candidate",
+            title="The Name of the Wind",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"genres": ["Fantasy"]},
+        )
+        scifi_candidate = ContentItem(
+            id="scifi_candidate",
+            title="Hyperion",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"genres": ["Science Fiction"]},
+        )
+
+        mock_storage.get_completed_items = Mock(
+            side_effect=lambda content_type=None, **kwargs: [
+                finished_fantasy,
+                finished_scifi,
+            ]
+        )
+        mock_storage.get_unconsumed_items = Mock(
+            return_value=[fantasy_candidate, scifi_candidate]
+        )
+
+        recs = non_ai_engine.generate_recommendations(
+            content_type=ContentType.BOOK,
+            count=2,
+            user_preference_config=UserPreferenceConfig(variety_after_completion=True),
+        )
+
+        # Sci-fi finished most recently => stronger penalty => ranked lower.
+        assert _variety_rank_of(recs, "fantasy_candidate") < _variety_rank_of(
+            recs, "scifi_candidate"
+        )
+        fantasy_penalty = next(
+            rec["variety_penalty"]
+            for rec in recs
+            if rec["item"].id == "fantasy_candidate"
+        )
+        scifi_penalty = next(
+            rec["variety_penalty"]
+            for rec in recs
+            if rec["item"].id == "scifi_candidate"
+        )
+        assert scifi_penalty == pytest.approx(0.8)
+        assert fantasy_penalty == pytest.approx(0.64)
+
+    def test_variety_penalty_is_per_content_type(
+        self, non_ai_engine, mock_storage
+    ) -> None:
+        """Finishing a fantasy book must not penalise a fantasy game.
+
+        The penalty ladder is scoped to completed items of the content type
+        being recommended, so genres vary independently per type.
+        """
+        finished_book = ContentItem(
+            id="finished_book",
+            title="The Hobbit",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            date_completed=date(2026, 1, 1),
+            metadata={"genres": ["Fantasy"]},
+        )
+        fantasy_game = ContentItem(
+            id="fantasy_game",
+            title="Baldur's Gate 3",
+            content_type=ContentType.VIDEO_GAME,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"genres": ["Fantasy"]},
+        )
+
+        def completed_items(content_type=None, **kwargs):
+            # Cross-type preference analysis sees the book; the game-type
+            # query (used to build the ladder) sees no completed games.
+            if content_type is None or content_type == ContentType.BOOK:
+                return [finished_book]
+            return []
+
+        mock_storage.get_completed_items = Mock(side_effect=completed_items)
+        mock_storage.get_unconsumed_items = Mock(return_value=[fantasy_game])
+
+        recs = non_ai_engine.generate_recommendations(
+            content_type=ContentType.VIDEO_GAME,
+            count=1,
+            user_preference_config=UserPreferenceConfig(variety_after_completion=True),
+        )
+
+        # No completed games => empty ladder => the fantasy game is untouched.
+        assert recs[0]["item"].id == "fantasy_game"
+        assert recs[0]["variety_penalty"] == 0.0
+
+    def test_no_variety_no_penalty(self, non_ai_engine, mock_storage) -> None:
+        """With variety disabled, no penalty is recorded on recommendations."""
+        consumed = ContentItem(
+            id="consumed_1",
+            title="Dune",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            date_completed=date(2026, 1, 1),
+            metadata={"genres": ["Science Fiction"]},
+        )
+        candidate = ContentItem(
+            id="candidate_1",
+            title="Foundation",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"genres": ["Science Fiction"]},
+        )
+
+        mock_storage.get_completed_items = Mock(
+            side_effect=lambda content_type=None, **kwargs: [consumed]
+        )
+        mock_storage.get_unconsumed_items = Mock(return_value=[candidate])
+
+        recs = non_ai_engine.generate_recommendations(
+            content_type=ContentType.BOOK,
+            count=1,
+            user_preference_config=UserPreferenceConfig(variety_after_completion=False),
+        )
+        assert recs[0]["variety_penalty"] == 0.0
+
+
+class TestVarietyAfterCompletionRegression:
+    """Regression tests for the variety_after_completion feature (issue #74)."""
+
+    def test_next_in_series_demoted_when_variety_enabled_regression(
+        self, non_ai_engine, mock_storage
+    ) -> None:
+        """The next book in a just-finished series must not be #1 with variety on.
+
+        Reported: 'Finished a book, setting turned on, new number 1
+        recommendation is the next book in the series.'
+
+        Root cause: variety_after_completion only nudged the legacy ranker's
+        weak additive diversity bonus, which could not overcome the strong
+        SeriesOrderScorer (next-in-series scores 1.0).
+
+        Fix: variety now multiplicatively penalises recently finished genre
+        clusters, demoting the next-in-series fantasy book below a
+        different-genre candidate.
+        """
+        consumed = ContentItem(
+            id="dragonlance_1",
+            title="Dragonlance: Dragons of Autumn Twilight",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            date_completed=date(2026, 1, 1),
+            metadata={
+                "franchise": "Dragonlance",
+                "series_position": 1,
+                "genres": ["Fantasy"],
+            },
+        )
+        next_in_series = ContentItem(
+            id="dragonlance_2",
+            title="Dragonlance: Dragons of Winter Night",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.UNREAD,
+            metadata={
+                "franchise": "Dragonlance",
+                "series_position": 2,
+                "genres": ["Fantasy"],
+            },
+        )
         different_genre = ContentItem(
-            id="diff_genre",
-            title="Sherlock Holmes",
+            id="mystery_book",
+            title="The Hound of the Baskervilles",
             content_type=ContentType.BOOK,
             status=ConsumptionStatus.UNREAD,
             metadata={"genres": ["Mystery"]},
@@ -1602,97 +1837,26 @@ class TestVarietyAfterCompletion:
             side_effect=lambda content_type=None, **kwargs: [consumed]
         )
         mock_storage.get_unconsumed_items = Mock(
-            return_value=[same_genre, different_genre]
+            return_value=[next_in_series, different_genre]
         )
 
-        # Without variety: get baseline scores
-        prefs_no_variety = UserPreferenceConfig(variety_after_completion=False)
-        recs_no_variety = non_ai_engine.generate_recommendations(
+        # Without variety: the next-in-series fantasy book tops the list (bug).
+        recs_off = non_ai_engine.generate_recommendations(
             content_type=ContentType.BOOK,
             count=2,
-            user_preference_config=prefs_no_variety,
+            user_preference_config=UserPreferenceConfig(variety_after_completion=False),
         )
+        assert recs_off[0]["item"].id == "dragonlance_2"
 
-        # With variety: genre-diverse item should get a boost
-        prefs_with_variety = UserPreferenceConfig(variety_after_completion=True)
-        recs_with_variety = non_ai_engine.generate_recommendations(
+        # With variety: the fantasy continuation is demoted below the mystery.
+        recs_on = non_ai_engine.generate_recommendations(
             content_type=ContentType.BOOK,
             count=2,
-            user_preference_config=prefs_with_variety,
+            user_preference_config=UserPreferenceConfig(variety_after_completion=True),
         )
-
-        # Find the different-genre item's score in each run
-        def score_for(recs: list[dict], item_id: str) -> float:
-            for rec in recs:
-                if rec["item"].id == item_id:
-                    return rec["score"]
-            return 0.0
-
-        diff_score_without = score_for(recs_no_variety, "diff_genre")
-        diff_score_with = score_for(recs_with_variety, "diff_genre")
-
-        # The diversity bonus should increase the different-genre item's score
-        assert diff_score_with > diff_score_without, (
-            f"Expected variety toggle to boost genre-diverse item: "
-            f"without={diff_score_without:.4f}, with={diff_score_with:.4f}"
-        )
-
-    def test_variety_toggle_respects_explicit_diversity_weight(
-        self, non_ai_engine, mock_storage
-    ) -> None:
-        """When diversity_weight is explicitly set, variety toggle doesn't override it."""
-        consumed = ContentItem(
-            id="consumed_1",
-            title="Dune",
-            content_type=ContentType.BOOK,
-            status=ConsumptionStatus.COMPLETED,
-            rating=5,
-            metadata={"genres": ["Science Fiction"]},
-        )
-
-        candidate = ContentItem(
-            id="candidate_1",
-            title="Sherlock Holmes",
-            content_type=ContentType.BOOK,
-            status=ConsumptionStatus.UNREAD,
-            metadata={"genres": ["Mystery"]},
-        )
-
-        mock_storage.get_completed_items = Mock(
-            side_effect=lambda content_type=None, **kwargs: [consumed]
-        )
-        mock_storage.get_unconsumed_items = Mock(return_value=[candidate])
-
-        # Explicit diversity_weight=0.5 with variety toggle on
-        prefs_explicit = UserPreferenceConfig(
-            variety_after_completion=True,
-            diversity_weight=0.5,
-        )
-        recs_explicit = non_ai_engine.generate_recommendations(
-            content_type=ContentType.BOOK,
-            count=1,
-            user_preference_config=prefs_explicit,
-        )
-
-        # Variety toggle on with default (0.0) diversity_weight → uses 0.2
-        prefs_default = UserPreferenceConfig(
-            variety_after_completion=True,
-            diversity_weight=0.0,
-        )
-        recs_default = non_ai_engine.generate_recommendations(
-            content_type=ContentType.BOOK,
-            count=1,
-            user_preference_config=prefs_default,
-        )
-
-        # The explicit 0.5 weight should produce a higher score than the
-        # default 0.2 that the toggle applies
-        score_explicit = recs_explicit[0]["score"]
-        score_default = recs_default[0]["score"]
-        assert score_explicit > score_default, (
-            f"Expected explicit diversity_weight=0.5 to produce higher score "
-            f"than default 0.2: explicit={score_explicit:.4f}, "
-            f"default={score_default:.4f}"
+        assert recs_on[0]["item"].id == "mystery_book"
+        assert _variety_rank_of(recs_on, "mystery_book") < _variety_rank_of(
+            recs_on, "dragonlance_2"
         )
 
 

--- a/tests/test_variety.py
+++ b/tests/test_variety.py
@@ -1,0 +1,215 @@
+"""Unit tests for the genre-fatigue variety penalty (issue #74).
+
+These tests document the stepped penalty ladder built from recently completed
+content and the penalty looked up for a candidate. They cover completion-date
+ordering, distinct-cluster stepping, the exact stepped percentages, and the
+COMPLETED-only filter.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from src.models.content import ConsumptionStatus, ContentItem, ContentType
+from src.recommendations.variety import (
+    VARIETY_LADDER_STEPS,
+    VARIETY_TOP_PENALTY,
+    build_variety_ladder,
+    variety_penalty_for,
+)
+
+
+def _completed(
+    title: str,
+    genres: list[str],
+    *,
+    completed_on: date | None = None,
+    db_id: int | None = None,
+    status: ConsumptionStatus = ConsumptionStatus.COMPLETED,
+) -> ContentItem:
+    """Build a completed book item carrying *genres* in metadata."""
+    return ContentItem(
+        id=title.lower().replace(" ", "_"),
+        db_id=db_id,
+        title=title,
+        content_type=ContentType.BOOK,
+        status=status,
+        date_completed=completed_on,
+        metadata={"genres": genres},
+    )
+
+
+def _candidate(title: str, genres: list[str]) -> ContentItem:
+    """Build an unread candidate book item carrying *genres* in metadata."""
+    return ContentItem(
+        id=title.lower().replace(" ", "_"),
+        title=title,
+        content_type=ContentType.BOOK,
+        status=ConsumptionStatus.UNREAD,
+        metadata={"genres": genres},
+    )
+
+
+class TestBuildVarietyLadder:
+    """Tests for :func:`build_variety_ladder`."""
+
+    def test_empty_when_no_completed_items(self) -> None:
+        assert build_variety_ladder([]) == {}
+
+    def test_single_cluster_gets_top_penalty(self) -> None:
+        ladder = build_variety_ladder(
+            [_completed("Mistborn", ["Fantasy"], completed_on=date(2026, 1, 1))]
+        )
+        assert ladder == {"fantasy": pytest.approx(VARIETY_TOP_PENALTY)}
+
+    def test_stepped_percentages_descend_by_recency(self) -> None:
+        """The documented ladder: 80 / 64 / 48 / 32 / 16 percent."""
+        items = [
+            _completed("Bio", ["Biography"], completed_on=date(2026, 1, 5)),
+            _completed("Crime", ["Mystery"], completed_on=date(2026, 1, 4)),
+            _completed("Space", ["Science Fiction"], completed_on=date(2026, 1, 3)),
+            _completed("Dragons", ["Fantasy"], completed_on=date(2026, 1, 2)),
+            _completed("West", ["Western"], completed_on=date(2026, 1, 1)),
+        ]
+        ladder = build_variety_ladder(items)
+
+        # Newest first: biography strongest, western weakest.
+        assert ladder["nonfiction_documentary"] == pytest.approx(0.80)
+        assert ladder["crime_thriller"] == pytest.approx(0.64)
+        assert ladder["science_fiction"] == pytest.approx(0.48)
+        assert ladder["fantasy"] == pytest.approx(0.32)
+        assert ladder["western"] == pytest.approx(0.16)
+
+    def test_ladder_capped_at_step_count(self) -> None:
+        """A sixth distinct cluster is beyond the ladder and is not recorded."""
+        items = [
+            _completed("F", ["Fantasy"], completed_on=date(2026, 1, 6)),
+            _completed("S", ["Science Fiction"], completed_on=date(2026, 1, 5)),
+            _completed("M", ["Mystery"], completed_on=date(2026, 1, 4)),
+            _completed("B", ["Biography"], completed_on=date(2026, 1, 3)),
+            _completed("W", ["Western"], completed_on=date(2026, 1, 2)),
+            _completed("H", ["Horror"], completed_on=date(2026, 1, 1)),
+        ]
+        ladder = build_variety_ladder(items)
+        assert len(ladder) == VARIETY_LADDER_STEPS
+        # The five freshest clusters are recorded; the sixth is dropped.
+        assert set(ladder) == {
+            "fantasy",
+            "science_fiction",
+            "crime_thriller",
+            "nonfiction_documentary",
+            "western",
+        }
+        assert "horror_dark" not in ladder
+
+    def test_duplicate_clusters_collapse_to_one_rung(self) -> None:
+        """Finishing two fantasy books does not consume two rungs."""
+        items = [
+            _completed("Fantasy A", ["Fantasy"], completed_on=date(2026, 1, 3)),
+            _completed("Fantasy B", ["Fantasy"], completed_on=date(2026, 1, 2)),
+            _completed("Sci", ["Science Fiction"], completed_on=date(2026, 1, 1)),
+        ]
+        ladder = build_variety_ladder(items)
+        assert len(ladder) == 2
+        assert ladder["fantasy"] == pytest.approx(VARIETY_TOP_PENALTY)
+        # Sci-fi is the second *distinct* cluster -> rung 1, not rung 2.
+        assert ladder["science_fiction"] == pytest.approx(0.64)
+
+    def test_db_id_breaks_ties_for_same_completion_date(self) -> None:
+        """With equal dates, the higher db_id is treated as the most recent."""
+        items = [
+            _completed("Older", ["Fantasy"], completed_on=date(2026, 1, 1), db_id=1),
+            _completed(
+                "Newer", ["Science Fiction"], completed_on=date(2026, 1, 1), db_id=2
+            ),
+        ]
+        ladder = build_variety_ladder(items)
+        assert ladder["science_fiction"] == pytest.approx(VARIETY_TOP_PENALTY)
+        assert ladder["fantasy"] == pytest.approx(0.64)
+
+    def test_unread_items_excluded(self) -> None:
+        """Only COMPLETED items contribute to the ladder."""
+        items = [
+            _completed(
+                "Wishlist",
+                ["Fantasy"],
+                completed_on=date(2026, 1, 2),
+                status=ConsumptionStatus.UNREAD,
+            ),
+            _completed("Done", ["Science Fiction"], completed_on=date(2026, 1, 1)),
+        ]
+        ladder = build_variety_ladder(items)
+        assert "fantasy" not in ladder
+        assert ladder["science_fiction"] == pytest.approx(VARIETY_TOP_PENALTY)
+
+    def test_currently_consuming_items_excluded(self) -> None:
+        """In-progress items do not represent a finished genre."""
+        items = [
+            _completed(
+                "Reading",
+                ["Fantasy"],
+                completed_on=date(2026, 1, 2),
+                status=ConsumptionStatus.CURRENTLY_CONSUMING,
+            ),
+            _completed("Done", ["Science Fiction"], completed_on=date(2026, 1, 1)),
+        ]
+        ladder = build_variety_ladder(items)
+        assert "fantasy" not in ladder
+        assert ladder["science_fiction"] == pytest.approx(VARIETY_TOP_PENALTY)
+
+    def test_undated_items_sort_after_dated_items(self) -> None:
+        """Items without a completion date rank below dated ones."""
+        items = [
+            _completed("Undated", ["Fantasy"], completed_on=None, db_id=1),
+            _completed("Dated", ["Science Fiction"], completed_on=date(2026, 1, 1)),
+        ]
+        ladder = build_variety_ladder(items)
+        # Dated sci-fi is freshest -> top penalty; undated fantasy is rung 1.
+        assert ladder["science_fiction"] == pytest.approx(VARIETY_TOP_PENALTY)
+        assert ladder["fantasy"] == pytest.approx(0.64)
+
+    def test_custom_steps_and_top_penalty(self) -> None:
+        items = [
+            _completed("A", ["Fantasy"], completed_on=date(2026, 1, 2)),
+            _completed("B", ["Science Fiction"], completed_on=date(2026, 1, 1)),
+        ]
+        ladder = build_variety_ladder(items, steps=2, top_penalty=1.0)
+        assert ladder["fantasy"] == pytest.approx(1.0)
+        assert ladder["science_fiction"] == pytest.approx(0.5)
+
+    def test_zero_steps_disables_ladder(self) -> None:
+        items = [_completed("A", ["Fantasy"], completed_on=date(2026, 1, 1))]
+        assert build_variety_ladder(items, steps=0) == {}
+
+
+class TestVarietyPenaltyFor:
+    """Tests for :func:`variety_penalty_for`."""
+
+    def test_no_ladder_no_penalty(self) -> None:
+        assert variety_penalty_for(_candidate("X", ["Fantasy"]), {}) == 0.0
+
+    def test_matching_cluster_returns_its_penalty(self) -> None:
+        ladder = {"fantasy": 0.8}
+        assert variety_penalty_for(
+            _candidate("Dragon", ["Fantasy"]), ladder
+        ) == pytest.approx(0.8)
+
+    def test_unmatched_candidate_returns_zero(self) -> None:
+        ladder = {"fantasy": 0.8}
+        assert variety_penalty_for(_candidate("Crime", ["Mystery"]), ladder) == 0.0
+
+    def test_candidate_without_genres_returns_zero(self) -> None:
+        """An un-enriched candidate (no genre metadata) is never penalised."""
+        ladder = {"fantasy": 0.8}
+        assert variety_penalty_for(_candidate("Unknown", []), ladder) == 0.0
+
+    def test_strongest_matching_cluster_wins(self) -> None:
+        """A multi-genre candidate is judged by its freshest matching genre."""
+        ladder = {"fantasy": 0.32, "science_fiction": 0.8}
+        # Candidate is both fantasy and sci-fi; sci-fi is fresher -> 0.8.
+        penalty = variety_penalty_for(
+            _candidate("Crossover", ["Fantasy", "Science Fiction"]), ladder
+        )
+        assert penalty == pytest.approx(0.8)

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -855,6 +855,65 @@ def test_recommendations_include_breakdown(client, mock_components):
     assert data[0]["score_breakdown"]["creator_match"] == 0.5
 
 
+def test_recommendations_include_variety_penalty(client, mock_components):
+    """Recommendations response includes the variety_penalty field (issue #74)."""
+    mock_item = ContentItem(
+        id="1",
+        title="Penalised Book",
+        author="Author",
+        content_type=ContentType.BOOK,
+        status=ConsumptionStatus.UNREAD,
+    )
+    mock_recommendations = [
+        {
+            "item": mock_item,
+            "score": 0.2,
+            "similarity_score": 0.5,
+            "preference_score": 0.5,
+            "reasoning": "Recommended",
+            "score_breakdown": {"genre_match": 0.9},
+            "variety_penalty": 0.8,
+        }
+    ]
+    mock_components["engine"].generate_recommendations.return_value = (
+        mock_recommendations
+    )
+
+    response = client.get("/api/recommendations?type=book&count=1")
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["variety_penalty"] == 0.8
+
+
+def test_recommendations_variety_penalty_defaults_to_zero(client, mock_components):
+    """variety_penalty defaults to 0.0 when the engine omits it."""
+    mock_item = ContentItem(
+        id="1",
+        title="Plain Book",
+        author="Author",
+        content_type=ContentType.BOOK,
+        status=ConsumptionStatus.UNREAD,
+    )
+    mock_recommendations = [
+        {
+            "item": mock_item,
+            "score": 0.85,
+            "similarity_score": 0.8,
+            "preference_score": 0.7,
+            "reasoning": "Recommended",
+            "score_breakdown": {"genre_match": 0.9},
+        }
+    ]
+    mock_components["engine"].generate_recommendations.return_value = (
+        mock_recommendations
+    )
+
+    response = client.get("/api/recommendations?type=book&count=1")
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["variety_penalty"] == 0.0
+
+
 def test_recommendations_with_user_id(client, mock_components):
     """GET /api/recommendations with user_id loads user preferences."""
     mock_item = ContentItem(


### PR DESCRIPTION
## Summary

Implements a **stepped genre-fatigue penalty** for the `variety_after_completion` preference (issue #74). Previously, enabling the variety setting only nudged a weak additive diversity bonus in the legacy ranker, which could not overcome the strong `SeriesOrderScorer` — so finishing a book made the **next book in the same series the new #1 recommendation**, the exact bug reported.

Now, when variety is enabled, the genres you most recently *completed* are penalised on a recency ladder, multiplicatively demoting candidates in those genres so recommendations actually vary.

Closes #74

## How it works

- The most recently finished genre **cluster** takes an 80% penalty; the penalty decays linearly over your last **5 distinct** finished clusters: **80% → 64% → 48% → 32% → 16%**, then nothing.
- A candidate is penalised by its **freshest matching genre**; the penalty multiplies its final score (`score × (1 − penalty)`). The top penalty stays below 1.0, so a genre-homogeneous library never returns an empty list.
- **Per content type**: finishing a fantasy *book* varies your book recommendations but leaves fantasy *movies* and *games* untouched — the ladder is scoped to completed items of the type being recommended.
- Genres are grouped via the existing thematic `genre_clusters`, robust to messy source tags.

## What changed

- **`src/recommendations/variety.py`** (new) — `build_variety_ladder()` + `variety_penalty_for()`.
- **Engine** — applies the penalty after ranking, scoped per content type; `_configure_ranker` now honours only an explicit `diversity_weight` (the toggle drives the new penalty instead). Each recommendation carries `variety_penalty`.
- **CLI** — new `preferences set-toggle <series_in_order|variety_after_completion> <on|off>` (the UI already had these toggles; the CLI had no setter). The penalty is surfaced in `recommend` JSON + table output.
- **Web API** — `variety_penalty` on `RecommendationResponse` (and the SSE stream), via a shared `_recommendation_payload` helper so the two paths can't drift.
- **UI** — `RecScoreDetails.vue` renders a distinct "Variety penalty −NN%" row; Snowstorm theme warning colour darkened for WCAG AA contrast; decorative bars marked `aria-hidden`.
- **Docs** — README, ARCHITECTURE, QUICKSTART.

## Test plan

- `tests/test_variety.py` — ladder ordering by completion date, exact stepped percentages, distinct-cluster collapse, `db_id` tie-break, COMPLETED-only filter, cap at 5, candidate lookup.
- `tests/test_recommendation_engine.py` — penalty demotes recently finished genre, steps by recency, **per-content-type independence**, and a `TestVarietyAfterCompletionRegression` reproducing the issue #74 next-in-series bug.
- CLI, web API, and `RecScoreDetails` component tests for the surfaced penalty + the new toggle command.
- `command make check` green: 2900 Python tests, 339 frontend tests, black / mypy (strict) / ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)