### PR TITLE
fix(sorting): only strip English articles when sorting titles

### DIFF
--- a/src/utils/sorting.py
+++ b/src/utils/sorting.py
@@ -2,35 +2,11 @@
 
 import re
 
-# Common articles to strip when sorting titles.
-# Includes English and some common non-English articles.
-ARTICLES = frozenset(
-    {
-        "a",
-        "an",
-        "the",
-        # French
-        "le",
-        "la",
-        "les",
-        "un",
-        "une",
-        # Spanish
-        "el",
-        "los",
-        "las",
-        # German
-        "der",
-        "die",
-        "das",
-        "ein",
-        "eine",
-        # Italian
-        "il",
-        "lo",
-        "gli",
-    }
-)
+# Articles to strip when sorting titles. Intentionally English-only: a
+# multilingual set collides with English words (German "die" in "Die Hard",
+# Spanish "el" in "El Camino"), sorting them under the wrong letter. Locale-aware
+# multilingual stripping is deferred to a future per-locale config (see #77).
+ARTICLES = frozenset({"a", "an", "the"})
 
 # Regex to match a leading article followed by whitespace
 _ARTICLE_PATTERN = re.compile(
@@ -58,8 +34,8 @@ def get_sort_title(title: str) -> str:
         'tale of two cities'
         >>> get_sort_title("An American in Paris")
         'american in paris'
-        >>> get_sort_title("Les Misérables")
-        'misérables'
+        >>> get_sort_title("Die Hard")
+        'die hard'
         >>> get_sort_title("1984")
         '1984'
     """
@@ -80,8 +56,8 @@ def get_sort_title(title: str) -> str:
 def titles_similar(title1: str, title2: str) -> bool:
     """Check if two titles are similar (fuzzy matching).
 
-    Uses get_sort_title to strip leading articles (including non-English)
-    and normalize case, then checks substring containment.
+    Uses get_sort_title to strip leading English articles and normalize
+    case, then checks substring containment.
 
     Args:
         title1: First title.

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -57,22 +57,22 @@ class TestGetSortTitle:
         # "Theater" starts with "The" but shouldn't be stripped
         assert get_sort_title("Theater") == "theater"
 
-    def test_french_articles(self) -> None:
-        """Test French articles are stripped."""
-        assert get_sort_title("Les Misérables") == "misérables"
-        assert get_sort_title("Le Petit Prince") == "petit prince"
-        assert get_sort_title("La Vie en Rose") == "vie en rose"
+    def test_french_articles_not_stripped(self) -> None:
+        """Test French articles are NOT stripped (English-only, see #77)."""
+        assert get_sort_title("Les Misérables") == "les misérables"
+        assert get_sort_title("Le Petit Prince") == "le petit prince"
+        assert get_sort_title("La Vie en Rose") == "la vie en rose"
 
-    def test_spanish_articles(self) -> None:
-        """Test Spanish articles are stripped."""
-        assert get_sort_title("El Mariachi") == "mariachi"
-        assert get_sort_title("Los Tres Amigos") == "tres amigos"
+    def test_spanish_articles_not_stripped(self) -> None:
+        """Test Spanish articles are NOT stripped (English-only, see #77)."""
+        assert get_sort_title("El Mariachi") == "el mariachi"
+        assert get_sort_title("Los Tres Amigos") == "los tres amigos"
 
-    def test_german_articles(self) -> None:
-        """Test German articles are stripped."""
-        assert get_sort_title("Der Untergang") == "untergang"
-        assert get_sort_title("Die Hard") == "hard"
-        assert get_sort_title("Das Boot") == "boot"
+    def test_german_articles_not_stripped(self) -> None:
+        """Test German articles are NOT stripped (English-only, see #77)."""
+        assert get_sort_title("Der Untergang") == "der untergang"
+        assert get_sort_title("Die Hard") == "die hard"
+        assert get_sort_title("Das Boot") == "das boot"
 
     def test_single_word_starting_with_article_letters(self) -> None:
         """Test that single words starting with article letters aren't mangled."""
@@ -93,17 +93,11 @@ class TestSortTitleArticleRegression:
         Root cause: "i" was included as an Italian plural article, but it
         collides with the very common English word "I".
 
-        Fix: Removed "i" from ARTICLES frozenset.
+        Fix: Removed "i" from ARTICLES frozenset (later superseded by the full
+        English-only narrowing in #77, which removed every non-English article).
         """
         assert get_sort_title("I Am Legend") == "i am legend"
         assert get_sort_title("I, Robot") == "i, robot"
-
-    def test_il_postino_still_strips_regression(self) -> None:
-        """Regression test: "Il Postino" should still strip the Italian article.
-
-        Ensures removing "i" didn't break "il" stripping.
-        """
-        assert get_sort_title("Il Postino") == "postino"
 
     def test_l_apostrophe_was_unreachable_regression(self) -> None:
         """Regression test: "l'" was dead code in ARTICLES.
@@ -113,6 +107,46 @@ class TestSortTitleArticleRegression:
         Titles like "L'Étranger" are unaffected (were never stripped).
         """
         assert get_sort_title("L'Étranger") == "l'étranger"
+
+
+class TestNonEnglishArticleStrippingRegression:
+    """Regression tests for issue #77: non-English articles wrongly stripped.
+
+    Bug reported: "Die Hard" sorted under H instead of D because the German
+    article "die" ("the") was in the multilingual ARTICLES set and got
+    stripped. Same trap for "Das Boot" (German "das"), "El Camino" (Spanish
+    "el"), "Los Angeles" (Spanish "los"), etc.
+
+    Root cause: ARTICLES spanned English, French, Spanish, German, and Italian.
+    Many non-English articles collide with English words and proper nouns.
+
+    Fix: Narrowed ARTICLES to English only ({"a", "an", "the"}). Locale-aware
+    multilingual stripping is deferred to a future per-locale config.
+    """
+
+    def test_die_hard_sorts_under_d_regression(self) -> None:
+        """ "Die Hard" must keep "die" so it sorts under D, not H."""
+        assert get_sort_title("Die Hard") == "die hard"
+
+    def test_das_boot_sorts_under_d_regression(self) -> None:
+        """ "Das Boot" must keep the German article "das"."""
+        assert get_sort_title("Das Boot") == "das boot"
+
+    def test_el_camino_sorts_under_e_regression(self) -> None:
+        """ "El Camino" must keep the Spanish article "el"."""
+        assert get_sort_title("El Camino") == "el camino"
+
+    def test_le_petit_prince_sorts_under_l_regression(self) -> None:
+        """ "Le Petit Prince" must keep the French article "le"."""
+        assert get_sort_title("Le Petit Prince") == "le petit prince"
+
+    def test_il_postino_sorts_under_i_regression(self) -> None:
+        """ "Il Postino" must keep the Italian article "il"."""
+        assert get_sort_title("Il Postino") == "il postino"
+
+    def test_english_the_still_stripped_regression(self) -> None:
+        """English articles must still be stripped after the narrowing."""
+        assert get_sort_title("The Matrix") == "matrix"
 
 
 class TestSortTitleOrdering:


### PR DESCRIPTION
## What

"Die Hard" was sorting under **H** instead of **D**. The title sort key strips leading articles before sorting, and the article list included five languages. German "die" means "the", so "Die Hard" got "die" stripped and sorted as "hard". Same trap for "Das Boot", "El Camino", "Los Angeles", and friends.

This narrows article stripping to English only (`a`, `an`, `the`). English titles that happen to start with a foreign article word now sort by their real first letter.

| Title | Before | After |
|-------|--------|-------|
| Die Hard | H | **D** |
| Das Boot | B | **D** |
| El Camino | C | **E** |
| The Matrix | M | M (unchanged) |

## Why English only for now

We can safely assume primary titles are English for the moment. I did not want to lose sight of the fact that a German-primary user would legitimately want "Die"/"Das"/"Der" treated as articles, so that concern is deferred (not dropped) to a future per-locale config. The code carries a comment pointing back at #77 so the multilingual case is not forgotten.

## Scope note

This also feeds adaptation detection in the recommendation engine. The narrowing applies symmetrically to both sides of every comparison, so adaptation matching is unaffected (and slightly more correct — a "Die Hard" book and movie now match on "die hard" rather than both collapsing to "hard").

Out of scope, surfaced during QA: `titles_similar` does loose substring matching that can over-match ultra-short titles. It predates this change and is left for separate triage.

## Tests

- Inverted the existing French/Spanish/German/Italian "strips article" assertions to "does not strip" — the new contract.
- Added `TestNonEnglishArticleStrippingRegression` covering all five formerly-stripped language families plus a guard that English `the` is still stripped.
- `command make check` green: black, ruff, mypy (strict), pytest (2927), and the frontend Vitest suite.

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)