### PR TITLE
feat: surface unenriched items and allow manual enrichment editing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -159,6 +159,8 @@ Background system that fills gaps in content metadata from external APIs.
 - Token bucket rate limiter per provider
 - Background worker with configurable batch size
 - Optional auto-enrichment hook after sync
+- **Manual metadata editing**: users can set genres, tags, and a description by hand from the web edit modal or `library edit --genre/--tag/--description`. Unlike the gap-filling merge, manual values overwrite the detail-table fields. The edit records the `"manual"` provider via `mark_enrichment_complete`, which marks the item enriched (so it leaves the `not_enriched` filter) and keeps it out of the automatic re-enrichment queue so manual values are never overwritten
+- **Enrichment-state filtering**: `get_content_items(enrichment="enriched"|"not_enriched")` and the per-row `enriched` flag share a single predicate (`_ENRICHED_PREDICATE`) over the joined `enrichment_status` row — an item is enriched only with a real provider, no error, not `not_found`, and `needs_enrichment=0`
 
 ### 6. Conversation System (`src/conversation/`) — Optional
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ see **[docs/DATA_SOURCES.md](docs/DATA_SOURCES.md)**.
 - Multi-source ingestion with cross-content recommendations via semantic genre clusters
 - Transparent scoring pipeline — genre, creator, series order, tag overlap, rating patterns ([how it works](docs/SCORING.md))
 - Natural-language [custom rules](docs/CUSTOM_RULES.md) like "avoid horror" or "prefer short books"
-- Content-length filtering, multi-user support, [metadata enrichment](docs/ENRICHMENT_SETUP.md) (TMDB/OpenLibrary/RAWG)
+- Content-length filtering, multi-user support, [metadata enrichment](docs/ENRICHMENT_SETUP.md) (TMDB/OpenLibrary/RAWG) — automatic, plus manual editing of genres, tags, and descriptions and a library filter by enrichment state
 - Themeable web UI (ships with Nord and Snowstorm) with version display and update detection
 - Dual interface — CLI for automation, web UI for browsing
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -38,6 +38,9 @@ python3.11 -m src.cli status --format json
 python3.11 -m src.cli library list --type book --status completed --sort rating --limit 20
 python3.11 -m src.cli library list --format json
 
+# Filter by enrichment state (enriched or not_enriched)
+python3.11 -m src.cli library list --enrichment not_enriched
+
 # Show item details
 python3.11 -m src.cli library show --id 42
 
@@ -47,6 +50,10 @@ python3.11 -m src.cli library edit --id 42 --rating 5 --status completed
 # Mark watched TV seasons (comma-separated season numbers, each 1-200)
 python3.11 -m src.cli library edit --id 42 --seasons-watched 1,2,3
 
+# Set manual enrichment metadata (repeated --genre/--tag replace the existing
+# lists; any provided field marks the item enriched)
+python3.11 -m src.cli library edit --id 42 --genre Action --genre RPG --tag co-op --description "A grand adventure."
+
 # Ignore/unignore items (excluded from recommendations)
 python3.11 -m src.cli library ignore --id 42
 python3.11 -m src.cli library unignore --id 42
@@ -55,6 +62,17 @@ python3.11 -m src.cli library unignore --id 42
 python3.11 -m src.cli library export --type book --format csv --output books.csv
 python3.11 -m src.cli library export --type video_game --format json
 ```
+
+`library list --enrichment` filters by enrichment state. An item is "enriched"
+only when a provider matched it cleanly (a real provider, no error, not "not
+found", and not pending re-enrichment); `not_enriched` is everything else. The
+list table shows an **Enriched** column.
+
+Passing any of `--genre`, `--tag`, or `--description` to `library edit` writes
+manual metadata. Repeated `--genre`/`--tag` replace the existing lists (they do
+not append), and `--description` replaces the existing text. Providing any of
+these marks the item enriched via the `manual` provider, so it drops out of the
+`not_enriched` set and is never re-queued for automatic enrichment.
 
 ## Source management
 

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -80,6 +80,11 @@ The CLI accepts `--workers N` to override per-invocation, e.g.
 
 ## Library export
 
+The **Library** tab can be filtered by content type, consumption status, and
+enrichment state (all items, enriched, or not enriched). The enrichment filter is
+handy for finding items still missing metadata so you can edit them by hand — see
+[ENRICHMENT_SETUP.md](ENRICHMENT_SETUP.md#manual-enrichment-editing).
+
 Export your library data from the web UI:
 
 1. Go to the **Library** tab.

--- a/docs/ENRICHMENT_SETUP.md
+++ b/docs/ENRICHMENT_SETUP.md
@@ -201,7 +201,7 @@ Automatic enrichment covers most of your library, but some items never match a p
 
 An item counts as enriched only when a provider matched it cleanly (a real provider, no error, not marked "not found", and not pending re-enrichment). Everything else is unenriched.
 
-- **Web:** on the **Library** page, use the **Enrichment** filter in the toolbar to show only **Not enriched** items (or only **Enriched** ones). Unenriched items also display a "Not enriched" indicator on their library card.
+- **Web:** on the **Library** page, use the **Enrichment** filter in the toolbar to show only **Not enriched** items (or only **Enriched** ones). Unenriched items also carry a "Not enriched" badge on their library card.
 - **CLI:** `python3.11 -m src.cli library list --enrichment not_enriched` lists the items still missing metadata. The `library list` table includes an **Enriched** column, and `library show --id <id>` displays the item's enriched state alongside its genres, tags, and description.
 
 ### Editing metadata in the web edit modal
@@ -212,7 +212,7 @@ On the **Library** page, open an item's edit modal. Under **Enrichment metadata*
 - **Tags** — add or remove tag chips
 - **Description** — free text
 
-Save the modal to write the values. If the item was unenriched, saving these fields marks it enriched and clears its "Not enriched" indicator.
+Save the modal to write the values. If the item was unenriched, saving these fields marks it enriched and clears its "Not enriched" badge.
 
 ### Editing metadata from the CLI
 
@@ -231,7 +231,7 @@ Repeated `--genre` and `--tag` values replace the existing lists rather than app
 
 Manual genres, tags, and descriptions **overwrite** the existing detail values (unlike the gap-filling merge that sync and automatic enrichment use). Providing any one of them marks the item enriched with the provider `"manual"`. That has two effects:
 
-- The item drops out of the `not_enriched` filter (and stops showing the "Not enriched" indicator).
+- The item drops out of the `not_enriched` filter (and stops showing the "Not enriched" badge).
 - Automatic enrichment never re-queues the item, so your manual values are not overwritten on a later enrichment run.
 
 ## Troubleshooting

--- a/docs/ENRICHMENT_SETUP.md
+++ b/docs/ENRICHMENT_SETUP.md
@@ -187,9 +187,52 @@ python3.11 -m src.cli enrichment status
 
 On the **Data** page, the **Metadata Enrichment** section shows your current enrichment coverage with a breakdown by provider. Click the enrichment button to start a new enrichment run.
 
+The **Data** page is where you run and monitor enrichment jobs. To see and filter your library by enrichment state — for example, to find the items that are still missing metadata — use the **Library** page instead (see Manual Enrichment Editing below).
+
 ### Auto-Enrichment
 
 Set `auto_enrich_on_sync: true` in your config to automatically queue enrichment after every data sync. This is convenient if you want a hands-off workflow — sync your sources and enrichment runs immediately after.
+
+## Manual Enrichment Editing
+
+Automatic enrichment covers most of your library, but some items never match a provider database (niche, very new, or oddly titled content). For those, you can fill in the metadata yourself. A manual edit marks the item enriched, so it leaves the unenriched set and is never re-queued for automatic enrichment.
+
+### Finding unenriched items
+
+An item counts as enriched only when a provider matched it cleanly (a real provider, no error, not marked "not found", and not pending re-enrichment). Everything else is unenriched.
+
+- **Web:** on the **Library** page, use the **Enrichment** filter in the toolbar to show only **Not enriched** items (or only **Enriched** ones). Unenriched items also carry a "Not enriched" badge on their library card.
+- **CLI:** `python3.11 -m src.cli library list --enrichment not_enriched` lists the items still missing metadata. The `library list` table includes an **Enriched** column, and `library show --id <id>` displays the item's enriched state alongside its genres, tags, and description.
+
+### Editing metadata in the web edit modal
+
+On the **Library** page, open an item's edit modal. Under **Enrichment metadata** you can edit:
+
+- **Genres** — add or remove genre chips
+- **Tags** — add or remove tag chips
+- **Description** — free text
+
+Save the modal to write the values. If the item was unenriched, saving these fields marks it enriched and clears its "Not enriched" badge.
+
+### Editing metadata from the CLI
+
+`library edit` accepts the same three fields:
+
+```bash
+python3.11 -m src.cli library edit --id 42 \
+  --genre Action --genre RPG \
+  --tag co-op --tag open-world \
+  --description "A grand adventure."
+```
+
+Repeated `--genre` and `--tag` values replace the existing lists rather than appending. `--description` replaces the existing description.
+
+### How manual edits interact with automatic enrichment
+
+Manual genres, tags, and descriptions **overwrite** the existing detail values (unlike the gap-filling merge that sync and automatic enrichment use). Providing any one of them marks the item enriched with the provider `"manual"`. That has two effects:
+
+- The item drops out of the `not_enriched` filter (and stops showing the "Not enriched" badge).
+- Automatic enrichment never re-queues the item, so your manual values are not overwritten on a later enrichment run.
 
 ## Troubleshooting
 

--- a/docs/ENRICHMENT_SETUP.md
+++ b/docs/ENRICHMENT_SETUP.md
@@ -201,7 +201,7 @@ Automatic enrichment covers most of your library, but some items never match a p
 
 An item counts as enriched only when a provider matched it cleanly (a real provider, no error, not marked "not found", and not pending re-enrichment). Everything else is unenriched.
 
-- **Web:** on the **Library** page, use the **Enrichment** filter in the toolbar to show only **Not enriched** items (or only **Enriched** ones). Unenriched items also carry a "Not enriched" badge on their library card.
+- **Web:** on the **Library** page, use the **Enrichment** filter in the toolbar to show only **Not enriched** items (or only **Enriched** ones). Unenriched items also display a "Not enriched" indicator on their library card.
 - **CLI:** `python3.11 -m src.cli library list --enrichment not_enriched` lists the items still missing metadata. The `library list` table includes an **Enriched** column, and `library show --id <id>` displays the item's enriched state alongside its genres, tags, and description.
 
 ### Editing metadata in the web edit modal
@@ -212,7 +212,7 @@ On the **Library** page, open an item's edit modal. Under **Enrichment metadata*
 - **Tags** — add or remove tag chips
 - **Description** — free text
 
-Save the modal to write the values. If the item was unenriched, saving these fields marks it enriched and clears its "Not enriched" badge.
+Save the modal to write the values. If the item was unenriched, saving these fields marks it enriched and clears its "Not enriched" indicator.
 
 ### Editing metadata from the CLI
 
@@ -231,7 +231,7 @@ Repeated `--genre` and `--tag` values replace the existing lists rather than app
 
 Manual genres, tags, and descriptions **overwrite** the existing detail values (unlike the gap-filling merge that sync and automatic enrichment use). Providing any one of them marks the item enriched with the provider `"manual"`. That has two effects:
 
-- The item drops out of the `not_enriched` filter (and stops showing the "Not enriched" badge).
+- The item drops out of the `not_enriched` filter (and stops showing the "Not enriched" indicator).
 - Automatic enrichment never re-queues the item, so your manual values are not overwritten on a later enrichment run.
 
 ## Troubleshooting

--- a/docs/THEME_DEVELOPMENT.md
+++ b/docs/THEME_DEVELOPMENT.md
@@ -93,7 +93,7 @@ Override these variables in `colors.css` using a `:root` selector. You only need
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `--color-success` | `#a3be8c` | Success states (completed, unignore) |
-| `--color-warning` | `#ebcb8b` | Warning states (unread status badge, rating stars, ignored indicator) |
+| `--color-warning` | `#ebcb8b` | Warning states (unread status badge, rating stars, ignored badge) |
 | `--color-error` | `#bf616a` | Error states (danger buttons, failures) |
 | `--color-info` | `var(--accent)` | Info states (loading, sync) |
 

--- a/docs/THEME_DEVELOPMENT.md
+++ b/docs/THEME_DEVELOPMENT.md
@@ -77,7 +77,7 @@ Override these variables in `colors.css` using a `:root` selector. You only need
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `--accent` | `#81a1c1` | Primary accent (buttons, links, active states) |
-| `--accent-light` | `#88c0d0` | Light accent (highlights, ratings) |
+| `--accent-light` | `#88c0d0` | Light accent (highlights) |
 | `--accent-teal` | `#8fbcbb` | Teal accent (supplementary) |
 
 ### Border Colors
@@ -93,7 +93,7 @@ Override these variables in `colors.css` using a `:root` selector. You only need
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `--color-success` | `#a3be8c` | Success states (completed, unignore) |
-| `--color-warning` | `#ebcb8b` | Warning states (unread badges) |
+| `--color-warning` | `#ebcb8b` | Warning states (unread status badge, rating stars, ignored indicator) |
 | `--color-error` | `#bf616a` | Error states (danger buttons, failures) |
 | `--color-info` | `var(--accent)` | Info states (loading, sync) |
 

--- a/resources/css/base.css
+++ b/resources/css/base.css
@@ -977,27 +977,6 @@ input[type="checkbox"] {
   border-color: color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
-.badge-rating {
-  background: color-mix(in srgb, var(--accent-light) 10%, transparent);
-  color: var(--accent-light);
-  border-color: color-mix(in srgb, var(--accent-light) 30%, transparent);
-}
-
-.badge-ignored {
-  background: color-mix(in srgb, var(--color-warning) 10%, transparent);
-  color: var(--color-warning);
-  border-color: color-mix(in srgb, var(--color-warning) 30%, transparent);
-}
-
-/* Neutral marker for items lacking enrichment metadata. Uses the readable
-   --text-secondary token (not --text-muted) to clear 4.5:1 contrast on the
-   elevated background across themes. */
-.badge-enrichment {
-  background: var(--bg-elevated);
-  color: var(--text-secondary);
-  border-color: var(--border-default);
-}
-
 .badge-score {
   background: color-mix(in srgb, var(--accent) 20%, transparent);
   color: var(--accent-light);
@@ -1211,12 +1190,76 @@ input[type="checkbox"] {
   margin-bottom: var(--space-2);
 }
 
-.library-item-badges {
+/* Primary meta row: categorical pills anchored left, rating anchored right.
+   The fixed two-zone structure keeps every permutation visually balanced. */
+.library-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin: var(--space-2) 0 var(--space-3);
+}
+
+.library-meta-tags {
+  display: flex;
+  gap: var(--space-1);
+}
+
+/* Rating is a plain value (no badge chrome): filled/outlined stars convey the
+   value by form, with a visible n/5 and sr-only text for assistive tech. */
+.rating-stars {
+  display: inline-flex;
+  align-items: baseline;
+  font-size: var(--text-sm);
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.rating-stars .star.filled {
+  color: var(--color-warning);
+}
+
+.rating-stars .star.empty {
+  color: var(--text-secondary);
+}
+
+.rating-stars .value {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  margin-left: var(--space-1);
+}
+
+/* Quiet caption line for non-categorical states (not-enriched, ignored).
+   Both can coexist and wrap as text; dots are supplementary to the labels. */
+.library-state-lines {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-1);
-  margin-top: var(--space-2);
+  gap: var(--space-2);
   margin-bottom: var(--space-3);
+}
+
+.library-state {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+.library-state .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.library-state.not-enriched .dot {
+  background: var(--text-muted);
+}
+
+.library-state.ignored .dot {
+  background: var(--color-warning);
 }
 
 .library-item-actions {

--- a/resources/css/base.css
+++ b/resources/css/base.css
@@ -977,6 +977,21 @@ input[type="checkbox"] {
   border-color: color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
+.badge-ignored {
+  background: color-mix(in srgb, var(--color-warning) 10%, transparent);
+  color: var(--color-warning);
+  border-color: color-mix(in srgb, var(--color-warning) 30%, transparent);
+}
+
+/* Neutral marker for items lacking enrichment metadata. Uses the readable
+   --text-secondary token (not --text-muted) to clear 4.5:1 contrast on the
+   elevated background across themes. */
+.badge-enrichment {
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+}
+
 .badge-score {
   background: color-mix(in srgb, var(--accent) 20%, transparent);
   color: var(--accent-light);
@@ -1190,19 +1205,36 @@ input[type="checkbox"] {
   margin-bottom: var(--space-2);
 }
 
-/* Primary meta row: categorical pills anchored left, rating anchored right.
-   The fixed two-zone structure keeps every permutation visually balanced. */
+/* Primary meta row: three categorical pills anchored left on a single line.
+   nowrap + flex-shrink:0 + the reduced pill size guarantee the type, status,
+   and Not enriched pills never wrap even at the 280px minimum card width. */
 .library-meta {
   display: flex;
+  flex-wrap: nowrap;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  margin: var(--space-2) 0 var(--space-3);
+  gap: var(--space-1);
+  margin-top: var(--space-2);
 }
 
-.library-meta-tags {
+.library-meta .badge {
+  flex-shrink: 0;
+  white-space: nowrap;
+  padding: 2px 6px;
+  font-size: 11px;
+}
+
+/* Secondary meta row: rating anchored left, Ignored pinned right via
+   margin-left:auto so it stays right-aligned with or without a rating. */
+.library-meta-secondary {
   display: flex;
-  gap: var(--space-1);
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+  margin-bottom: var(--space-1);
+}
+
+.library-meta-secondary .badge-ignored {
+  margin-left: auto;
 }
 
 /* Rating is a plain value (no badge chrome): filled/outlined stars convey the
@@ -1230,38 +1262,6 @@ input[type="checkbox"] {
   margin-left: var(--space-1);
 }
 
-/* Quiet caption line for non-categorical states (not-enriched, ignored).
-   Both can coexist and wrap as text; dots are supplementary to the labels. */
-.library-state-lines {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  margin-bottom: var(--space-3);
-}
-
-.library-state {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-size: var(--text-xs);
-  color: var(--text-secondary);
-}
-
-.library-state .dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.library-state.not-enriched .dot {
-  background: var(--text-muted);
-}
-
-.library-state.ignored .dot {
-  background: var(--color-warning);
-}
-
 .library-item-actions {
   margin-top: auto;
   padding-top: var(--space-3);
@@ -1274,8 +1274,21 @@ input[type="checkbox"] {
   flex: 1;
 }
 
+/* Ignored items are de-emphasized without dimming text. A dashed, muted border
+   marks the card as set aside / excluded from recommendations while every label
+   stays at full opacity, so all text keeps its normal >= 4.5:1 contrast
+   (WCAG 1.4.3). Replaces the former opacity: 0.5, which composited the whole card
+   toward the page background and halved as-rendered text contrast. The dashed
+   border is a non-text indicator and clears 3:1 against both surfaces in both
+   themes (WCAG 1.4.11). */
 .library-item.ignored {
-  opacity: 0.5;
+  border-style: dashed;
+  border-color: var(--text-muted);
+}
+
+/* Ignored cards keep their de-emphasized read on hover (no accent-border highlight). */
+.library-item.ignored:hover {
+  border-color: var(--text-muted);
 }
 
 .library-load-more {

--- a/resources/css/base.css
+++ b/resources/css/base.css
@@ -989,6 +989,15 @@ input[type="checkbox"] {
   border-color: color-mix(in srgb, var(--color-warning) 30%, transparent);
 }
 
+/* Neutral marker for items lacking enrichment metadata. Uses the readable
+   --text-secondary token (not --text-muted) to clear 4.5:1 contrast on the
+   elevated background across themes. */
+.badge-enrichment {
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+}
+
 .badge-score {
   background: color-mix(in srgb, var(--accent) 20%, transparent);
   color: var(--accent-light);
@@ -1331,6 +1340,22 @@ input[type="checkbox"] {
 .edit-field select:focus,
 .edit-field textarea:focus {
   border-color: var(--border-focus);
+}
+
+.edit-modal-divider {
+  border: none;
+  border-top: 1px solid var(--border-default);
+  margin: var(--space-5) 0 var(--space-4) 0;
+}
+
+.edit-modal-section {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  /* --text-secondary (not --text-muted) to clear WCAG 4.5:1 at this size on all themes */
+  color: var(--text-secondary);
+  margin: 0 0 var(--space-4) 0;
 }
 
 .edit-modal-actions {

--- a/resources/js/components/atoms/TagInput.test.ts
+++ b/resources/js/components/atoms/TagInput.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TagInput from './TagInput.vue'
+
+describe('TagInput', () => {
+  function mountInput(props = {}) {
+    return mount(TagInput, {
+      props: { modelValue: [], label: 'Genres', inputId: 'edit-genres', ...props },
+    })
+  }
+
+  it('renders existing tags as chips', () => {
+    const wrapper = mountInput({ modelValue: ['Sci-Fi', 'Drama'] })
+    const chips = wrapper.findAll('.tag-input-chip')
+    expect(chips.map((c) => c.text())).toEqual(['Sci-Fi ×', 'Drama ×'])
+  })
+
+  it('associates the input with its label', () => {
+    const wrapper = mountInput()
+    expect(wrapper.find('label[for="edit-genres"]').exists()).toBe(true)
+    expect(wrapper.find('#edit-genres').exists()).toBe(true)
+  })
+
+  it('shows empty text when there are no tags', () => {
+    const wrapper = mountInput({ emptyText: 'No genres yet' })
+    expect(wrapper.find('.empty-rules').text()).toBe('No genres yet')
+    expect(wrapper.find('.tag-input-chips').exists()).toBe(false)
+  })
+
+  it('emits updated list when adding via Add button', async () => {
+    const wrapper = mountInput({ modelValue: ['Sci-Fi'] })
+    await wrapper.find('#edit-genres').setValue('Drama')
+    await wrapper.find('.add-rule-form button').trigger('click')
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual([['Sci-Fi', 'Drama']])
+  })
+
+  it('adds a tag when Enter is pressed in the input', async () => {
+    const wrapper = mountInput()
+    const input = wrapper.find('#edit-genres')
+    await input.setValue('Drama')
+    await input.trigger('keypress', { key: 'Enter' })
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual([['Drama']])
+  })
+
+  it('removes a tag when its remove button is clicked', async () => {
+    const wrapper = mountInput({ modelValue: ['Sci-Fi', 'Drama'] })
+    await wrapper.findAll('.tag-input-remove')[0].trigger('click')
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual([['Drama']])
+  })
+
+  it('trims whitespace and ignores empty input', async () => {
+    const wrapper = mountInput()
+    await wrapper.find('#edit-genres').setValue('   ')
+    await wrapper.find('.add-rule-form button').trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
+
+  it('de-dupes case-insensitively without emitting', async () => {
+    const wrapper = mountInput({ modelValue: ['Sci-Fi'] })
+    await wrapper.find('#edit-genres').setValue('sci-fi')
+    await wrapper.find('.add-rule-form button').trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
+
+  it('labels each remove button with the tag value', () => {
+    const wrapper = mountInput({ modelValue: ['Sci-Fi'] })
+    expect(wrapper.find('.tag-input-remove').attributes('aria-label')).toBe('Remove Sci-Fi')
+  })
+
+  it('add button is type="button" to avoid implicit submit', () => {
+    const wrapper = mountInput()
+    expect(wrapper.find('.add-rule-form button').attributes('type')).toBe('button')
+  })
+
+  it('caps the input at 100 characters via maxlength', () => {
+    const wrapper = mountInput()
+    expect(wrapper.find('#edit-genres').attributes('maxlength')).toBe('100')
+  })
+
+  it('does not add an entry longer than 100 characters', async () => {
+    const wrapper = mountInput()
+    await wrapper.find('#edit-genres').setValue('x'.repeat(101))
+    await wrapper.find('.add-rule-form button').trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
+})

--- a/resources/js/components/atoms/TagInput.vue
+++ b/resources/js/components/atoms/TagInput.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const props = withDefaults(defineProps<{
+  modelValue: string[]
+  label: string
+  inputId: string
+  addButtonLabel?: string
+  placeholder?: string
+  emptyText?: string
+}>(), {
+  addButtonLabel: 'Add',
+  placeholder: '',
+  emptyText: 'None yet',
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string[]]
+}>()
+
+const draft = ref('')
+
+// The web API rejects genre/tag strings longer than this with a 422.
+const MAX_LENGTH = 100
+
+function add() {
+  const value = draft.value.trim()
+  if (!value || value.length > MAX_LENGTH) return
+  if (props.modelValue.some((tag) => tag.toLowerCase() === value.toLowerCase())) {
+    draft.value = ''
+    return
+  }
+  emit('update:modelValue', [...props.modelValue, value])
+  draft.value = ''
+}
+
+function remove(index: number) {
+  emit('update:modelValue', props.modelValue.filter((_, i) => i !== index))
+}
+
+function onKeypress(event: KeyboardEvent) {
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    add()
+  }
+}
+</script>
+
+<template>
+  <div class="tag-input">
+    <label :for="inputId">{{ label }}</label>
+    <div v-if="modelValue.length === 0" class="empty-rules">{{ emptyText }}</div>
+    <div v-else class="tag-input-chips">
+      <span v-for="(tag, index) in modelValue" :key="tag" class="profile-tag tag-input-chip">
+        {{ tag }}
+        <button
+          type="button"
+          class="tag-input-remove"
+          :aria-label="`Remove ${tag}`"
+          @click="remove(index)"
+        >×</button>
+      </span>
+    </div>
+    <div class="add-rule-form">
+      <input
+        :id="inputId"
+        type="text"
+        v-model="draft"
+        :placeholder="placeholder"
+        :maxlength="MAX_LENGTH"
+        @keypress="onKeypress"
+      >
+      <button type="button" class="btn btn-small btn-primary" @click="add">{{ addButtonLabel }}</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tag-input label {
+  display: block;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: var(--space-1);
+}
+
+.tag-input-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.tag-input-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.tag-input-remove {
+  border: none;
+  background: none;
+  color: inherit;
+  font-size: var(--text-md);
+  line-height: 1;
+  padding: 0;
+  cursor: pointer;
+}
+</style>

--- a/resources/js/components/molecules/EditModal.test.ts
+++ b/resources/js/components/molecules/EditModal.test.ts
@@ -19,10 +19,10 @@ const defaultItem = {
   seasons_watched: null,
   total_seasons: null,
   ignored: false,
+  enriched: false,
   genres: [],
   tags: [],
   description: null,
-  enrichment_status: null,
 }
 
 describe('EditModal', () => {
@@ -95,7 +95,79 @@ describe('EditModal', () => {
     await wrapper.findAll('.btn-primary').find(b => b.text().includes('Save'))!.trigger('click')
     const emitted = wrapper.emitted('save')!
     expect(emitted[0][0]).toBe(1)
-    expect(emitted[0][1]).toMatchObject({ status: 'completed' })
+    expect(emitted[0][1]).toEqual({
+      status: 'completed',
+      rating: null,
+      review: null,
+      genres: [],
+      tags: [],
+      description: null,
+    })
+    wrapper.unmount()
+  })
+
+  it('renders the enrichment subsection with genres, tags, and description fields', () => {
+    const wrapper = mount(EditModal, {
+      props: { item: defaultItem, saving: false },
+      attachTo: document.body,
+    })
+    expect(wrapper.find('.edit-modal-section').text()).toBe('Enrichment metadata')
+    expect(wrapper.find('label[for="edit-genres"]').exists()).toBe(true)
+    expect(wrapper.find('label[for="edit-tags"]').exists()).toBe(true)
+    expect(wrapper.find('label[for="edit-description"]').exists()).toBe(true)
+    expect(wrapper.find('#edit-description').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('pre-fills enrichment fields from the item', () => {
+    const item = { ...defaultItem, genres: ['Sci-Fi'], tags: ['classic'], description: 'A tale.' }
+    const wrapper = mount(EditModal, {
+      props: { item, saving: false },
+      attachTo: document.body,
+    })
+    expect(wrapper.text()).toContain('Sci-Fi')
+    expect(wrapper.text()).toContain('classic')
+    expect((wrapper.find('#edit-description').element as HTMLTextAreaElement).value).toBe('A tale.')
+    wrapper.unmount()
+  })
+
+  it('save emits edited genres, tags, and description', async () => {
+    const item = { ...defaultItem, genres: ['Sci-Fi'], tags: [], description: null }
+    const wrapper = mount(EditModal, {
+      props: { item, saving: false },
+      attachTo: document.body,
+    })
+    await wrapper.find('#edit-tags').setValue('classic')
+    await wrapper.find('#edit-tags').trigger('keypress', { key: 'Enter' })
+    await wrapper.find('#edit-description').setValue('A tale.')
+    await wrapper.findAll('.btn-primary').find(b => b.text().includes('Save'))!.trigger('click')
+    const emitted = wrapper.emitted('save')!
+    expect(emitted[0][1]).toEqual({
+      status: 'unread',
+      rating: null,
+      review: null,
+      genres: ['Sci-Fi'],
+      tags: ['classic'],
+      description: 'A tale.',
+    })
+    wrapper.unmount()
+  })
+
+  it('save serializes an empty description to null', async () => {
+    const wrapper = mount(EditModal, {
+      props: { item: defaultItem, saving: false },
+      attachTo: document.body,
+    })
+    await wrapper.findAll('.btn-primary').find(b => b.text().includes('Save'))!.trigger('click')
+    const emitted = wrapper.emitted('save')!
+    expect(emitted[0][1]).toEqual({
+      status: 'unread',
+      rating: null,
+      review: null,
+      genres: [],
+      tags: [],
+      description: null,
+    })
     wrapper.unmount()
   })
 })

--- a/resources/js/components/molecules/EditModal.vue
+++ b/resources/js/components/molecules/EditModal.vue
@@ -5,6 +5,7 @@ import { formatContentType, formatStatusForContentType } from '@/utils/format'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import StarRating from '@/components/atoms/StarRating.vue'
 import SeasonChecklist from '@/components/molecules/SeasonChecklist.vue'
+import TagInput from '@/components/atoms/TagInput.vue'
 
 const props = defineProps<{
   item: ContentItemResponse
@@ -23,6 +24,9 @@ const status = ref(props.item.status)
 const rating = ref<number | null>(props.item.rating)
 const review = ref(props.item.review || '')
 const seasonsWatched = ref<number[]>(props.item.seasons_watched || [])
+const genres = ref<string[]>(props.item.genres ?? [])
+const tags = ref<string[]>(props.item.tags ?? [])
+const description = ref(props.item.description ?? '')
 
 const isTvShow = computed(() => props.item.content_type === 'tv_show' && props.item.total_seasons)
 
@@ -44,6 +48,9 @@ function save() {
     status: status.value,
     rating: rating.value,
     review: review.value || null,
+    genres: genres.value,
+    tags: tags.value,
+    description: description.value || null,
   }
   if (isTvShow.value) {
     data.seasons_watched = seasonsWatched.value
@@ -92,6 +99,34 @@ function onBackdropClick(event: MouseEvent) {
           v-model="seasonsWatched"
           :total-seasons="item.total_seasons!"
         />
+      </div>
+
+      <hr class="edit-modal-divider">
+      <h4 class="edit-modal-section">Enrichment metadata</h4>
+
+      <div class="edit-field">
+        <TagInput
+          v-model="genres"
+          label="Genres"
+          input-id="edit-genres"
+          placeholder="Add a genre..."
+          empty-text="No genres yet"
+        />
+      </div>
+
+      <div class="edit-field">
+        <TagInput
+          v-model="tags"
+          label="Tags"
+          input-id="edit-tags"
+          placeholder="Add a tag..."
+          empty-text="No tags yet"
+        />
+      </div>
+
+      <div class="edit-field">
+        <label for="edit-description">Description</label>
+        <textarea id="edit-description" v-model="description" maxlength="10000" placeholder="Add a description..." />
       </div>
 
       <div class="edit-modal-actions">

--- a/resources/js/components/molecules/LibraryCard.test.ts
+++ b/resources/js/components/molecules/LibraryCard.test.ts
@@ -22,15 +22,189 @@ const baseItem = {
 }
 
 describe('LibraryCard', () => {
-  it('shows the "Not enriched" badge when the item is not enriched', () => {
-    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, enriched: false } } })
-    const badge = wrapper.find('.badge-enrichment')
-    expect(badge.exists()).toBe(true)
-    expect(badge.text()).toBe('Not enriched')
+  it('renders the type and status pills in the left meta zone', () => {
+    const wrapper = mount(LibraryCard, { props: { item: baseItem } })
+    const tags = wrapper.find('.library-meta-tags')
+    expect(tags.exists()).toBe(true)
+    expect(tags.find('.badge-type').text()).toBe('Book')
+    expect(tags.find('.badge-status').text()).toBe('Unread')
   })
 
-  it('omits the enrichment badge when the item is enriched', () => {
-    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, enriched: true } } })
+  it('renders the rating as a non-badge element with five star slots', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, rating: 3 } } })
+
+    // Rating is no longer a badge.
+    expect(wrapper.find('.badge-rating').exists()).toBe(false)
+
+    const rating = wrapper.find('.rating-stars')
+    expect(rating.exists()).toBe(true)
+
+    const stars = rating.findAll('.star')
+    expect(stars.length).toBe(5)
+    expect(rating.findAll('.star.filled').length).toBe(3)
+    expect(rating.findAll('.star.empty').length).toBe(2)
+
+    // The filled-vs-empty glyph distinction is the whole visual rationale, so
+    // assert the actual rendered characters to catch an accidental template swap.
+    expect(rating.find('.star.filled').text()).toBe('★')
+    expect(rating.find('.star.empty').text()).toBe('☆')
+
+    // Visible numeric value and screen-reader text.
+    expect(rating.find('.value').text()).toBe('3/5')
+    expect(rating.find('.sr-only').text()).toBe('Rated 3 out of 5')
+
+    // The glyph wrapper and numeric value are hidden from assistive tech so the
+    // rating is announced once via the sr-only text, not duplicated.
+    const glyphWrapper = rating.find('.star').element.parentElement
+    expect(glyphWrapper?.getAttribute('aria-hidden')).toBe('true')
+    expect(rating.find('.value').attributes('aria-hidden')).toBe('true')
+  })
+
+  it('fills exactly one star at the minimum rating of 1', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, rating: 1 } } })
+    const rating = wrapper.find('.rating-stars')
+    expect(rating.findAll('.star.filled').length).toBe(1)
+    expect(rating.findAll('.star.empty').length).toBe(4)
+    expect(rating.find('.value').text()).toBe('1/5')
+    expect(rating.find('.sr-only').text()).toBe('Rated 1 out of 5')
+  })
+
+  it('fills all five stars at the maximum rating of 5', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, rating: 5 } } })
+    const rating = wrapper.find('.rating-stars')
+    expect(rating.findAll('.star.filled').length).toBe(5)
+    expect(rating.findAll('.star.empty').length).toBe(0)
+    expect(rating.find('.value').text()).toBe('5/5')
+    expect(rating.find('.sr-only').text()).toBe('Rated 5 out of 5')
+  })
+
+  it('renders five empty stars at a rating of 0', () => {
+    // Documents the `v-if="item.rating !== null"` render-guard boundary: a 0
+    // rating still renders. The backend constrains rating to 1-5, so this is not
+    // a reachable backend state, only a guard-behavior assertion.
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, rating: 0 } } })
+    const rating = wrapper.find('.rating-stars')
+    expect(rating.exists()).toBe(true)
+    expect(rating.findAll('.star.filled').length).toBe(0)
+    expect(rating.findAll('.star.empty').length).toBe(5)
+    expect(rating.find('.value').text()).toBe('0/5')
+    expect(rating.find('.sr-only').text()).toBe('Rated 0 out of 5')
+  })
+
+  it('renders no rating element for an unrated item', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, rating: null } } })
+    expect(wrapper.find('.rating-stars').exists()).toBe(false)
+    // The meta row still renders with its pills.
+    expect(wrapper.find('.library-meta-tags .badge-type').exists()).toBe(true)
+  })
+
+  it('shows the "Not enriched" marker in the state caption line, not the pill row', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, enriched: false } } })
+    const state = wrapper.find('.library-state.not-enriched')
+    expect(state.exists()).toBe(true)
+    // The decorative .dot span carries no text, so the label is deterministic.
+    expect(state.text()).toBe('Not enriched')
+    // Not a badge.
     expect(wrapper.find('.badge-enrichment').exists()).toBe(false)
+  })
+
+  it('shows the "Ignored" marker in the state caption line', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, ignored: true } } })
+    const state = wrapper.find('.library-state.ignored')
+    expect(state.exists()).toBe(true)
+    expect(state.text()).toBe('Ignored')
+    expect(wrapper.find('.badge-ignored').exists()).toBe(false)
+  })
+
+  it('shows both state markers together when the item is not enriched and ignored', () => {
+    const wrapper = mount(LibraryCard, {
+      props: { item: { ...baseItem, enriched: false, ignored: true } },
+    })
+    expect(wrapper.find('.library-state.not-enriched').text()).toBe('Not enriched')
+    expect(wrapper.find('.library-state.ignored').text()).toBe('Ignored')
+  })
+
+  it('renders no rating and no state line for an enriched, non-ignored, unrated item', () => {
+    const wrapper = mount(LibraryCard, { props: { item: baseItem } })
+    expect(wrapper.find('.rating-stars').exists()).toBe(false)
+    expect(wrapper.find('.library-state-lines').exists()).toBe(false)
+    expect(wrapper.find('.library-state').exists()).toBe(false)
+  })
+
+  it('emits edit with the db_id when the Edit button is clicked', async () => {
+    const wrapper = mount(LibraryCard, { props: { item: baseItem } })
+    const buttons = wrapper.findAll('.library-item-actions button')
+    const edit = buttons.find((b) => b.text() === 'Edit')
+    expect(edit).toBeDefined()
+    await edit!.trigger('click')
+    expect(wrapper.emitted('edit')).toEqual([[1]])
+  })
+
+  it('emits toggleIgnore to ignore a non-ignored item and labels the button "Ignore"', async () => {
+    const wrapper = mount(LibraryCard, {
+      props: { item: { ...baseItem, ignored: false } },
+    })
+    const buttons = wrapper.findAll('.library-item-actions button')
+    const action = buttons.find((b) => b.text() === 'Ignore')
+    expect(action).toBeDefined()
+    await action!.trigger('click')
+    expect(wrapper.emitted('toggleIgnore')).toEqual([[1, true]])
+  })
+
+  it('emits toggleIgnore to unignore an ignored item and labels the button "Unignore"', async () => {
+    const wrapper = mount(LibraryCard, {
+      props: { item: { ...baseItem, ignored: true } },
+    })
+    const buttons = wrapper.findAll('.library-item-actions button')
+    const action = buttons.find((b) => b.text() === 'Unignore')
+    expect(action).toBeDefined()
+    await action!.trigger('click')
+    expect(wrapper.emitted('toggleIgnore')).toEqual([[1, false]])
+  })
+
+  it('applies the ignored class to the root only when the item is ignored', () => {
+    const ignored = mount(LibraryCard, { props: { item: { ...baseItem, ignored: true } } })
+    expect(ignored.find('.library-item').classes()).toContain('ignored')
+
+    const notIgnored = mount(LibraryCard, { props: { item: { ...baseItem, ignored: false } } })
+    expect(notIgnored.find('.library-item').classes()).not.toContain('ignored')
+  })
+
+  it('renders no action buttons when the item has no db_id', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, db_id: null } } })
+    expect(wrapper.find('.library-item-actions').exists()).toBe(false)
+  })
+
+  it('renders the title but no author element when the author is absent', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, author: null } } })
+    expect(wrapper.find('.item-author').exists()).toBe(false)
+    expect(wrapper.find('h3').text()).toBe('Test Book')
+  })
+
+  it('renders a content-type-aware status label for non-book items', () => {
+    const wrapper = mount(LibraryCard, {
+      props: { item: { ...baseItem, content_type: 'movie', status: 'unread' } },
+    })
+    expect(wrapper.find('.badge-status').text()).toBe('Unwatched')
+  })
+
+  it('falls back to the unknown status class for an out-of-allowlist status', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, status: 'archived' } } })
+    expect(wrapper.find('.badge-status').classes()).toContain('unknown')
+  })
+
+  it('applies the currently_consuming status class and label for an in-progress item', () => {
+    const wrapper = mount(LibraryCard, {
+      props: { item: { ...baseItem, status: 'currently_consuming' } },
+    })
+    expect(wrapper.find('.badge-status').classes()).toContain('currently_consuming')
+    expect(wrapper.find('.badge-status').text()).toBe('In Progress')
+  })
+
+  it('applies the completed status class for a completed item', () => {
+    const wrapper = mount(LibraryCard, {
+      props: { item: { ...baseItem, status: 'completed' } },
+    })
+    expect(wrapper.find('.badge-status').classes()).toContain('completed')
   })
 })

--- a/resources/js/components/molecules/LibraryCard.test.ts
+++ b/resources/js/components/molecules/LibraryCard.test.ts
@@ -22,12 +22,36 @@ const baseItem = {
 }
 
 describe('LibraryCard', () => {
-  it('renders the type and status pills in the left meta zone', () => {
+  it('renders the type and status pills in the primary meta row', () => {
     const wrapper = mount(LibraryCard, { props: { item: baseItem } })
-    const tags = wrapper.find('.library-meta-tags')
-    expect(tags.exists()).toBe(true)
-    expect(tags.find('.badge-type').text()).toBe('Book')
-    expect(tags.find('.badge-status').text()).toBe('Unread')
+    const meta = wrapper.find('.library-meta')
+    expect(meta.exists()).toBe(true)
+    expect(meta.find('.badge-type').text()).toBe('Book')
+    expect(meta.find('.badge-status').text()).toBe('Unread')
+    expect(meta.find('.badge-status').classes()).toContain('unread')
+  })
+
+  it('renders a "Not enriched" pill in the primary meta row only for unenriched items', () => {
+    const notEnriched = mount(LibraryCard, { props: { item: { ...baseItem, enriched: false } } })
+    const pill = notEnriched.find('.library-meta .badge-enrichment')
+    expect(pill.exists()).toBe(true)
+    expect(pill.text()).toBe('Not enriched')
+
+    const enriched = mount(LibraryCard, { props: { item: baseItem } })
+    expect(enriched.find('.badge-enrichment').exists()).toBe(false)
+  })
+
+  it('renders both the "Not enriched" and "Ignored" markers when an item is both', () => {
+    const wrapper = mount(LibraryCard, {
+      props: { item: { ...baseItem, enriched: false, ignored: true } },
+    })
+    const meta = wrapper.find('.library-meta')
+    expect(meta.exists()).toBe(true)
+    expect(meta.find('.badge-enrichment').text()).toBe('Not enriched')
+
+    const secondary = wrapper.find('.library-meta-secondary')
+    expect(secondary.exists()).toBe(true)
+    expect(secondary.find('.badge-ignored').text()).toBe('Ignored')
   })
 
   it('renders the rating as a non-badge element with five star slots', () => {
@@ -36,7 +60,10 @@ describe('LibraryCard', () => {
     // Rating is no longer a badge.
     expect(wrapper.find('.badge-rating').exists()).toBe(false)
 
-    const rating = wrapper.find('.rating-stars')
+    // For a rated, non-ignored item the rating lives inside the secondary row.
+    const secondary = wrapper.find('.library-meta-secondary')
+    expect(secondary.exists()).toBe(true)
+    const rating = secondary.find('.rating-stars')
     expect(rating.exists()).toBe(true)
 
     const stars = rating.findAll('.star')
@@ -94,41 +121,39 @@ describe('LibraryCard', () => {
   it('renders no rating element for an unrated item', () => {
     const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, rating: null } } })
     expect(wrapper.find('.rating-stars').exists()).toBe(false)
-    // The meta row still renders with its pills.
-    expect(wrapper.find('.library-meta-tags .badge-type').exists()).toBe(true)
+    // The primary meta row still renders with its pills.
+    expect(wrapper.find('.library-meta .badge-type').exists()).toBe(true)
   })
 
-  it('shows the "Not enriched" marker in the state caption line, not the pill row', () => {
-    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, enriched: false } } })
-    const state = wrapper.find('.library-state.not-enriched')
-    expect(state.exists()).toBe(true)
-    // The decorative .dot span carries no text, so the label is deterministic.
-    expect(state.text()).toBe('Not enriched')
-    // Not a badge.
-    expect(wrapper.find('.badge-enrichment').exists()).toBe(false)
-  })
-
-  it('shows the "Ignored" marker in the state caption line', () => {
-    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, ignored: true } } })
-    const state = wrapper.find('.library-state.ignored')
-    expect(state.exists()).toBe(true)
-    expect(state.text()).toBe('Ignored')
+  it('renders no "Ignored" pill for a non-ignored item', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, ignored: false } } })
     expect(wrapper.find('.badge-ignored').exists()).toBe(false)
   })
 
-  it('shows both state markers together when the item is not enriched and ignored', () => {
+  it('renders both the rating and the Ignored pill in the secondary row together', () => {
     const wrapper = mount(LibraryCard, {
-      props: { item: { ...baseItem, enriched: false, ignored: true } },
+      props: { item: { ...baseItem, rating: 3, ignored: true } },
     })
-    expect(wrapper.find('.library-state.not-enriched').text()).toBe('Not enriched')
-    expect(wrapper.find('.library-state.ignored').text()).toBe('Ignored')
+    const secondary = wrapper.find('.library-meta-secondary')
+    expect(secondary.exists()).toBe(true)
+    expect(secondary.find('.rating-stars').exists()).toBe(true)
+    expect(secondary.find('.badge-ignored').text()).toBe('Ignored')
   })
 
-  it('renders no rating and no state line for an enriched, non-ignored, unrated item', () => {
+  it('renders the secondary row with the Ignored pill but no rating when ignored and unrated', () => {
+    const wrapper = mount(LibraryCard, {
+      props: { item: { ...baseItem, rating: null, ignored: true } },
+    })
+    const secondary = wrapper.find('.library-meta-secondary')
+    expect(secondary.exists()).toBe(true)
+    expect(secondary.find('.rating-stars').exists()).toBe(false)
+    expect(secondary.find('.badge-ignored').text()).toBe('Ignored')
+  })
+
+  it('renders no secondary meta row for an unrated, non-ignored item', () => {
     const wrapper = mount(LibraryCard, { props: { item: baseItem } })
     expect(wrapper.find('.rating-stars').exists()).toBe(false)
-    expect(wrapper.find('.library-state-lines').exists()).toBe(false)
-    expect(wrapper.find('.library-state').exists()).toBe(false)
+    expect(wrapper.find('.library-meta-secondary').exists()).toBe(false)
   })
 
   it('emits edit with the db_id when the Edit button is clicked', async () => {
@@ -147,6 +172,7 @@ describe('LibraryCard', () => {
     const buttons = wrapper.findAll('.library-item-actions button')
     const action = buttons.find((b) => b.text() === 'Ignore')
     expect(action).toBeDefined()
+    expect(action!.classes()).toContain('btn-ignore')
     await action!.trigger('click')
     expect(wrapper.emitted('toggleIgnore')).toEqual([[1, true]])
   })
@@ -158,6 +184,7 @@ describe('LibraryCard', () => {
     const buttons = wrapper.findAll('.library-item-actions button')
     const action = buttons.find((b) => b.text() === 'Unignore')
     expect(action).toBeDefined()
+    expect(action!.classes()).toContain('btn-unignore')
     await action!.trigger('click')
     expect(wrapper.emitted('toggleIgnore')).toEqual([[1, false]])
   })

--- a/resources/js/components/molecules/LibraryCard.test.ts
+++ b/resources/js/components/molecules/LibraryCard.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import LibraryCard from './LibraryCard.vue'
+
+const baseItem = {
+  id: 'test-1',
+  db_id: 1,
+  title: 'Test Book',
+  author: 'Author',
+  content_type: 'book',
+  status: 'unread',
+  rating: null,
+  review: null,
+  source: 'goodreads',
+  ignored: false,
+  seasons_watched: null,
+  total_seasons: null,
+  enriched: true,
+  genres: [],
+  tags: [],
+  description: null,
+}
+
+describe('LibraryCard', () => {
+  it('shows the "Not enriched" badge when the item is not enriched', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, enriched: false } } })
+    const badge = wrapper.find('.badge-enrichment')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('Not enriched')
+  })
+
+  it('omits the enrichment badge when the item is enriched', () => {
+    const wrapper = mount(LibraryCard, { props: { item: { ...baseItem, enriched: true } } })
+    expect(wrapper.find('.badge-enrichment').exists()).toBe(false)
+  })
+})

--- a/resources/js/components/molecules/LibraryCard.vue
+++ b/resources/js/components/molecules/LibraryCard.vue
@@ -22,12 +22,13 @@ function statusClass(status: string): string {
     <h3>{{ item.title }}</h3>
     <div v-if="item.author" class="item-author">{{ item.author }}</div>
     <div class="library-meta">
-      <div class="library-meta-tags">
-        <span class="badge badge-type">{{ formatContentType(item.content_type) }}</span>
-        <span class="badge badge-status" :class="statusClass(item.status)">
-          {{ formatStatusForContentType(item.status, item.content_type) }}
-        </span>
-      </div>
+      <span class="badge badge-type">{{ formatContentType(item.content_type) }}</span>
+      <span class="badge badge-status" :class="statusClass(item.status)">
+        {{ formatStatusForContentType(item.status, item.content_type) }}
+      </span>
+      <span v-if="!item.enriched" class="badge badge-enrichment">Not enriched</span>
+    </div>
+    <div v-if="item.rating !== null || item.ignored" class="library-meta-secondary">
       <span v-if="item.rating !== null" class="rating-stars">
         <span aria-hidden="true">
           <span
@@ -40,16 +41,7 @@ function statusClass(status: string): string {
         <span class="value" aria-hidden="true">{{ item.rating }}/5</span>
         <span class="sr-only">Rated {{ item.rating }} out of 5</span>
       </span>
-    </div>
-    <div v-if="!item.enriched || item.ignored" class="library-state-lines">
-      <span v-if="!item.enriched" class="library-state not-enriched">
-        <span class="dot" aria-hidden="true"></span>
-        Not enriched
-      </span>
-      <span v-if="item.ignored" class="library-state ignored">
-        <span class="dot" aria-hidden="true"></span>
-        Ignored
-      </span>
+      <span v-if="item.ignored" class="badge badge-ignored">Ignored</span>
     </div>
     <div v-if="item.db_id" class="library-item-actions">
       <button class="btn btn-small btn-secondary" @click="emit('edit', item.db_id!)">Edit</button>

--- a/resources/js/components/molecules/LibraryCard.vue
+++ b/resources/js/components/molecules/LibraryCard.vue
@@ -31,6 +31,7 @@ function statusClass(status: string): string {
         {{ formatStatusForContentType(item.status, item.content_type) }}
       </span>
       <span v-if="item.rating" class="badge badge-rating">{{ renderStars(item.rating) }}</span>
+      <span v-if="!item.enriched" class="badge badge-enrichment">Not enriched</span>
       <span v-if="item.ignored" class="badge badge-ignored">Ignored</span>
     </div>
     <div v-if="item.db_id" class="library-item-actions">

--- a/resources/js/components/molecules/LibraryCard.vue
+++ b/resources/js/components/molecules/LibraryCard.vue
@@ -11,10 +11,6 @@ const emit = defineEmits<{
   toggleIgnore: [dbId: number, ignored: boolean]
 }>()
 
-function renderStars(rating: number): string {
-  return '★'.repeat(rating)
-}
-
 function statusClass(status: string): string {
   const valid = ['unread', 'currently_consuming', 'completed']
   return valid.includes(status) ? status : 'unknown'
@@ -25,14 +21,35 @@ function statusClass(status: string): string {
   <div class="library-item" :class="{ ignored: item.ignored }">
     <h3>{{ item.title }}</h3>
     <div v-if="item.author" class="item-author">{{ item.author }}</div>
-    <div class="library-item-badges">
-      <span class="badge badge-type">{{ formatContentType(item.content_type) }}</span>
-      <span class="badge badge-status" :class="statusClass(item.status)">
-        {{ formatStatusForContentType(item.status, item.content_type) }}
+    <div class="library-meta">
+      <div class="library-meta-tags">
+        <span class="badge badge-type">{{ formatContentType(item.content_type) }}</span>
+        <span class="badge badge-status" :class="statusClass(item.status)">
+          {{ formatStatusForContentType(item.status, item.content_type) }}
+        </span>
+      </div>
+      <span v-if="item.rating !== null" class="rating-stars">
+        <span aria-hidden="true">
+          <span
+            v-for="star in 5"
+            :key="star"
+            class="star"
+            :class="star <= item.rating ? 'filled' : 'empty'"
+          >{{ star <= item.rating ? '★' : '☆' }}</span>
+        </span>
+        <span class="value" aria-hidden="true">{{ item.rating }}/5</span>
+        <span class="sr-only">Rated {{ item.rating }} out of 5</span>
       </span>
-      <span v-if="item.rating" class="badge badge-rating">{{ renderStars(item.rating) }}</span>
-      <span v-if="!item.enriched" class="badge badge-enrichment">Not enriched</span>
-      <span v-if="item.ignored" class="badge badge-ignored">Ignored</span>
+    </div>
+    <div v-if="!item.enriched || item.ignored" class="library-state-lines">
+      <span v-if="!item.enriched" class="library-state not-enriched">
+        <span class="dot" aria-hidden="true"></span>
+        Not enriched
+      </span>
+      <span v-if="item.ignored" class="library-state ignored">
+        <span class="dot" aria-hidden="true"></span>
+        Ignored
+      </span>
     </div>
     <div v-if="item.db_id" class="library-item-actions">
       <button class="btn btn-small btn-secondary" @click="emit('edit', item.db_id!)">Edit</button>

--- a/resources/js/components/organisms/LibraryFilters.test.ts
+++ b/resources/js/components/organisms/LibraryFilters.test.ts
@@ -6,6 +6,7 @@ describe('LibraryFilters', () => {
   const defaultProps = {
     typeFilter: '',
     statusFilter: '',
+    enrichmentFilter: '',
     showIgnored: false,
   }
 
@@ -41,6 +42,34 @@ describe('LibraryFilters', () => {
     await select.setValue('completed')
 
     expect(wrapper.emitted('filterChange')).toEqual([['status', 'completed']])
+  })
+
+  it('renders the enrichment select with All/Enriched/Not enriched options', () => {
+    const wrapper = mount(LibraryFilters, { props: defaultProps })
+
+    const select = wrapper.find('select[aria-label="Enrichment"]')
+    expect(select.exists()).toBe(true)
+    const options = select.findAll('option')
+    expect(options.map(o => o.text())).toEqual(['All Items', 'Enriched', 'Not enriched'])
+    expect(options.map(o => o.attributes('value'))).toEqual(['', 'enriched', 'not_enriched'])
+  })
+
+  it('reflects enrichmentFilter prop in the enrichment select value', () => {
+    const wrapper = mount(LibraryFilters, {
+      props: { ...defaultProps, enrichmentFilter: 'not_enriched' },
+    })
+
+    const el = wrapper.find('select[aria-label="Enrichment"]').element as HTMLSelectElement
+    expect(el.value).toBe('not_enriched')
+  })
+
+  it('emits filterChange for enrichment on select change', async () => {
+    const wrapper = mount(LibraryFilters, { props: defaultProps })
+
+    const select = wrapper.find('select[aria-label="Enrichment"]')
+    await select.setValue('not_enriched')
+
+    expect(wrapper.emitted('filterChange')).toEqual([['enrichment', 'not_enriched']])
   })
 
   it('renders Unwatched label for movies', () => {

--- a/resources/js/components/organisms/LibraryFilters.vue
+++ b/resources/js/components/organisms/LibraryFilters.vue
@@ -7,11 +7,12 @@ import ToggleSwitch from '@/components/atoms/ToggleSwitch.vue'
 const props = defineProps<{
   typeFilter: string
   statusFilter: string
+  enrichmentFilter: string
   showIgnored: boolean
 }>()
 
 const emit = defineEmits<{
-  filterChange: [key: 'type' | 'status' | 'showIgnored', value: string | boolean]
+  filterChange: [key: 'type' | 'status' | 'enrichment' | 'showIgnored', value: string | boolean]
   export: [format: 'csv' | 'json']
 }>()
 
@@ -77,6 +78,11 @@ onUnmounted(() => {
           <option value="unread">{{ unreadLabel }}</option>
           <option value="currently_consuming">In Progress</option>
           <option value="completed">Completed</option>
+        </select>
+        <select class="toolbar-select" aria-label="Enrichment" :value="enrichmentFilter" @change="emit('filterChange', 'enrichment', ($event.target as HTMLSelectElement).value)">
+          <option value="">All Items</option>
+          <option value="enriched">Enriched</option>
+          <option value="not_enriched">Not enriched</option>
         </select>
       </div>
 

--- a/resources/js/components/pages/LibraryPage.vue
+++ b/resources/js/components/pages/LibraryPage.vue
@@ -64,6 +64,7 @@ onUnmounted(() => {
     <LibraryFilters
       :type-filter="lib.typeFilter"
       :status-filter="lib.statusFilter"
+      :enrichment-filter="lib.enrichmentFilter"
       :show-ignored="lib.showIgnored"
       @filter-change="lib.setFilter"
       @export="lib.exportLibrary"

--- a/resources/js/components/pages/RecommendationsPage.test.ts
+++ b/resources/js/components/pages/RecommendationsPage.test.ts
@@ -19,6 +19,10 @@ function makeFullItem(overrides: Partial<ContentItemResponse> = {}): ContentItem
     ignored: false,
     seasons_watched: null,
     total_seasons: null,
+    enriched: true,
+    genres: [],
+    tags: [],
+    description: null,
     ...overrides,
   }
 }

--- a/resources/js/stores/data.test.ts
+++ b/resources/js/stores/data.test.ts
@@ -249,6 +249,137 @@ describe('useDataStore', () => {
     expect(store.isSourceIdSyncing('steam')).toBe(false)
   })
 
+  it('checkSyncStatus starts enrichment polling when a completed sync auto-triggered enrichment', async () => {
+    // Reported in #59: after a sync that auto-triggers enrichment
+    // (enrichment.auto_enrich_on_sync), the data view did not reflect that
+    // enrichment was running and never live-updated — the user had to
+    // navigate away and back. Root cause: the completed branch of
+    // checkSyncStatus called loadEnrichmentStats() once (a one-shot refresh)
+    // instead of checkEnrichmentStatus(), so the running job was never
+    // detected and polling never started. Fix calls checkEnrichmentStatus()
+    // which both refreshes stats and starts the 3s poll when running.
+    const runningStatus = {
+      running: true,
+      completed: false,
+      cancelled: false,
+      items_processed: 5,
+      items_enriched: 5,
+      items_failed: 0,
+      items_not_found: 0,
+      total_items: 50,
+      current_item: 'Half-Life 2',
+      content_type: null,
+      errors: [],
+      elapsed_seconds: 2.0,
+      progress_percent: 10,
+    }
+    const stats = {
+      enabled: true,
+      total: 50,
+      enriched: 5,
+      pending: 45,
+      not_found: 0,
+      failed: 0,
+      by_provider: {},
+      by_quality: {},
+    }
+    mockGet
+      // checkSyncStatus -> GET /sync/status (completed, nothing running)
+      .mockResolvedValueOnce({
+        status: 'idle',
+        jobs: [
+          {
+            source: 'Steam',
+            status: 'completed',
+            items_processed: 50,
+            total_items: 50,
+            error_count: 0,
+            errors: [],
+            sources: [],
+          },
+        ],
+      })
+      // checkEnrichmentStatus -> GET /enrichment/status (job running)
+      .mockResolvedValueOnce(runningStatus)
+      // checkEnrichmentStatus -> GET /enrichment/stats (refresh while running)
+      .mockResolvedValueOnce(stats)
+
+    const store = useDataStore()
+    await store.checkSyncStatus()
+    // Let the checkEnrichmentStatus() chain (not awaited in the completed
+    // branch) settle before asserting.
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(store.syncStatus).toBe('completed')
+    expect(store.enrichmentJob).toEqual(runningStatus)
+    expect(store.enrichmentStats).toEqual(stats)
+
+    // Polling is live: a tick re-fetches status (running again) + stats,
+    // and the refreshed values land in the store.
+    const tickStatus = { ...runningStatus, items_processed: 30, items_enriched: 30, progress_percent: 60 }
+    const tickStats = { ...stats, enriched: 30, pending: 20 }
+    mockGet.mockResolvedValueOnce(tickStatus).mockResolvedValueOnce(tickStats)
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(mockGet).toHaveBeenCalledWith('/enrichment/status')
+    expect(store.enrichmentJob).toEqual(tickStatus)
+    expect(store.enrichmentStats).toEqual(tickStats)
+
+    store.cleanup()
+  })
+
+  it('checkSyncStatus does not start enrichment polling when the completed sync left enrichment idle', async () => {
+    // Symmetric to the auto-trigger case: a completed sync that did NOT
+    // start enrichment must not spin up the 3s enrichment poll, otherwise
+    // the data view would fetch /enrichment/status forever for no reason.
+    const idleStatus = {
+      running: false,
+      completed: false,
+      cancelled: false,
+      items_processed: 0,
+      items_enriched: 0,
+      items_failed: 0,
+      items_not_found: 0,
+      total_items: 0,
+      current_item: null,
+      content_type: null,
+      errors: [],
+      elapsed_seconds: 0,
+      progress_percent: 0,
+    }
+    mockGet
+      // checkSyncStatus -> GET /sync/status (completed, nothing running)
+      .mockResolvedValueOnce({
+        status: 'idle',
+        jobs: [
+          {
+            source: 'Steam',
+            status: 'completed',
+            items_processed: 50,
+            total_items: 50,
+            error_count: 0,
+            errors: [],
+            sources: [],
+          },
+        ],
+      })
+      // checkEnrichmentStatus -> GET /enrichment/status (not running)
+      .mockResolvedValueOnce(idleStatus)
+
+    const store = useDataStore()
+    await store.checkSyncStatus()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(store.syncStatus).toBe('completed')
+    expect(store.enrichmentJob).toEqual(idleStatus)
+
+    // No poll is scheduled: advancing past a tick must not re-fetch status.
+    const callsBefore = mockGet.mock.calls.length
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(mockGet.mock.calls.length).toBe(callsBefore)
+
+    store.cleanup()
+  })
+
   it('checkSyncStatus aggregates errors across completed jobs', async () => {
     mockGet.mockResolvedValue({
       status: 'idle',

--- a/resources/js/stores/data.ts
+++ b/resources/js/stores/data.ts
@@ -189,7 +189,12 @@ export const useDataStore = defineStore('data', () => {
           syncMessage.value = msg
         }
         stopSyncPolling()
-        loadEnrichmentStats()
+        // A completed sync may have auto-triggered enrichment server-side
+        // (enrichment.auto_enrich_on_sync). checkEnrichmentStatus refreshes
+        // the stats AND starts polling when a job is running, so the data
+        // view live-updates enrichment progress without a manual reload —
+        // a one-shot loadEnrichmentStats would miss the running job.
+        checkEnrichmentStatus()
       } else {
         syncStatus.value = 'idle'
         syncMessage.value = ''

--- a/resources/js/stores/library.test.ts
+++ b/resources/js/stores/library.test.ts
@@ -74,6 +74,27 @@ describe('useLibraryStore', () => {
     expect(mockGet).toHaveBeenCalled()
   })
 
+  it('setFilter stores the enrichment filter and sends it as a query param', async () => {
+    mockGet.mockResolvedValue([])
+    const store = useLibraryStore()
+
+    await store.setFilter('enrichment', 'not_enriched')
+
+    expect(store.enrichmentFilter).toBe('not_enriched')
+    const params = mockGet.mock.lastCall![1]
+    expect(params.enrichment).toBe('not_enriched')
+  })
+
+  it('omits the enrichment param when no enrichment filter is set', async () => {
+    mockGet.mockResolvedValue([])
+    const store = useLibraryStore()
+
+    await store.resetAndLoad()
+
+    const params = mockGet.mock.lastCall![1]
+    expect(params.enrichment).toBeUndefined()
+  })
+
   it('saveEdit updates item in list', async () => {
     const item = { db_id: 1, title: 'Book A', content_type: 'book', status: 'unread', rating: null, ignored: false }
     mockGet.mockResolvedValue([item])
@@ -85,9 +106,26 @@ describe('useLibraryStore', () => {
     store.editingItem = item as any
     await store.saveEdit(1, { status: 'completed', rating: 4 })
 
+    expect(mockPatch.mock.lastCall![0]).toBe('/items/1')
     expect(store.items[0].status).toBe('completed')
     expect(store.items[0].rating).toBe(4)
     expect(store.editingItem).toBeNull()
+  })
+
+  it('saveEdit posts enrichment fields and flips the local enriched flag', async () => {
+    const item = { db_id: 1, title: 'Book A', content_type: 'book', status: 'unread', rating: null, ignored: false, enriched: false, genres: [], tags: [], description: null }
+    mockGet.mockResolvedValue([item])
+    const store = useLibraryStore()
+    await store.resetAndLoad()
+
+    const updated = { ...item, enriched: true, genres: ['Sci-Fi'], tags: ['classic'], description: 'A tale.' }
+    mockPatch.mockResolvedValue(updated)
+    await store.saveEdit(1, { status: 'unread', genres: ['Sci-Fi'], tags: ['classic'], description: 'A tale.' })
+
+    const body = mockPatch.mock.lastCall![1]
+    expect(body).toMatchObject({ genres: ['Sci-Fi'], tags: ['classic'], description: 'A tale.' })
+    expect(store.items[0].enriched).toBe(true)
+    expect(store.items[0].genres).toEqual(['Sci-Fi'])
   })
 
   it('toggleIgnore updates item in list', async () => {

--- a/resources/js/stores/library.ts
+++ b/resources/js/stores/library.ts
@@ -19,6 +19,7 @@ export const useLibraryStore = defineStore('library', () => {
   // Filters
   const typeFilter = ref('')
   const statusFilter = ref('')
+  const enrichmentFilter = ref('')
   const showIgnored = ref(false)
 
   // Edit modal
@@ -51,6 +52,7 @@ export const useLibraryStore = defineStore('library', () => {
       }
       if (typeFilter.value) params.type = typeFilter.value
       if (statusFilter.value) params.status = statusFilter.value
+      if (enrichmentFilter.value) params.enrichment = enrichmentFilter.value
       if (showIgnored.value) params.include_ignored = true
 
       const result = await api.get<ContentItemResponse[]>('/items', params)
@@ -79,9 +81,10 @@ export const useLibraryStore = defineStore('library', () => {
     }
   }
 
-  function setFilter(key: 'type' | 'status' | 'showIgnored', value: string | boolean) {
+  function setFilter(key: 'type' | 'status' | 'enrichment' | 'showIgnored', value: string | boolean) {
     if (key === 'type') typeFilter.value = value as string
     else if (key === 'status') statusFilter.value = value as string
+    else if (key === 'enrichment') enrichmentFilter.value = value as string
     else if (key === 'showIgnored') showIgnored.value = value as boolean
     return resetAndLoad()
   }
@@ -165,6 +168,7 @@ export const useLibraryStore = defineStore('library', () => {
     error,
     typeFilter,
     statusFilter,
+    enrichmentFilter,
     showIgnored,
     editingItem,
     editSaving,

--- a/resources/js/stores/recommendations.test.ts
+++ b/resources/js/stores/recommendations.test.ts
@@ -17,6 +17,10 @@ function makeItem(overrides: Partial<ContentItemResponse> = {}): ContentItemResp
     ignored: false,
     seasons_watched: null,
     total_seasons: null,
+    enriched: true,
+    genres: [],
+    tags: [],
+    description: null,
     ...overrides,
   }
 }

--- a/resources/js/types/api.ts
+++ b/resources/js/types/api.ts
@@ -15,6 +15,10 @@ export interface ContentItemResponse {
   ignored: boolean
   seasons_watched: number[] | null
   total_seasons: number | null
+  enriched: boolean
+  genres: string[]
+  tags: string[]
+  description: string | null
 }
 
 export interface RecommendationResponse {
@@ -287,6 +291,9 @@ export interface ItemEditRequest {
   rating?: number | null
   review?: string | null
   seasons_watched?: number[] | null
+  genres?: string[]
+  tags?: string[]
+  description?: string | null
 }
 
 export interface IgnoreItemRequest {

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -11,7 +11,7 @@ import threading
 import time
 import webbrowser
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import Any, NoReturn, cast
 
 import click
 from tabulate import tabulate
@@ -29,6 +29,7 @@ from src.models.content import (
     ConsumptionStatus,
     ContentItem,
     ContentType,
+    EnrichmentFilter,
     get_enum_value,
 )
 from src.models.user_preferences import UserPreferenceConfig
@@ -79,6 +80,14 @@ from src.web.sync_sources import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Manual-enrichment bounds, mirroring the web ItemEditRequest so both
+# interfaces reject the same oversized genres/tags/descriptions.
+MAX_GENRES = 50
+MAX_TAGS = 100
+MAX_GENRE_TAG_LENGTH = 100
+MAX_DESCRIPTION_LENGTH = 10000
+MAX_REVIEW_LENGTH = 10000
 
 
 @click.command()
@@ -1189,6 +1198,13 @@ def library() -> None:
     help="Include ignored items",
 )
 @click.option(
+    "--enrichment",
+    "enrichment_str",
+    type=click.Choice(["enriched", "not_enriched"], case_sensitive=False),
+    default=None,
+    help="Filter by enrichment state (default: all)",
+)
+@click.option(
     "--limit",
     type=click.IntRange(min=1, max=200),
     default=50,
@@ -1221,6 +1237,7 @@ def library_list(
     status_str: str | None,
     sort_by: str,
     show_ignored: bool,
+    enrichment_str: str | None,
     limit: int | None,
     offset: int,
     output_format: str,
@@ -1233,6 +1250,9 @@ def library_list(
         ContentType.from_string(content_type_str) if content_type_str else None
     )
     consumption_status = ConsumptionStatus(status_str) if status_str else None
+    enrichment: EnrichmentFilter | None = (
+        cast(EnrichmentFilter, enrichment_str.lower()) if enrichment_str else None
+    )
 
     items: list[ContentItem] = storage.get_content_items(
         user_id=user_id,
@@ -1242,6 +1262,7 @@ def library_list(
         include_ignored=show_ignored,
         limit=limit,
         offset=offset,
+        enrichment=enrichment,
     )
 
     if output_format == "json":
@@ -1264,9 +1285,10 @@ def library_list(
                 get_enum_value(item.content_type),
                 get_enum_value(item.status),
                 "N/A" if item.rating is None else item.rating,
+                "Yes" if item.enriched else "No",
             ]
         )
-    headers = ["ID", "Title", "Author", "Type", "Status", "Rating"]
+    headers = ["ID", "Title", "Author", "Type", "Status", "Rating", "Enriched"]
     click.echo(tabulate(table_data, headers=headers, tablefmt="grid"))
 
 
@@ -1301,6 +1323,10 @@ def library_show(
     if output_format == "json":
         click.echo(json.dumps(item_to_dict(item), indent=2))
     else:
+        serialized = item_to_dict(item)
+        genres = serialized["genres"]
+        tags = serialized["tags"]
+        description = serialized["description"]
         table_data = [
             ["Title", item.title],
             ["Author", item.author or "N/A"],
@@ -1313,6 +1339,10 @@ def library_show(
                 item.date_completed.isoformat() if item.date_completed else "N/A",
             ],
             ["Ignored", "Yes" if item.ignored else "No"],
+            ["Enriched", "Yes" if item.enriched else "No"],
+            ["Genres", ", ".join(cast(list[str], genres)) or "N/A"],
+            ["Tags", ", ".join(cast(list[str], tags)) or "N/A"],
+            ["Description", description or "N/A"],
         ]
         click.echo(tabulate(table_data, tablefmt="grid"))
 
@@ -1342,6 +1372,23 @@ def library_show(
     help=f"Comma-separated list of watched season numbers (1-{MAX_SEASONS})",
 )
 @click.option(
+    "--genre",
+    "genres",
+    multiple=True,
+    help="Manual genre (repeatable); replaces existing genres and marks enriched",
+)
+@click.option(
+    "--tag",
+    "tags",
+    multiple=True,
+    help="Manual tag (repeatable); replaces existing tags and marks enriched",
+)
+@click.option(
+    "--description",
+    default=None,
+    help="Manual description; replaces the existing one and marks enriched",
+)
+@click.option(
     "--user",
     "user_id",
     type=int,
@@ -1356,18 +1403,24 @@ def library_edit(
     rating: int | None,
     review: str | None,
     seasons_watched: str | None,
+    genres: tuple[str, ...],
+    tags: tuple[str, ...],
+    description: str | None,
     user_id: int,
 ) -> None:
-    """Edit an item's status, rating, or review."""
+    """Edit an item's status, rating, review, or manual enrichment metadata."""
     if (
         status_str is None
         and rating is None
         and review is None
         and seasons_watched is None
+        and not genres
+        and not tags
+        and description is None
     ):
         click.echo(
             "Error: Provide at least one of --status, --rating, --review, "
-            "--seasons-watched.",
+            "--seasons-watched, --genre, --tag, --description.",
             err=True,
         )
         raise click.Abort()
@@ -1409,12 +1462,50 @@ def library_edit(
             )
             raise click.Abort()
 
+    genre_list = list(genres) if genres else None
+    tag_list = list(tags) if tags else None
+    if genre_list is not None and len(genre_list) > MAX_GENRES:
+        click.echo(
+            f"Error: --genre accepts at most {MAX_GENRES} values.",
+            err=True,
+        )
+        raise click.Abort()
+    if tag_list is not None and len(tag_list) > MAX_TAGS:
+        click.echo(
+            f"Error: --tag accepts at most {MAX_TAGS} values.",
+            err=True,
+        )
+        raise click.Abort()
+    if any(len(value) > MAX_GENRE_TAG_LENGTH for value in genres + tags):
+        click.echo(
+            f"Error: each --genre/--tag must be at most {MAX_GENRE_TAG_LENGTH} "
+            "characters.",
+            err=True,
+        )
+        raise click.Abort()
+    if description is not None and len(description) > MAX_DESCRIPTION_LENGTH:
+        click.echo(
+            f"Error: --description must be at most {MAX_DESCRIPTION_LENGTH} "
+            "characters.",
+            err=True,
+        )
+        raise click.Abort()
+    if review is not None and len(review) > MAX_REVIEW_LENGTH:
+        click.echo(
+            f"Error: --review must be at most {MAX_REVIEW_LENGTH} characters.",
+            err=True,
+        )
+        raise click.Abort()
+
     updated = storage.update_item_from_ui(
         db_id=item_id,
         status=effective_status,
         rating=rating,
         review=review,
         seasons_watched=parsed_seasons,
+        genres=genre_list,
+        tags=tag_list,
+        description=description,
         user_id=user_id,
     )
 

--- a/src/models/content.py
+++ b/src/models/content.py
@@ -2,12 +2,16 @@
 
 from datetime import date
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 # Default user ID used across the application when no user is specified
 DEFAULT_USER_ID = 1
+
+# Enrichment-state filter for content listings. ``None`` (no filter) returns
+# every item; the two states partition the library.
+EnrichmentFilter = Literal["enriched", "not_enriched"]
 
 
 class ContentType(str, Enum):
@@ -95,6 +99,10 @@ class ContentItem(BaseModel):
     # Runtime-only: parent item ID (e.g., TV show ID for a season item).
     # Set during recommendation expansion, not persisted.
     parent_id: str | None = None
+
+    # Runtime-only: whether the item has been enriched (clean enrichment_status
+    # row). Populated when read from storage; None when the state is unknown.
+    enriched: bool | None = None
 
     # Whether this item is ignored (excluded from recommendations).
     # None means "not specified by this source" — the existing database

--- a/src/storage/manager.py
+++ b/src/storage/manager.py
@@ -18,6 +18,7 @@ from src.models.content import (
     ConsumptionStatus,
     ContentItem,
     ContentType,
+    EnrichmentFilter,
     get_enum_value,
 )
 from src.models.user_preferences import UserPreferenceConfig
@@ -261,6 +262,7 @@ class StorageManager:
         offset: int = 0,
         sort_by: str = "title",
         include_ignored: bool = True,
+        enrichment: EnrichmentFilter | None = None,
     ) -> list[ContentItem]:
         """Get content items with optional filters.
 
@@ -276,6 +278,8 @@ class StorageManager:
                 "updated_at", "rating", or "created_at"
             include_ignored: Whether to include ignored items (default True
                 for backward compatibility)
+            enrichment: Filter by enrichment state ("enriched" or
+                "not_enriched"). None returns all items.
 
         Returns:
             List of ContentItem objects
@@ -289,6 +293,7 @@ class StorageManager:
             offset=offset,
             sort_by=sort_by,
             include_ignored=include_ignored,
+            enrichment=enrichment,
         )
 
     def get_unconsumed_items(
@@ -433,6 +438,9 @@ class StorageManager:
         rating: int | None = None,
         review: str | None = None,
         seasons_watched: list[int] | None = None,
+        genres: list[str] | None = None,
+        tags: list[str] | None = None,
+        description: str | None = None,
         user_id: int | None = None,
     ) -> bool:
         """Update a content item from the web UI (unrestricted editing).
@@ -446,6 +454,9 @@ class StorageManager:
             rating: New rating (1-5) or None to clear.
             review: New review text or None to clear.
             seasons_watched: List of watched season numbers (TV shows only).
+            genres: Manual genres to set (overwrite). None leaves them as-is.
+            tags: Manual tags to set (overwrite). None leaves them as-is.
+            description: Manual description to set. None leaves it as-is.
             user_id: Optional user ID filter for authorization.
 
         Returns:
@@ -457,6 +468,9 @@ class StorageManager:
             rating=rating,
             review=review,
             seasons_watched=seasons_watched,
+            genres=genres,
+            tags=tags,
+            description=description,
             user_id=user_id,
         )
 

--- a/src/storage/schema.py
+++ b/src/storage/schema.py
@@ -803,21 +803,24 @@ def get_enrichment_status(
     return None
 
 
-def mark_enrichment_complete(
-    conn: sqlite3.Connection,
+def write_enrichment_complete(
+    cursor: sqlite3.Cursor,
     content_item_id: int,
     provider: str,
     quality: str,
 ) -> None:
-    """Mark an item as successfully enriched.
+    """Write the "enriched" status row without committing.
+
+    Lets a caller fold the write into its own transaction and control the
+    single commit point. ``mark_enrichment_complete`` wraps this for callers
+    that own the connection and want an immediate commit.
 
     Args:
-        conn: SQLite database connection
+        cursor: Cursor on the caller's open transaction
         content_item_id: Content item database ID
         provider: Name of the provider that enriched the item
         quality: Match quality ("high", "medium", "not_found")
     """
-    cursor = conn.cursor()
     cursor.execute(
         """INSERT OR REPLACE INTO enrichment_status
            (content_item_id, last_enriched_at, enrichment_provider,
@@ -825,6 +828,23 @@ def mark_enrichment_complete(
            VALUES (?, CURRENT_TIMESTAMP, ?, ?, 0, NULL)""",
         (content_item_id, provider, quality),
     )
+
+
+def mark_enrichment_complete(
+    conn: sqlite3.Connection,
+    content_item_id: int,
+    provider: str,
+    quality: str,
+) -> None:
+    """Mark an item as successfully enriched and commit.
+
+    Args:
+        conn: SQLite database connection
+        content_item_id: Content item database ID
+        provider: Name of the provider that enriched the item
+        quality: Match quality ("high", "medium", "not_found")
+    """
+    write_enrichment_complete(conn.cursor(), content_item_id, provider, quality)
     conn.commit()
 
 

--- a/src/storage/sqlite_db.py
+++ b/src/storage/sqlite_db.py
@@ -12,6 +12,7 @@ from src.models.content import (
     ConsumptionStatus,
     ContentItem,
     ContentType,
+    EnrichmentFilter,
     get_enum_value,
 )
 from src.storage.merge import (
@@ -24,7 +25,11 @@ from src.storage.merge import (
     _parse_json_list,
     normalize_title_for_matching,
 )
-from src.storage.schema import create_schema, get_default_user_id
+from src.storage.schema import (
+    create_schema,
+    get_default_user_id,
+    write_enrichment_complete,
+)
 from src.utils.list_merge import merge_string_lists
 from src.utils.sorting import get_sort_title
 
@@ -65,13 +70,32 @@ _CONTENT_ITEM_SELECT = """
            vgd.platforms, vgd.genres as game_genres,
            vgd.release_year as game_year,
            vgd.tags as game_tags, vgd.description as game_description,
-           vgd.metadata as game_metadata
+           vgd.metadata as game_metadata,
+           es.content_item_id as enrichment_item_id,
+           es.needs_enrichment, es.enrichment_provider,
+           es.enrichment_quality, es.enrichment_error
     FROM content_items ci
     LEFT JOIN book_details bd ON ci.id = bd.content_item_id
     LEFT JOIN movie_details md ON ci.id = md.content_item_id
     LEFT JOIN tv_show_details td ON ci.id = td.content_item_id
     LEFT JOIN video_game_details vgd ON ci.id = vgd.content_item_id
+    LEFT JOIN enrichment_status es ON ci.id = es.content_item_id
 """
+
+# An item is enriched when it has a clean enrichment_status row: a real
+# provider found a match, no error, and re-enrichment is not pending. Anything
+# else (no row, needs_enrichment=1, not_found quality, or a recorded error)
+# counts as not enriched. Expressed as a WHERE fragment over the ``es`` alias
+# from _CONTENT_ITEM_SELECT so the list filter and the per-row flag stay in
+# sync.
+_ENRICHED_PREDICATE = (
+    "es.content_item_id IS NOT NULL"
+    " AND es.needs_enrichment = 0"
+    " AND es.enrichment_error IS NULL"
+    " AND es.enrichment_provider IS NOT NULL"
+    " AND es.enrichment_provider != 'none'"
+    " AND es.enrichment_quality != 'not_found'"
+)
 
 
 def _resolve_status_forward(existing_status: str | None, incoming_status: str) -> str:
@@ -777,6 +801,7 @@ class SQLiteDB:
         offset: int = 0,
         sort_by: str = "title",
         include_ignored: bool = True,
+        enrichment: EnrichmentFilter | None = None,
     ) -> list[ContentItem]:
         """Get content items with optional filters.
 
@@ -792,6 +817,8 @@ class SQLiteDB:
                 "updated_at", "rating", or "created_at"
             include_ignored: Whether to include ignored items (default True
                 for backward compatibility)
+            enrichment: Filter by enrichment state ("enriched" or
+                "not_enriched"). None returns all items.
 
         Returns:
             List of ContentItem objects
@@ -812,6 +839,11 @@ class SQLiteDB:
                 query += " AND ci.content_type = ?"
                 content_type_value = get_enum_value(content_type)
                 params.append(content_type_value)
+
+            if enrichment == "enriched":
+                query += f" AND ({_ENRICHED_PREDICATE})"
+            elif enrichment == "not_enriched":
+                query += f" AND NOT ({_ENRICHED_PREDICATE})"
 
             if status is not None:
                 if isinstance(status, list):
@@ -1060,8 +1092,27 @@ class SQLiteDB:
             date_completed=date_completed,
             source=self._get_row_value(row, "source"),
             ignored=bool(self._get_row_value(row, "ignored")),
+            enriched=self._row_is_enriched(row),
             metadata=metadata,
         )
+
+    @staticmethod
+    def _row_is_enriched(row: sqlite3.Row) -> bool:
+        """Derive the enriched flag from the joined enrichment_status columns.
+
+        Mirrors ``_ENRICHED_PREDICATE`` so the per-row flag and the list
+        filter agree: a clean row (real provider, no error, not pending).
+        """
+        if SQLiteDB._get_row_value(row, "enrichment_item_id") is None:
+            return False
+        if SQLiteDB._get_row_value(row, "needs_enrichment"):
+            return False
+        if SQLiteDB._get_row_value(row, "enrichment_error") is not None:
+            return False
+        if SQLiteDB._get_row_value(row, "enrichment_quality") == "not_found":
+            return False
+        provider = SQLiteDB._get_row_value(row, "enrichment_provider")
+        return provider is not None and provider != "none"
 
     def update_item_from_ui(
         self,
@@ -1070,6 +1121,9 @@ class SQLiteDB:
         rating: int | None = None,
         review: str | None = None,
         seasons_watched: list[int] | None = None,
+        genres: list[str] | None = None,
+        tags: list[str] | None = None,
+        description: str | None = None,
         user_id: int | None = None,
     ) -> bool:
         """Update a content item from the web UI (unrestricted editing).
@@ -1083,12 +1137,20 @@ class SQLiteDB:
         0 watched = unread, all watched = completed, partial = currently_consuming.
         The auto-derived status overrides the status parameter.
 
+        Manual genres/tags/description overwrite the detail-table values
+        (rather than the additive merge used by sync/enrichment) and mark the
+        item enriched via the ``manual`` provider so it drops out of the
+        not-enriched filter and is never re-queued for automatic enrichment.
+
         Args:
             db_id: Database ID of the item to update.
             status: New status value (unread, currently_consuming, completed).
             rating: New rating (1-5) or None to clear.
             review: New review text or None to clear.
             seasons_watched: List of watched season numbers (TV shows only).
+            genres: Manual genres to set (overwrite). None leaves them as-is.
+            tags: Manual tags to set (overwrite). None leaves them as-is.
+            description: Manual description to set. None leaves it as-is.
             user_id: Optional user ID filter for authorization.
 
         Returns:
@@ -1160,8 +1222,74 @@ class SQLiteDB:
                 " WHERE id = ?",
                 (resolved_status, rating, review, db_id),
             )
+
+            if genres is not None or tags is not None or description is not None:
+                # _write_manual_metadata raises for an unknown content_type, so
+                # the enriched row is only written when metadata actually was.
+                self._write_manual_metadata(
+                    cursor, db_id, content_type, genres, tags, description
+                )
+                write_enrichment_complete(cursor, db_id, "manual", "high")
+
             conn.commit()
             return True
+
+    def _write_manual_metadata(
+        self,
+        cursor: sqlite3.Cursor,
+        db_id: int,
+        content_type: str,
+        genres: list[str] | None,
+        tags: list[str] | None,
+        description: str | None,
+    ) -> None:
+        """Overwrite manual genres/tags/description in the detail table.
+
+        Only the supplied (non-None) fields are written. Genres/tags are
+        stored as JSON arrays to match the detail-table read path. The row is
+        created if the item has no detail row yet.
+
+        Raises ``ValueError`` for an unknown content_type so the caller never
+        marks an item enriched without having written any metadata.
+        """
+        config = self._DETAIL_TABLE_CONFIG.get(content_type)
+        if not config:
+            raise ValueError(f"Unknown content_type: {content_type!r}")
+        table = config["table"]
+        if table not in _ALLOWED_DETAIL_TABLES:
+            raise ValueError(f"Unknown detail table: {table!r}")
+
+        updates: dict[str, Any] = {}
+        if genres is not None:
+            updates["genres"] = json.dumps(genres)
+        if tags is not None:
+            updates["tags"] = json.dumps(tags)
+        if description is not None:
+            updates["description"] = description
+
+        cursor.execute(
+            f"SELECT 1 FROM {table} WHERE content_item_id = ?",
+            (db_id,),
+        )
+        row_exists = cursor.fetchone() is not None
+
+        columns = list(updates)
+        for name in columns:
+            _assert_safe_identifier(name)
+
+        if row_exists:
+            set_clause = ", ".join(f"{name} = ?" for name in columns)
+            cursor.execute(
+                f"UPDATE {table} SET {set_clause} WHERE content_item_id = ?",
+                [*updates.values(), db_id],
+            )
+        else:
+            col_list = ", ".join(["content_item_id", *columns])
+            placeholders = ", ".join("?" for _ in range(len(columns) + 1))
+            cursor.execute(
+                f"INSERT INTO {table} ({col_list}) VALUES ({placeholders})",
+                [db_id, *updates.values()],
+            )
 
     def delete_content_item(self, db_id: int, user_id: int | None = None) -> bool:
         """Delete a content item by database ID.

--- a/src/utils/item_serialization.py
+++ b/src/utils/item_serialization.py
@@ -38,6 +38,7 @@ def item_to_dict(item: ContentItem) -> dict[str, object]:
     prevents field-set drift between the two interfaces.
     """
     seasons_watched, total_seasons = extract_tv_season_fields(item)
+    metadata = item.metadata
     return {
         "id": item.id,
         "db_id": item.db_id,
@@ -54,4 +55,12 @@ def item_to_dict(item: ContentItem) -> dict[str, object]:
         "ignored": bool(item.ignored),
         "seasons_watched": seasons_watched,
         "total_seasons": total_seasons,
+        # enriched is bool | None on ContentItem; None means the enrichment
+        # state is unknown (e.g. an item not read back from storage). The wire
+        # type is a non-nullable bool, so None intentionally serializes as
+        # False — unknown state is presented as "not enriched".
+        "enriched": bool(item.enriched),
+        "genres": metadata.get("genres") or [],
+        "tags": metadata.get("tags") or [],
+        "description": metadata.get("description"),
     }

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -23,6 +23,7 @@ from src.models.content import (
     ConsumptionStatus,
     ContentItem,
     ContentType,
+    EnrichmentFilter,
     get_enum_value,
 )
 from src.models.user_preferences import UserPreferenceConfig
@@ -145,6 +146,10 @@ class ContentItemResponse(BaseModel):
     ignored: bool = False
     seasons_watched: list[int] | None = None
     total_seasons: int | None = None
+    enriched: bool = False
+    genres: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    description: str | None = None
 
 
 class RecommendationResponse(BaseModel):
@@ -297,6 +302,15 @@ class ItemEditRequest(BaseModel):
     review: str | None = Field(None, max_length=10000)
     seasons_watched: list[Annotated[int, Field(ge=1, le=MAX_SEASONS)]] | None = Field(
         None, max_length=MAX_SEASONS
+    )
+    genres: list[Annotated[str, Field(max_length=100)]] | None = Field(
+        None, max_length=50, description="Manual genres (overwrite)"
+    )
+    tags: list[Annotated[str, Field(max_length=100)]] | None = Field(
+        None, max_length=100, description="Manual tags (overwrite)"
+    )
+    description: str | None = Field(
+        None, max_length=10000, description="Manual description"
     )
 
 
@@ -790,6 +804,10 @@ async def list_items(
         False,
         description="Whether to include ignored items (default: hide ignored)",
     ),
+    enrichment: EnrichmentFilter | None = Query(
+        None,
+        description="Filter by enrichment state: enriched or not_enriched",
+    ),
 ) -> list[ContentItemResponse]:
     """List content items with optional filters.
 
@@ -801,6 +819,7 @@ async def list_items(
         offset: Number of items to skip (for pagination).
         sort_by: Sort order (default: title, which ignores leading articles).
         include_ignored: Whether to include ignored items (default: False).
+        enrichment: Optional enrichment-state filter (enriched/not_enriched).
 
     Returns:
         List of content items.
@@ -844,6 +863,7 @@ async def list_items(
         offset=offset,
         sort_by=sort_by.lower(),
         include_ignored=include_ignored,
+        enrichment=enrichment,
     )
 
     return [_item_to_response(item) for item in items]
@@ -1011,6 +1031,9 @@ async def edit_item(
         rating=request.rating,
         review=request.review,
         seasons_watched=request.seasons_watched,
+        genres=request.genres,
+        tags=request.tags,
+        description=request.description,
         user_id=user_id,
     )
     if not success:

--- a/tests/cli/test_cli_library.py
+++ b/tests/cli/test_cli_library.py
@@ -7,6 +7,13 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
+from src.cli.commands import (
+    MAX_DESCRIPTION_LENGTH,
+    MAX_GENRE_TAG_LENGTH,
+    MAX_GENRES,
+    MAX_REVIEW_LENGTH,
+    MAX_TAGS,
+)
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
 from src.storage.manager import StorageManager
 from src.utils.series import MAX_SEASONS
@@ -88,6 +95,10 @@ class TestLibraryList:
             "ignored",
             "seasons_watched",
             "total_seasons",
+            "enriched",
+            "genres",
+            "tags",
+            "description",
         }
         assert item["title"] == "Book One"
         assert item["db_id"] == 1
@@ -136,6 +147,73 @@ class TestLibraryList:
 
         assert result.exit_code == 0
         assert "No items found" in result.output
+
+    def test_list_enrichment_not_enriched(self, cli_runner: CliRunner) -> None:
+        """Test --enrichment not_enriched forwards the filter to storage."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "list", "--enrichment", "not_enriched"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["enrichment"] == "not_enriched"
+
+    def test_list_enrichment_enriched(self, cli_runner: CliRunner) -> None:
+        """Test --enrichment enriched forwards the filter to storage."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "list", "--enrichment", "enriched"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["enrichment"] == "enriched"
+
+    def test_list_enrichment_default_unset(self, cli_runner: CliRunner) -> None:
+        """Test the enrichment filter is None (all items) when not provided."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(cli_runner, ["library", "list"], mock_storage)
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["enrichment"] is None
+
+    def test_list_enrichment_invalid_value(self, cli_runner: CliRunner) -> None:
+        """Test an invalid --enrichment value is rejected by Click choices."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "list", "--enrichment", "partial"],
+            mock_storage,
+        )
+
+        assert result.exit_code != 0
+        mock_storage.get_content_items.assert_not_called()
+
+    def test_list_table_shows_enriched_column(self, cli_runner: CliRunner) -> None:
+        """Test the table output carries an Enriched indicator column."""
+        item = _make_item(db_id=1, title="Book One")
+        item.enriched = True
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = [item]
+
+        result = _invoke_with_mocks(cli_runner, ["library", "list"], mock_storage)
+
+        assert result.exit_code == 0
+        assert "Enriched" in result.output
 
     def test_list_forwards_sort_limit_offset(self, cli_runner: CliRunner) -> None:
         """Test that --sort, --limit, --offset, --show-ignored reach storage."""
@@ -233,6 +311,10 @@ class TestLibraryShow:
             "ignored",
             "seasons_watched",
             "total_seasons",
+            "enriched",
+            "genres",
+            "tags",
+            "description",
         }
         assert parsed["title"] == "The Great Book"
         assert parsed["rating"] == 5
@@ -382,10 +464,7 @@ class TestLibraryEdit:
         )
 
         assert result.exit_code != 0
-        assert (
-            "Provide at least one of --status, --rating, --review, --seasons-watched."
-            in result.output
-        )
+        assert "Provide at least one of" in result.output
         # Guard fires before any storage access.
         mock_storage.get_content_item.assert_not_called()
         mock_storage.update_item_from_ui.assert_not_called()
@@ -421,6 +500,78 @@ class TestLibraryEdit:
         call_kwargs = mock_storage.update_item_from_ui.call_args[1]
         assert call_kwargs["seasons_watched"] == [1, 2, 3]
 
+    def test_edit_genres_tags_description(self, cli_runner: CliRunner) -> None:
+        """Test setting manual enrichment metadata forwards lists/text to storage."""
+        item = _make_item(db_id=1, title="Book One")
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+        mock_storage.update_item_from_ui.return_value = True
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            [
+                "library",
+                "edit",
+                "--id",
+                "1",
+                "--genre",
+                "Action",
+                "--genre",
+                "RPG",
+                "--tag",
+                "co-op",
+                "--description",
+                "A grand adventure.",
+            ],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.update_item_from_ui.call_args[1]
+        assert call_kwargs["genres"] == ["Action", "RPG"]
+        assert call_kwargs["tags"] == ["co-op"]
+        assert call_kwargs["description"] == "A grand adventure."
+
+    def test_edit_genre_only_leaves_others_unchanged(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Test editing only --genre leaves tags/description as None (unchanged)."""
+        item = _make_item(db_id=1, title="Book One")
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+        mock_storage.update_item_from_ui.return_value = True
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "1", "--genre", "Sci-Fi"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.update_item_from_ui.call_args[1]
+        assert call_kwargs["genres"] == ["Sci-Fi"]
+        assert call_kwargs["tags"] is None
+        assert call_kwargs["description"] is None
+
+    def test_edit_description_only(self, cli_runner: CliRunner) -> None:
+        """Test editing only --description leaves genres/tags as None (unchanged)."""
+        item = _make_item(db_id=1, title="Book One")
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+        mock_storage.update_item_from_ui.return_value = True
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "1", "--description", "New blurb."],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.update_item_from_ui.call_args[1]
+        assert call_kwargs["description"] == "New blurb."
+        assert call_kwargs["genres"] is None
+        assert call_kwargs["tags"] is None
+
     def test_edit_update_fails(self, cli_runner: CliRunner) -> None:
         """Test edit when storage update returns False."""
         item = _make_item(db_id=1, title="Book One")
@@ -437,9 +588,26 @@ class TestLibraryEdit:
         assert result.exit_code != 0
         assert "failed to update" in result.output.lower()
 
+    def test_edit_review_at_length_limit(self, cli_runner: CliRunner) -> None:
+        """A review at exactly the length limit is accepted and forwarded."""
+        item = _make_item(db_id=1, title="Book One")
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+        mock_storage.update_item_from_ui.return_value = True
+
+        review = "x" * MAX_REVIEW_LENGTH
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "1", "--review", review],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        assert mock_storage.update_item_from_ui.call_args[1]["review"] == review
+
 
 class TestLibraryEditRegression:
-    """Regression tests for the library edit command's season validation."""
+    """Regression tests for the library edit command's input validation."""
 
     def _tv_storage(self) -> MagicMock:
         """A storage mock returning a TV show item from get_content_item."""
@@ -504,6 +672,90 @@ class TestLibraryEditRegression:
         assert result.exit_code != 0
         assert f"at most {MAX_SEASONS} seasons" in result.output
         mock_storage.update_item_from_ui.assert_not_called()
+
+    def test_edit_rejects_over_long_review_regression(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """An over-long review is rejected, matching the web bound.
+
+        Bug reported: the web ItemEditRequest rejects reviews over
+        MAX_REVIEW_LENGTH with a 422, but the CLI stored them silently.
+        Root cause: --review had no length check before reaching storage.
+        Fix: the CLI now rejects over-long reviews before touching storage.
+        """
+        item = _make_item(db_id=1, title="Book One")
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+        mock_storage.update_item_from_ui.return_value = True
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "1", "--review", "x" * (MAX_REVIEW_LENGTH + 1)],
+            mock_storage,
+        )
+
+        assert result.exit_code != 0
+        assert f"at most {MAX_REVIEW_LENGTH} characters" in result.output
+        mock_storage.update_item_from_ui.assert_not_called()
+
+    def test_edit_rejects_manual_metadata_over_caps_regression(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Over-cap manual genres/tags/description are rejected by the CLI.
+
+        Bug reported: the web ItemEditRequest caps manual metadata (at most
+        MAX_GENRES genres, MAX_TAGS tags, MAX_GENRE_TAG_LENGTH chars per
+        value, MAX_DESCRIPTION_LENGTH for the description) and 422s past those
+        bounds, but the CLI accepted any size and wrote it straight through.
+        Root cause: --genre/--tag/--description had no length checks before
+        reaching storage. Fix: the CLI now validates each bound and aborts
+        before any storage write, matching the web 422.
+        """
+        item = _make_item(db_id=1, title="Book One")
+
+        cases: list[list[str]] = [
+            [arg for _ in range(MAX_GENRES + 1) for arg in ("--genre", "g")],
+            [arg for _ in range(MAX_TAGS + 1) for arg in ("--tag", "t")],
+            ["--genre", "x" * (MAX_GENRE_TAG_LENGTH + 1)],
+            ["--tag", "x" * (MAX_GENRE_TAG_LENGTH + 1)],
+            ["--description", "x" * (MAX_DESCRIPTION_LENGTH + 1)],
+        ]
+
+        for extra_args in cases:
+            mock_storage = MagicMock(spec=StorageManager)
+            mock_storage.get_content_item.return_value = item
+            mock_storage.update_item_from_ui.return_value = True
+
+            result = _invoke_with_mocks(
+                cli_runner,
+                ["library", "edit", "--id", "1", *extra_args],
+                mock_storage,
+            )
+
+            assert result.exit_code != 0, extra_args
+            mock_storage.update_item_from_ui.assert_not_called()
+
+    def test_edit_accepts_manual_metadata_at_caps(self, cli_runner: CliRunner) -> None:
+        """Manual metadata exactly at the caps is accepted and forwarded."""
+        item = _make_item(db_id=1, title="Book One")
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_item.return_value = item
+        mock_storage.update_item_from_ui.return_value = True
+
+        extra_args = [arg for _ in range(MAX_GENRES) for arg in ("--genre", "g")]
+        extra_args += [arg for _ in range(MAX_TAGS) for arg in ("--tag", "t")]
+        extra_args += ["--description", "x" * MAX_DESCRIPTION_LENGTH]
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "edit", "--id", "1", *extra_args],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.update_item_from_ui.call_args[1]
+        assert len(call_kwargs["genres"]) == MAX_GENRES
+        assert len(call_kwargs["tags"]) == MAX_TAGS
 
 
 class TestLibraryIgnore:

--- a/tests/enrichment/test_enrichment_manager.py
+++ b/tests/enrichment/test_enrichment_manager.py
@@ -1,6 +1,7 @@
 """Tests for the enrichment manager."""
 
 import time
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -667,3 +668,95 @@ class TestEnrichmentProgressRegression:
             content_type=None,
             user_id=None,
         )
+
+
+class TestManualEditEnrichmentProtectionRegression:
+    """Regression: an automatic enrichment run must not clobber manual edits.
+
+    Reported concern: a user hand-enters genres/tags/description on an item,
+    then a later background enrichment run could append provider genres/tags
+    (the merge is additive, not gap-fill) or otherwise mutate the manual data.
+
+    Root cause / fix: a manual edit marks the item enriched
+    (``needs_enrichment=0`` via the ``manual`` provider), so
+    ``get_items_needing_enrichment`` excludes it and ``_apply_enrichment``
+    never runs against it. This test drives the real StorageManager queue end
+    to end to prove the manual item is never handed to a provider and its
+    values survive a full run.
+    """
+
+    @pytest.fixture
+    def storage_manager(self, tmp_path: Path) -> StorageManager:
+        return StorageManager(sqlite_path=tmp_path / "test.db", ai_enabled=False)
+
+    @pytest.fixture
+    def registry(self) -> EnrichmentRegistry:
+        registry = EnrichmentRegistry()
+        registry._discovered = True
+        return registry
+
+    @pytest.fixture
+    def config(self) -> dict[str, Any]:
+        return {
+            "enrichment": {
+                "batch_size": 10,
+                "providers": {"mock": {"enabled": True}},
+            }
+        }
+
+    def test_auto_enrichment_skips_manually_edited_item_regression(
+        self,
+        storage_manager: StorageManager,
+        registry: EnrichmentRegistry,
+        config: dict[str, Any],
+    ) -> None:
+        """The provider never sees the manual item; its values are untouched."""
+        manual_id = storage_manager.save_content_item(
+            ContentItem(
+                id="manual_movie",
+                title="Manual Movie",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+        auto_id = storage_manager.save_content_item(
+            ContentItem(
+                id="auto_movie",
+                title="Auto Movie",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+
+        storage_manager.update_item_from_ui(
+            db_id=manual_id,
+            status="unread",
+            genres=["Drama"],
+            tags=["slow-burn"],
+            description="Hand written synopsis.",
+        )
+
+        provider = MockProvider()
+        registry.register(provider)
+
+        manager = EnrichmentManager(storage_manager, config, registry)
+        manager.start_enrichment()
+        manager._wait_for_completion()
+
+        # Only the un-edited item was offered to the provider — exactly one
+        # enrich call, never the manual item.
+        assert len(provider.enrich_calls) == 1
+        enriched_titles = {item.title for item in provider.enrich_calls}
+        assert enriched_titles == {"Auto Movie"}
+
+        # Manual values survive verbatim — no provider genres/tags appended.
+        manual = storage_manager.get_content_item(manual_id)
+        assert manual.metadata.get("genres") == ["Drama"]
+        assert manual.metadata.get("tags") == ["slow-burn"]
+        assert manual.metadata.get("description") == "Hand written synopsis."
+        assert manual.enriched is True
+
+        # The auto item did get enriched, proving the run actually executed.
+        auto = storage_manager.get_content_item(auto_id)
+        assert auto.metadata.get("genres") == ["Action", "Drama"]
+        assert auto.enriched is True

--- a/tests/enrichment/test_enrichment_storage.py
+++ b/tests/enrichment/test_enrichment_storage.py
@@ -622,3 +622,398 @@ class TestTagsAndDescriptionStorage:
         )
 
         assert found_id is None
+
+
+class TestEnrichmentFilter:
+    """Tests for the enrichment-state filter on get_content_items.
+
+    The filter joins enrichment_status. An item is enriched when it has a row
+    with needs_enrichment=0, enrichment_error IS NULL, and a real provider.
+    Everything else (no row, needs_enrichment=1, not_found, failed) is not
+    enriched. ``enriched`` and ``not_enriched`` partition the library.
+    """
+
+    @pytest.fixture
+    def storage_manager(self, tmp_path: Path) -> StorageManager:
+        db_path = tmp_path / "test.db"
+        return StorageManager(sqlite_path=db_path, ai_enabled=False)
+
+    def _save(self, storage: StorageManager, external_id: str) -> int:
+        return storage.save_content_item(
+            ContentItem(
+                id=external_id,
+                title=f"Movie {external_id}",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+
+    def test_not_enriched_includes_all_four_subcases(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """not_enriched returns: no row, needs_enrichment=1, not_found, failed."""
+        no_row = self._save(storage_manager, "no_row")
+        pending = self._save(storage_manager, "pending")
+        not_found = self._save(storage_manager, "not_found")
+        failed = self._save(storage_manager, "failed")
+        enriched = self._save(storage_manager, "enriched")
+
+        storage_manager.mark_item_needs_enrichment(pending)
+        storage_manager.mark_enrichment_complete(not_found, "tmdb", "not_found")
+        storage_manager.mark_enrichment_failed(failed, "boom")
+        storage_manager.mark_enrichment_complete(enriched, "tmdb", "high")
+
+        items = storage_manager.get_content_items(enrichment="not_enriched")
+        db_ids = {item.db_id for item in items}
+
+        assert db_ids == {no_row, pending, not_found, failed}
+        assert all(item.enriched is False for item in items)
+
+    def test_enriched_returns_complement(self, storage_manager: StorageManager) -> None:
+        """enriched returns only items with a clean enrichment_status row."""
+        self._save(storage_manager, "no_row")
+        high = self._save(storage_manager, "high")
+        medium = self._save(storage_manager, "medium")
+
+        storage_manager.mark_enrichment_complete(high, "tmdb", "high")
+        storage_manager.mark_enrichment_complete(medium, "tmdb", "medium")
+
+        items = storage_manager.get_content_items(enrichment="enriched")
+        db_ids = {item.db_id for item in items}
+
+        assert db_ids == {high, medium}
+        assert all(item.enriched is True for item in items)
+
+    def test_no_filter_returns_all_with_enriched_flag(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """No filter returns every item, each carrying its enriched flag."""
+        pending = self._save(storage_manager, "pending")
+        enriched = self._save(storage_manager, "enriched")
+        storage_manager.mark_enrichment_complete(enriched, "tmdb", "high")
+
+        items = storage_manager.get_content_items()
+        flags = {item.db_id: item.enriched for item in items}
+
+        assert flags == {pending: False, enriched: True}
+
+    def test_single_item_carries_enriched_flag(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """get_content_item exposes the enriched flag for the detail view."""
+        db_id = self._save(storage_manager, "movie")
+
+        assert storage_manager.get_content_item(db_id).enriched is False
+
+        storage_manager.mark_enrichment_complete(db_id, "tmdb", "high")
+        assert storage_manager.get_content_item(db_id).enriched is True
+
+    def test_failed_item_is_not_enriched(self, storage_manager: StorageManager) -> None:
+        """A failed item carries enriched=False even with a provider row.
+
+        Isolates the ``enrichment_error IS NOT NULL`` exclusion: the row has a
+        recorded error, so it must not count as enriched regardless of having
+        an enrichment_status row at all.
+        """
+        db_id = self._save(storage_manager, "failed")
+        storage_manager.mark_enrichment_failed(db_id, "boom")
+
+        assert storage_manager.get_content_item(db_id).enriched is False
+        enriched = storage_manager.get_content_items(enrichment="enriched")
+        assert db_id not in {item.db_id for item in enriched}
+
+    def test_not_enriched_combines_with_content_type_filter(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """not_enriched AND a content_type filter compose correctly.
+
+        Guards SQL precedence of the AND/OR predicate composition: the
+        not_enriched fragment is parenthesized so the content_type filter
+        narrows it rather than widening via a stray OR.
+        """
+        movie_pending = self._save(storage_manager, "movie_pending")
+        movie_enriched = self._save(storage_manager, "movie_enriched")
+        storage_manager.mark_enrichment_complete(movie_enriched, "tmdb", "high")
+
+        book_pending = storage_manager.save_content_item(
+            ContentItem(
+                id="book_pending",
+                title="Book Pending",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+
+        items = storage_manager.get_content_items(
+            content_type=ContentType.MOVIE, enrichment="not_enriched"
+        )
+        db_ids = {item.db_id for item in items}
+
+        # Only the not-enriched movie; the enriched movie and the book are out.
+        assert db_ids == {movie_pending}
+        assert movie_enriched not in db_ids
+        assert book_pending not in db_ids
+
+
+class TestManualMetadataEdit:
+    """Tests for persisting manual genres/tags/description via update_item_from_ui.
+
+    Manual edits overwrite the detail-table values and mark the item enriched
+    with the ``manual`` provider so it drops out of the not_enriched filter and
+    is never re-queued for automatic enrichment.
+    """
+
+    @pytest.fixture
+    def storage_manager(self, tmp_path: Path) -> StorageManager:
+        db_path = tmp_path / "test.db"
+        return StorageManager(sqlite_path=db_path, ai_enabled=False)
+
+    def test_manual_edit_persists_and_marks_enriched(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """Manual fields persist and the item becomes enriched."""
+        db_id = storage_manager.save_content_item(
+            ContentItem(
+                id="movie1",
+                title="Test Movie",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+
+        updated = storage_manager.update_item_from_ui(
+            db_id=db_id,
+            status="unread",
+            genres=["Drama", "Thriller"],
+            tags=["slow-burn"],
+            description="A tense character study.",
+        )
+        assert updated is True
+
+        loaded = storage_manager.get_content_item(db_id)
+        assert loaded.metadata.get("genres") == ["Drama", "Thriller"]
+        assert loaded.metadata.get("tags") == ["slow-burn"]
+        assert loaded.metadata.get("description") == "A tense character study."
+        assert loaded.enriched is True
+
+        status = storage_manager.get_enrichment_status(db_id)
+        assert status["enrichment_provider"] == "manual"
+        assert status["needs_enrichment"] is False
+
+    def test_manual_edit_overwrites_existing_values(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """Manual genres replace prior values rather than merging additively.
+
+        Also proves a None field (description here) leaves the stored value
+        as-is: only supplied fields are overwritten.
+        """
+        db_id = storage_manager.save_content_item(
+            ContentItem(
+                id="movie1",
+                title="Test Movie",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+                metadata={
+                    "genres": ["Action", "Comedy"],
+                    "tags": ["old"],
+                    "description": "Original synopsis.",
+                },
+            )
+        )
+
+        storage_manager.update_item_from_ui(
+            db_id=db_id,
+            status="unread",
+            genres=["Drama"],
+            tags=["new"],
+        )
+
+        loaded = storage_manager.get_content_item(db_id)
+        assert loaded.metadata.get("genres") == ["Drama"]
+        assert loaded.metadata.get("tags") == ["new"]
+        # description was omitted (None) so it must be left untouched.
+        assert loaded.metadata.get("description") == "Original synopsis."
+
+    def test_manual_edit_drops_item_from_not_enriched_filter(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """After a manual edit the item appears under enriched, not not_enriched."""
+        db_id = storage_manager.save_content_item(
+            ContentItem(
+                id="movie1",
+                title="Test Movie",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+
+        storage_manager.update_item_from_ui(
+            db_id=db_id,
+            status="unread",
+            description="Manually written.",
+        )
+
+        not_enriched = storage_manager.get_content_items(enrichment="not_enriched")
+        enriched = storage_manager.get_content_items(enrichment="enriched")
+        assert [item.db_id for item in not_enriched] == []
+        assert [item.db_id for item in enriched] == [db_id]
+
+    def test_status_only_edit_does_not_mark_enriched(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """Editing only status/rating leaves enrichment state untouched."""
+        db_id = storage_manager.save_content_item(
+            ContentItem(
+                id="movie1",
+                title="Test Movie",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+
+        storage_manager.update_item_from_ui(db_id=db_id, status="completed", rating=5)
+
+        assert storage_manager.get_enrichment_status(db_id) is None
+        assert storage_manager.get_content_item(db_id).enriched is False
+
+    def test_unknown_content_type_raises_and_does_not_mark_enriched(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """An unknown content_type raises and never marks the item enriched.
+
+        Guards the bug where _write_manual_metadata silently returned for an
+        unrecognized content_type while the caller went on to mark the item
+        enriched with no metadata written. The stored content_type is forced to
+        a bogus value to drive the defensive branch.
+        """
+        db_id = storage_manager.save_content_item(
+            ContentItem(
+                id="movie1",
+                title="Test Movie",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+        conn = storage_manager.sqlite_db._get_connection()
+        try:
+            conn.execute(
+                "UPDATE content_items SET content_type = ? WHERE id = ?",
+                ("bogus_type", db_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        with pytest.raises(ValueError, match="Unknown content_type"):
+            storage_manager.update_item_from_ui(
+                db_id=db_id, status="unread", genres=["Drama"]
+            )
+
+        # No enrichment row was written, so the item is not marked enriched.
+        assert storage_manager.get_enrichment_status(db_id) is None
+
+    def test_genres_empty_list_clears_while_none_leaves_as_is(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """genres=[] clears all genres; genres=None leaves them untouched.
+
+        An empty list is a deliberate "clear" that stores an empty JSON array
+        and still marks the item enriched; None means "no change".
+        """
+        db_id = storage_manager.save_content_item(
+            ContentItem(
+                id="movie1",
+                title="Test Movie",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+                metadata={"genres": ["Action", "Comedy"]},
+            )
+        )
+
+        # genres=[] clears; tags omitted (None) so they are left as-is.
+        storage_manager.update_item_from_ui(db_id=db_id, status="unread", genres=[])
+
+        loaded = storage_manager.get_content_item(db_id)
+        assert loaded.metadata.get("genres", []) == []
+        assert loaded.enriched is True
+
+        # The stored column is an empty JSON array, not NULL.
+        conn = storage_manager.sqlite_db._get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT genres FROM movie_details WHERE content_item_id = ?",
+                (db_id,),
+            )
+            assert cursor.fetchone()["genres"] == "[]"
+        finally:
+            conn.close()
+
+    def test_manual_edit_overrides_prior_auto_enrichment(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """A previously auto-enriched item flips to the manual provider.
+
+        After tmdb enrichment, a manual edit updates the enrichment row to
+        provider "manual" and the item still appears under enriched.
+        """
+        db_id = storage_manager.save_content_item(
+            ContentItem(
+                id="movie1",
+                title="Test Movie",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+        storage_manager.mark_enrichment_complete(db_id, "tmdb", "high")
+        assert storage_manager.get_enrichment_status(db_id)["enrichment_provider"] == (
+            "tmdb"
+        )
+
+        storage_manager.update_item_from_ui(
+            db_id=db_id, status="unread", genres=["Drama"]
+        )
+
+        status = storage_manager.get_enrichment_status(db_id)
+        assert status["enrichment_provider"] == "manual"
+        enriched = storage_manager.get_content_items(enrichment="enriched")
+        assert db_id in {item.db_id for item in enriched}
+
+    def test_manual_edit_inserts_detail_row_for_book(
+        self, storage_manager: StorageManager
+    ) -> None:
+        """Manual edit creates the detail row when the item has none yet.
+
+        Exercises the INSERT branch of _write_manual_metadata for a non-movie
+        type: the book_details row is removed to simulate an item without a
+        detail row, then a manual edit must insert it.
+        """
+        db_id = storage_manager.save_content_item(
+            ContentItem(
+                id="book1",
+                title="Test Book",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+        conn = storage_manager.sqlite_db._get_connection()
+        try:
+            conn.execute("DELETE FROM book_details WHERE content_item_id = ?", (db_id,))
+            conn.commit()
+        finally:
+            conn.close()
+
+        storage_manager.update_item_from_ui(
+            db_id=db_id,
+            status="unread",
+            genres=["Fantasy"],
+            tags=["epic"],
+            description="A sweeping tale.",
+        )
+
+        loaded = storage_manager.get_content_item(db_id)
+        assert loaded.metadata.get("genres") == ["Fantasy"]
+        assert loaded.metadata.get("tags") == ["epic"]
+        assert loaded.metadata.get("description") == "A sweeping tale."
+        assert loaded.enriched is True

--- a/tests/test_item_serialization.py
+++ b/tests/test_item_serialization.py
@@ -1,0 +1,18 @@
+"""Tests for the shared CLI/web ContentItem serialization helpers."""
+
+from src.utils.item_serialization import item_to_dict
+from tests.factories import make_item
+
+
+def test_unknown_enriched_serializes_as_false() -> None:
+    """A default ContentItem (enriched=None) serializes enriched as False.
+
+    The wire type is a non-nullable bool, so an unknown enrichment state
+    (an item not read back from storage) intentionally collapses to False.
+    """
+    item = make_item()
+    assert item.enriched is None
+
+    serialized = item_to_dict(item)
+
+    assert serialized["enriched"] is False

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1210,6 +1210,9 @@ def test_edit_item_status(client, mock_components):
         rating=None,
         review=None,
         seasons_watched=None,
+        genres=None,
+        tags=None,
+        description=None,
         user_id=1,
     )
 
@@ -1284,6 +1287,9 @@ def test_edit_tv_show_seasons(client, mock_components):
         rating=None,
         review=None,
         seasons_watched=[1, 2, 3],
+        genres=None,
+        tags=None,
+        description=None,
         user_id=1,
     )
 
@@ -1364,6 +1370,231 @@ def test_edit_response_includes_tv_metadata(client, mock_components):
     assert len(data) == 1
     assert data[0]["seasons_watched"] == [1, 2, 3, 4, 5]
     assert data[0]["total_seasons"] == 50
+
+
+# ---------------------------------------------------------------------------
+# GET /api/items — enrichment filter and exposed fields
+# ---------------------------------------------------------------------------
+
+
+def test_list_items_filters_not_enriched(client, mock_components):
+    """GET /api/items?enrichment=not_enriched forwards the filter to storage."""
+    mock_components["storage"].get_content_items = Mock(return_value=[])
+
+    response = client.get("/api/items?user_id=1&enrichment=not_enriched")
+
+    assert response.status_code == 200
+    call_kwargs = mock_components["storage"].get_content_items.call_args[1]
+    assert call_kwargs["enrichment"] == "not_enriched"
+
+
+def test_list_items_filters_enriched(client, mock_components):
+    """GET /api/items?enrichment=enriched forwards the filter to storage."""
+    mock_components["storage"].get_content_items = Mock(return_value=[])
+
+    response = client.get("/api/items?user_id=1&enrichment=enriched")
+
+    assert response.status_code == 200
+    call_kwargs = mock_components["storage"].get_content_items.call_args[1]
+    assert call_kwargs["enrichment"] == "enriched"
+
+
+def test_list_items_invalid_enrichment_returns_422(client, mock_components):
+    """GET /api/items?enrichment=bogus is rejected at the API boundary."""
+    response = client.get("/api/items?user_id=1&enrichment=bogus")
+    assert response.status_code == 422
+
+
+def test_list_items_default_enrichment_is_none(client, mock_components):
+    """GET /api/items without enrichment passes None (no filter)."""
+    mock_components["storage"].get_content_items = Mock(return_value=[])
+
+    response = client.get("/api/items?user_id=1")
+
+    assert response.status_code == 200
+    call_kwargs = mock_components["storage"].get_content_items.call_args[1]
+    assert call_kwargs["enrichment"] is None
+
+
+def test_list_items_response_exposes_enrichment_fields(client, mock_components):
+    """GET /api/items exposes enriched plus genres/tags/description."""
+    mock_item = ContentItem(
+        id="movie_1",
+        db_id=7,
+        title="Test Movie",
+        content_type=ContentType.MOVIE,
+        status=ConsumptionStatus.UNREAD,
+        metadata={
+            "genres": ["Drama"],
+            "tags": ["slow-burn"],
+            "description": "A tense character study.",
+        },
+    )
+    mock_item.enriched = True
+    mock_components["storage"].get_content_items = Mock(return_value=[mock_item])
+
+    response = client.get("/api/items?user_id=1")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["enriched"] is True
+    assert data[0]["genres"] == ["Drama"]
+    assert data[0]["tags"] == ["slow-burn"]
+    assert data[0]["description"] == "A tense character study."
+
+
+def test_get_single_item_exposes_enrichment_fields(client, mock_components):
+    """GET /api/items/{db_id} exposes enriched plus genres/tags/description."""
+    mock_item = ContentItem(
+        id="movie_1",
+        db_id=7,
+        title="Test Movie",
+        content_type=ContentType.MOVIE,
+        status=ConsumptionStatus.UNREAD,
+        metadata={"genres": ["Drama"], "tags": [], "description": None},
+    )
+    mock_item.enriched = False
+    mock_components["storage"].get_content_item = Mock(return_value=mock_item)
+
+    response = client.get("/api/items/7?user_id=1")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["enriched"] is False
+    assert data["genres"] == ["Drama"]
+
+
+def test_edit_item_manual_metadata(client, mock_components):
+    """PATCH /api/items/{db_id} forwards manual genres/tags/description."""
+    updated_item = ContentItem(
+        id="movie_1",
+        db_id=7,
+        title="Test Movie",
+        content_type=ContentType.MOVIE,
+        status=ConsumptionStatus.UNREAD,
+        metadata={
+            "genres": ["Drama"],
+            "tags": ["slow-burn"],
+            "description": "Hand written.",
+        },
+    )
+    updated_item.enriched = True
+    mock_components["storage"].update_item_from_ui = Mock(return_value=True)
+    mock_components["storage"].get_content_item = Mock(return_value=updated_item)
+
+    response = client.patch(
+        "/api/items/7?user_id=1",
+        json={
+            "status": "unread",
+            "genres": ["Drama"],
+            "tags": ["slow-burn"],
+            "description": "Hand written.",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["genres"] == ["Drama"]
+    assert data["tags"] == ["slow-burn"]
+    assert data["description"] == "Hand written."
+    assert data["enriched"] is True
+
+    mock_components["storage"].update_item_from_ui.assert_called_once_with(
+        db_id=7,
+        status="unread",
+        rating=None,
+        review=None,
+        seasons_watched=None,
+        genres=["Drama"],
+        tags=["slow-burn"],
+        description="Hand written.",
+        user_id=1,
+    )
+
+
+def test_edit_item_without_manual_metadata_passes_none(client, mock_components):
+    """PATCH without manual fields forwards None for genres/tags/description."""
+    updated_item = ContentItem(
+        id="movie_1",
+        db_id=7,
+        title="Test Movie",
+        content_type=ContentType.MOVIE,
+        status=ConsumptionStatus.COMPLETED,
+    )
+    mock_components["storage"].update_item_from_ui = Mock(return_value=True)
+    mock_components["storage"].get_content_item = Mock(return_value=updated_item)
+
+    response = client.patch(
+        "/api/items/7?user_id=1",
+        json={"status": "completed", "rating": 4},
+    )
+
+    assert response.status_code == 200
+    mock_components["storage"].update_item_from_ui.assert_called_once_with(
+        db_id=7,
+        status="completed",
+        rating=4,
+        review=None,
+        seasons_watched=None,
+        genres=None,
+        tags=None,
+        description=None,
+        user_id=1,
+    )
+
+
+def test_edit_rejects_oversized_manual_metadata(client, mock_components):
+    """PATCH /api/items/{db_id} rejects manual metadata above the model caps.
+
+    Bounds the manual-edit fields at the API boundary: at most 50 genres and
+    100 tags, each genre/tag string at most 100 chars, and a description at
+    most 10000 chars. Each over-cap payload must 422 before any storage write.
+    """
+    mock_components["storage"].update_item_from_ui = Mock(return_value=True)
+
+    too_many_genres = client.patch(
+        "/api/items/42?user_id=1",
+        json={"status": "unread", "genres": ["g"] * 51},
+    )
+    assert too_many_genres.status_code == 422
+    assert too_many_genres.json()["detail"]
+
+    genre_too_long = client.patch(
+        "/api/items/42?user_id=1",
+        json={"status": "unread", "genres": ["x" * 101]},
+    )
+    assert genre_too_long.status_code == 422
+    assert genre_too_long.json()["detail"]
+
+    tag_too_long = client.patch(
+        "/api/items/42?user_id=1",
+        json={"status": "unread", "tags": ["x" * 101]},
+    )
+    assert tag_too_long.status_code == 422
+    assert tag_too_long.json()["detail"]
+
+    description_too_long = client.patch(
+        "/api/items/42?user_id=1",
+        json={"status": "unread", "description": "x" * 10001},
+    )
+    assert description_too_long.status_code == 422
+    assert description_too_long.json()["detail"]
+
+    too_many_tags = client.patch(
+        "/api/items/42?user_id=1",
+        json={"status": "unread", "tags": ["t"] * 101},
+    )
+    assert too_many_tags.status_code == 422
+    assert too_many_tags.json()["detail"]
+
+    review_too_long = client.patch(
+        "/api/items/42?user_id=1",
+        json={"status": "unread", "review": "x" * 10001},
+    )
+    assert review_too_long.status_code == 422
+    assert review_too_long.json()["detail"]
+
+    mock_components["storage"].update_item_from_ui.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this does

Closes #59. You can now see which library items still need metadata, and fill that metadata in yourself.

Two pieces, plus a fix for the thing the issue comment flagged:

- **See and filter by enrichment state.** The library toolbar has a new Enrichment filter (All items / Enriched / Not enriched), and any item that hasn't been enriched gets a "Not enriched" badge on its card. It's deliberately two states only. Under the hood, items that are pending, came back not-found, or errored all count as "not enriched", since those are exactly the ones you'd want to fix by hand.
- **Manually add enrichment data.** The edit modal now has an Enrichment section where you can set genres, tags, and a description per item (genres/tags use a little chip input). Saving marks the item enriched so it drops out of the "not enriched" list, and a later automatic enrichment run won't clobber what you typed.
- **Data view now updates live after a sync.** The issue comment noted that after syncing it didn't show enrichment happening. Root cause was on the Data page: a finished sync did a one-shot stats refresh but never started polling, so a running job stayed invisible until you navigated away and back. It now starts polling on sync completion.

CLI keeps parity throughout: `library list --enrichment enriched|not_enriched`, and `library edit --genre/--tag/--description`, with the same length bounds the web API enforces.

## Engineering notes

- The enrichment filter and the per-item `enriched` flag are driven by a single shared SQL predicate so they can't drift.
- Manual edits write through a cursor-scoped helper inside the existing transaction (no nested commit), and an unknown content type raises instead of silently marking an item enriched with nothing written.
- Manual metadata is protected from auto-enrichment by queue exclusion (the item's `needs_enrichment` is cleared), verified by an end-to-end regression test that drives the real enrichment manager.

## How to test

1. **Filter:** open the library, switch the Enrichment filter between Enriched and Not enriched. Freshly synced items should show the "Not enriched" badge.
2. **Manual edit:** edit a not-enriched item, add a genre or two, a tag, and a description, save. The badge should clear and it should move into the Enriched filter.
3. **Overwrite protection:** run enrichment after a manual edit; your values should survive untouched.
4. **CLI:** `library list --enrichment not_enriched`, then `library edit --id <n> --genre Action --tag co-op --description "..."`, then `library show --id <n>`.
5. **Data view polling:** trigger a sync that auto-enriches; the Data page should show enrichment running and update progress without a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
