### PR TITLE
fix(sorting): require word boundaries when matching similar titles

### DIFF
--- a/src/utils/sorting.py
+++ b/src/utils/sorting.py
@@ -53,11 +53,40 @@ def get_sort_title(title: str) -> str:
     return normalized
 
 
+def _contains_on_word_boundary(shorter: str, longer: str) -> bool:
+    """Check if `shorter` occurs in `longer` aligned on word boundaries.
+
+    An occurrence counts only when it is bounded on each side by the string
+    start/end or a non-alphanumeric character, so a short title cannot match
+    mid-word (e.g. "an" must not match inside "antique").
+
+    Returns False for an empty `shorter`: it has no boundaries to align and
+    str.find("") would otherwise loop forever.
+    """
+    if not shorter:
+        return False
+
+    shorter_length = len(shorter)
+    start = longer.find(shorter)
+    while start != -1:
+        before_ok = start == 0 or not longer[start - 1].isalnum()
+        end = start + shorter_length
+        after_ok = end == len(longer) or not longer[end].isalnum()
+        if before_ok and after_ok:
+            return True
+        start = longer.find(shorter, start + 1)
+    return False
+
+
 def titles_similar(title1: str, title2: str) -> bool:
     """Check if two titles are similar (fuzzy matching).
 
     Uses get_sort_title to strip leading English articles and normalize
     case, then checks substring containment.
+
+    Substring containment must align on word boundaries: the shorter
+    normalized title only matches when it is bounded by the string start/end
+    or a non-alphanumeric character, so it never matches mid-word.
 
     Args:
         title1: First title.
@@ -72,4 +101,11 @@ def titles_similar(title1: str, title2: str) -> bool:
     t1_norm = get_sort_title(title1)
     t2_norm = get_sort_title(title2)
 
-    return t1_norm in t2_norm or t2_norm in t1_norm
+    if t1_norm == t2_norm:
+        return True
+
+    # Compare the shorter against the longer. When lengths are equal the two
+    # strings differ (equality returned above), so neither can contain the
+    # other and the helper returns False regardless of ordering.
+    shorter, longer = sorted((t1_norm, t2_norm), key=len)
+    return _contains_on_word_boundary(shorter, longer)

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -214,3 +214,60 @@ class TestTitlesSimilar:
     def test_no_false_match_on_short_overlap(self) -> None:
         """Unrelated titles with no substring relationship should not match."""
         assert titles_similar("Portal", "Inception") is False
+
+
+class TestTitlesSimilarWordBoundaryRegression:
+    """Regression tests for intra-word substring false positives.
+
+    Bug reported: titles_similar matched a short title that appeared INSIDE
+    an unrelated word (e.g. "An" matched "Antique", "Up" matched "Upgrade").
+
+    Root cause: the function used raw character substring containment
+    (`t1_norm in t2_norm or t2_norm in t1_norm`), so any normalized title
+    that happened to occur mid-word in another title was treated as similar.
+
+    Fix: substring containment now must align on word boundaries — the shorter
+    normalized title must be bounded by the string start/end or a
+    non-alphanumeric character on each side.
+    """
+
+    def test_an_does_not_match_antique_regression(self) -> None:
+        assert titles_similar("An", "Antique") is False
+
+    def test_up_does_not_match_upgrade_regression(self) -> None:
+        assert titles_similar("Up", "Upgrade") is False
+
+    def test_it_does_not_match_spirit_regression(self) -> None:
+        assert titles_similar("It", "Spirit") is False
+
+    def test_the_does_not_match_theater_regression(self) -> None:
+        # "The" alone normalizes to "the" (the strip regex needs trailing
+        # whitespace), so this exercises the mid-word boundary check, not
+        # article stripping: "the" must not match inside "theater".
+        assert titles_similar("The", "Theater") is False
+
+    def test_her_does_not_match_where_regression(self) -> None:
+        assert titles_similar("Her", "Where") is False
+
+    def test_a_does_not_match_cars_regression(self) -> None:
+        assert titles_similar("A", "Cars") is False
+
+    def test_phrase_prefix_still_matches_regression(self) -> None:
+        """A real phrase prefix bounded by whitespace still matches."""
+        assert titles_similar("Blade Runner", "Blade Runner 2049") is True
+
+    def test_hyphen_is_a_word_boundary_regression(self) -> None:
+        """A non-alphanumeric separator (hyphen) counts as a boundary."""
+        assert titles_similar("Spider", "Spider-Man") is True
+
+    def test_later_boundary_occurrence_matches_regression(self) -> None:
+        """The scan continues past a mid-word hit to a later boundary hit.
+
+        "it" occurs mid-word inside "spirit" (rejected) and again as a
+        standalone word (accepted), exercising the loop-continuation path.
+        """
+        assert titles_similar("It", "Spirit It") is True
+
+    def test_whitespace_only_title_does_not_match_regression(self) -> None:
+        """A title that normalizes to empty must not match (no infinite loop)."""
+        assert titles_similar("   ", "Spirited Away") is False


### PR DESCRIPTION
## What

`titles_similar` decided two titles were the same work by raw substring containment. That let a short title match *inside* an unrelated word:

| Pair | Before | After |
|------|--------|-------|
| `An` / `Antique` | similar | **not similar** |
| `Up` / `Upgrade` | similar | **not similar** |
| `It` / `Spirit` | similar | **not similar** |
| `The` / `Theater` | similar | **not similar** |
| `Die Hard` / `Die Hard (1988)` | similar | similar (kept) |
| `Spider` / `Spider-Man` | similar | similar (kept) |

Matching now has to land on a **word boundary**: the shorter normalized title only counts when each side is the string start/end or a non-alphanumeric character. Real prefixes and subtitles still match, mid-word coincidences don't.

## Why it mattered

`titles_similar` feeds `_find_direct_adaptations` in the recommendation engine. It's gated behind an exact author match, so the blast radius is small, but a same-author pair with titles like the ones above could surface a bogus "adaptation" in the reasoning shown to the user. This was spotted during QA of the article-sorting fix (#77) and is split out as its own change.

## How

A small `_contains_on_word_boundary` helper scans for the shorter title in the longer one and accepts a hit only when both edges are boundaries. It also guards the empty case up front, since an empty needle would otherwise spin `str.find` forever (reachable via a whitespace-only title that normalizes to empty).

## Scope

Deliberately left alone as pre-existing and unrelated to this bug: bare-year matches (`2049` in `Blade Runner 2049`), single-character title floors, and the equality of two whitespace-only titles. None are regressions of this change. Happy to take any of them as a follow-up.

## Tests

New `TestTitlesSimilarWordBoundaryRegression` class covers every false positive above plus the paths the fix introduced: hyphen-as-boundary, the scan continuing past a mid-word hit to a later word-boundary hit (`It` / `Spirit It`), and the empty-normalization guard. Existing positive and negative cases are unchanged. `command make check` green: black, ruff, mypy (strict), pytest, and the frontend Vitest suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)