### PR TITLE
feat: add library search (title and creator, fuzzy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ see **[docs/DATA_SOURCES.md](docs/DATA_SOURCES.md)**.
 - Transparent scoring pipeline — genre, creator, series order, tag overlap, rating patterns ([how it works](docs/SCORING.md))
 - Natural-language [custom rules](docs/CUSTOM_RULES.md) like "avoid horror" or "prefer short books"
 - Content-length filtering, multi-user support, [metadata enrichment](docs/ENRICHMENT_SETUP.md) (TMDB/OpenLibrary/RAWG) — automatic, plus manual editing of genres, tags, and descriptions and a library filter by enrichment state
+- Searchable library — fuzzy, typo-tolerant matching on title and creator (author/director/creators/developer), in both the web UI and CLI
 - Themeable web UI (ships with Nord and Snowstorm) with version display and update detection
 - Dual interface — CLI for automation, web UI for browsing
 
@@ -137,6 +138,7 @@ The CLI is a full peer to the web UI. A taste:
 python3.11 -m src.cli update --source all          # import everything
 python3.11 -m src.cli recommend --type book --count 10
 python3.11 -m src.cli library list --type book --status completed --sort rating
+python3.11 -m src.cli library list --search "die hard"   # fuzzy title/creator search
 python3.11 -m src.cli chat start                   # conversational mode (AI)
 ```
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -41,6 +41,10 @@ python3.11 -m src.cli library list --format json
 # Filter by enrichment state (enriched or not_enriched)
 python3.11 -m src.cli library list --enrichment not_enriched
 
+# Search by title or creator (matches web API search). Fuzzy and typo-tolerant;
+# combines with the type/status filters.
+python3.11 -m src.cli library list --search "die hard"
+
 # Show item details
 python3.11 -m src.cli library show --id 42
 

--- a/docs/ENRICHMENT_SETUP.md
+++ b/docs/ENRICHMENT_SETUP.md
@@ -71,7 +71,8 @@ TMDB provides comprehensive metadata for movies and TV shows. It's the backbone 
 - Ratings
 - Release dates
 - Studio/network information
-- Creator credits (TV shows)
+- Director (movies, from credits; up to 3 directors comma-joined)
+- Creator credits (TV shows; up to 3 creators comma-joined)
 - Collection/franchise info with series position ordering (e.g., knowing that *The Dark Knight* is the 2nd film in the Dark Knight trilogy)
 
 **Getting your API key:**

--- a/resources/css/base.css
+++ b/resources/css/base.css
@@ -1446,6 +1446,30 @@ input[type="checkbox"] {
   font-size: var(--text-sm);
 }
 
+.empty-state-search {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.empty-state-icon {
+  color: var(--text-muted);
+  margin-bottom: var(--space-2);
+}
+
+.empty-state-title {
+  font-size: var(--text-md);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.empty-state-hint {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  margin-bottom: var(--space-3);
+}
+
 /* Chat */
 .chat-container { display: grid; grid-template-columns: 1fr 280px; gap: var(--space-4); height: calc(100vh - 120px); min-height: 500px; }
 .chat-main { display: flex; flex-direction: column; background: var(--bg-card); border: 1px solid var(--border-default); border-radius: var(--radius-lg); overflow: hidden; }

--- a/resources/js/components/atoms/SearchInput.test.ts
+++ b/resources/js/components/atoms/SearchInput.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SearchInput from './SearchInput.vue'
+
+describe('SearchInput', () => {
+  it('renders a search input with role=search wrapper', () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: '' } })
+    expect(wrapper.find('[role="search"]').exists()).toBe(true)
+    expect(wrapper.find('input[type="search"]').exists()).toBe(true)
+  })
+
+  it('wires the label to the input via default id', () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: '' } })
+    const label = wrapper.find('label.sr-only')
+    const input = wrapper.find('input')
+    expect(label.text()).toBe('Search library')
+    expect(label.attributes('for')).toBe('library-search')
+    expect(input.attributes('id')).toBe('library-search')
+  })
+
+  it('accepts custom id, label and placeholder', () => {
+    const wrapper = mount(SearchInput, {
+      props: { modelValue: '', id: 'my-search', label: 'Find stuff', placeholder: 'Type here' },
+    })
+    expect(wrapper.find('label').attributes('for')).toBe('my-search')
+    expect(wrapper.find('label').text()).toBe('Find stuff')
+    expect(wrapper.find('input').attributes('id')).toBe('my-search')
+    expect(wrapper.find('input').attributes('placeholder')).toBe('Type here')
+  })
+
+  it('reflects modelValue on the input', () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: 'hello' } })
+    const input = wrapper.find('input').element as HTMLInputElement
+    expect(input.value).toBe('hello')
+  })
+
+  it('emits update:modelValue on input', async () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: '' } })
+    const input = wrapper.find('input')
+    await input.setValue('dune')
+    expect(wrapper.emitted('update:modelValue')).toEqual([['dune']])
+  })
+
+  it('decorative search icon is aria-hidden', () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: '' } })
+    const svgs = wrapper.findAll('svg')
+    expect(svgs.length).toBeGreaterThan(0)
+    expect(svgs[0].attributes('aria-hidden')).toBe('true')
+  })
+
+  it('hides the clear button when there is no text', () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: '' } })
+    expect(wrapper.find('.search-input-clear').exists()).toBe(false)
+  })
+
+  it('shows the clear button only when text is present', () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: 'abc' } })
+    const clear = wrapper.find('.search-input-clear')
+    expect(clear.exists()).toBe(true)
+    expect(clear.attributes('aria-label')).toBe('Clear search')
+  })
+
+  it('clear button emits empty modelValue then clear', async () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: 'abc' } })
+    await wrapper.find('.search-input-clear').trigger('click')
+    expect(wrapper.emitted('update:modelValue')).toEqual([['']])
+    expect(wrapper.emitted('clear')).toEqual([[]])
+  })
+
+  it('clear button restores focus to the input', async () => {
+    const wrapper = mount(SearchInput, {
+      props: { modelValue: 'abc' },
+      attachTo: document.body,
+    })
+    await wrapper.find('.search-input-clear').trigger('click')
+    expect(document.activeElement).toBe(wrapper.find('input').element)
+    wrapper.unmount()
+  })
+
+  it('spinner is aria-hidden while loading', () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: 'abc', loading: true } })
+    expect(wrapper.find('.spinner').attributes('aria-hidden')).toBe('true')
+  })
+
+  it('Escape clears when text is present and prevents default', async () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: 'abc' } })
+    await wrapper.find('input').trigger('keydown', { key: 'Escape' })
+    expect(wrapper.emitted('update:modelValue')).toEqual([['']])
+    expect(wrapper.emitted('clear')).toEqual([[]])
+  })
+
+  it('Escape does nothing when there is no text', async () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: '' } })
+    await wrapper.find('input').trigger('keydown', { key: 'Escape' })
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    expect(wrapper.emitted('clear')).toBeUndefined()
+  })
+
+  it('Escape clears even while loading', async () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: 'abc', loading: true } })
+    await wrapper.find('input').trigger('keydown', { key: 'Escape' })
+    expect(wrapper.emitted('update:modelValue')).toEqual([['']])
+    expect(wrapper.emitted('clear')).toEqual([[]])
+  })
+
+  it('shows a spinner and hides the clear button while loading', () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: 'abc', loading: true } })
+    expect(wrapper.find('.spinner').exists()).toBe(true)
+    expect(wrapper.find('.search-input-clear').exists()).toBe(false)
+  })
+
+  it('sets aria-busy from the loading prop', () => {
+    const idle = mount(SearchInput, { props: { modelValue: '' } })
+    expect(idle.find('input').attributes('aria-busy')).toBe('false')
+    const busy = mount(SearchInput, { props: { modelValue: 'x', loading: true } })
+    expect(busy.find('input').attributes('aria-busy')).toBe('true')
+  })
+
+  it('disables native autocomplete', () => {
+    const wrapper = mount(SearchInput, { props: { modelValue: '' } })
+    expect(wrapper.find('input').attributes('autocomplete')).toBe('off')
+  })
+})

--- a/resources/js/components/atoms/SearchInput.vue
+++ b/resources/js/components/atoms/SearchInput.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const props = withDefaults(defineProps<{
+  modelValue: string
+  loading?: boolean
+  id?: string
+  label?: string
+  placeholder?: string
+}>(), {
+  loading: false,
+  id: 'library-search',
+  label: 'Search library',
+  placeholder: '',
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+  clear: []
+}>()
+
+const input = ref<HTMLInputElement | null>(null)
+
+function onInput(e: Event) {
+  emit('update:modelValue', (e.target as HTMLInputElement).value)
+}
+
+function onClear() {
+  emit('update:modelValue', '')
+  emit('clear')
+  input.value?.focus()
+}
+
+function onEscape(e: KeyboardEvent) {
+  if (props.modelValue.length > 0) {
+    e.preventDefault()
+    onClear()
+  }
+}
+</script>
+
+<template>
+  <div class="search-input" role="search">
+    <label :for="id" class="sr-only">{{ label }}</label>
+    <svg
+      class="search-input-icon"
+      aria-hidden="true"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+    <input
+      :id="id"
+      ref="input"
+      type="search"
+      class="search-input-field"
+      :value="modelValue"
+      :placeholder="placeholder"
+      autocomplete="off"
+      enterkeyhint="search"
+      :aria-busy="loading"
+      @input="onInput"
+      @keydown.esc="onEscape"
+    >
+    <span class="search-input-trailing">
+      <span v-if="loading" class="spinner" aria-hidden="true" />
+      <button
+        v-else-if="modelValue.length > 0"
+        type="button"
+        class="btn btn-ghost search-input-clear"
+        aria-label="Clear search"
+        @click="onClear"
+      >
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+    </span>
+  </div>
+</template>
+
+<style scoped>
+.search-input {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-input);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition-fast);
+}
+
+.search-input:focus-within {
+  border-color: var(--border-focus);
+}
+
+.search-input:has(:focus-visible) {
+  outline: 2px solid var(--accent-light);
+  outline-offset: 2px;
+}
+
+.search-input-icon {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.search-input-field {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  font-family: inherit;
+}
+
+.search-input-field::placeholder {
+  color: var(--text-muted);
+}
+
+.search-input-field:focus-visible {
+  outline: none;
+}
+
+.search-input-field::-webkit-search-cancel-button {
+  display: none;
+}
+
+.search-input-trailing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  min-height: 32px;
+  flex-shrink: 0;
+}
+
+.search-input-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  min-height: 32px;
+  padding: 0;
+}
+</style>

--- a/resources/js/components/organisms/LibraryFilters.test.ts
+++ b/resources/js/components/organisms/LibraryFilters.test.ts
@@ -8,7 +8,46 @@ describe('LibraryFilters', () => {
     statusFilter: '',
     enrichmentFilter: '',
     showIgnored: false,
+    searchQuery: '',
+    searchLoading: false,
   }
+
+  it('renders the search input as the first toolbar child', () => {
+    const wrapper = mount(LibraryFilters, { props: defaultProps })
+
+    const search = wrapper.find('.lib-search')
+    expect(search.exists()).toBe(true)
+    expect(search.find('input[type="search"]').attributes('placeholder')).toBe('Search by title or creator')
+    expect(wrapper.find('.library-toolbar').element.firstElementChild).toBe(search.element)
+  })
+
+  it('reflects searchQuery into the search input', () => {
+    const wrapper = mount(LibraryFilters, {
+      props: { ...defaultProps, searchQuery: 'dune' },
+    })
+
+    const input = wrapper.find('.lib-search input').element as HTMLInputElement
+    expect(input.value).toBe('dune')
+  })
+
+  it('emits filterChange for search on input', async () => {
+    const wrapper = mount(LibraryFilters, { props: defaultProps })
+
+    await wrapper.find('.lib-search input').setValue('dune')
+
+    expect(wrapper.emitted('filterChange')).toEqual([['search', 'dune']])
+  })
+
+  it('emits filterChange with empty search on clear', async () => {
+    const wrapper = mount(LibraryFilters, {
+      props: { ...defaultProps, searchQuery: 'dune' },
+    })
+
+    await wrapper.find('.search-input-clear').trigger('click')
+
+    const emitted = wrapper.emitted('filterChange')!
+    expect(emitted).toContainEqual(['search', ''])
+  })
 
   it('renders TypePills with all options', () => {
     const wrapper = mount(LibraryFilters, { props: defaultProps })

--- a/resources/js/components/organisms/LibraryFilters.vue
+++ b/resources/js/components/organisms/LibraryFilters.vue
@@ -3,16 +3,22 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import TypePills from '@/components/atoms/TypePills.vue'
 import TypeSelect from '@/components/atoms/TypeSelect.vue'
 import ToggleSwitch from '@/components/atoms/ToggleSwitch.vue'
+import SearchInput from '@/components/atoms/SearchInput.vue'
 
 const props = defineProps<{
   typeFilter: string
   statusFilter: string
   enrichmentFilter: string
   showIgnored: boolean
+  searchQuery: string
+  searchLoading: boolean
 }>()
 
 const emit = defineEmits<{
-  filterChange: [key: 'type' | 'status' | 'enrichment' | 'showIgnored', value: string | boolean]
+  filterChange: [
+    key: 'type' | 'status' | 'enrichment' | 'showIgnored' | 'search',
+    value: string | boolean,
+  ]
   export: [format: 'csv' | 'json']
 }>()
 
@@ -57,6 +63,14 @@ onUnmounted(() => {
 <template>
   <div class="card">
     <div class="library-toolbar">
+      <SearchInput
+        class="lib-search"
+        :model-value="searchQuery"
+        :loading="searchLoading"
+        placeholder="Search by title or creator"
+        @update:model-value="emit('filterChange', 'search', $event)"
+      />
+
       <!-- Desktop: Type pills -->
       <TypePills
         class="lib-pills"
@@ -122,6 +136,11 @@ onUnmounted(() => {
   flex-wrap: wrap;
 }
 
+.lib-search {
+  flex: 1 1 100%;
+  order: -1;
+}
+
 .lib-filter-row,
 .lib-actions-row {
   display: flex;
@@ -138,6 +157,12 @@ onUnmounted(() => {
 }
 
 @media (max-width: 640px) {
+  .card {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+  }
+
   .lib-pills,
   .toolbar-divider {
     display: none;

--- a/resources/js/components/pages/LibraryPage.test.ts
+++ b/resources/js/components/pages/LibraryPage.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createTestingPinia } from '@pinia/testing'
+import LibraryPage from './LibraryPage.vue'
+import { useLibraryStore } from '@/stores/library'
+
+// jsdom has no IntersectionObserver; the page sets one up on mount.
+class FakeIntersectionObserver {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+  takeRecords = vi.fn(() => [])
+}
+
+beforeEach(() => {
+  vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver)
+})
+
+function mountPage(overrides: Record<string, unknown> = {}) {
+  const wrapper = mount(LibraryPage, {
+    global: {
+      plugins: [createTestingPinia({ createSpy: vi.fn })],
+      stubs: {
+        LibraryFilters: true,
+        LibraryCard: true,
+        EditModal: true,
+      },
+    },
+  })
+  const lib = useLibraryStore()
+  Object.assign(lib, { items: [], loading: false, searchQuery: '', searchAnnouncement: '', error: '', ...overrides })
+  return { wrapper, lib }
+}
+
+describe('LibraryPage search behaviour', () => {
+  it('renders the search empty state with the query and a Clear search button', async () => {
+    const { wrapper } = mountPage({ items: [], loading: false, searchQuery: 'dune' })
+    await wrapper.vm.$nextTick()
+
+    const empty = wrapper.find('.empty-state-search')
+    expect(empty.exists()).toBe(true)
+    expect(empty.text()).toContain('dune')
+    const clearBtn = empty.findAll('button').find((b) => b.text() === 'Clear search')
+    expect(clearBtn).toBeDefined()
+  })
+
+  it('clicking Clear search calls setFilter with an empty search', async () => {
+    const { wrapper, lib } = mountPage({ items: [], loading: false, searchQuery: 'dune' })
+    await wrapper.vm.$nextTick()
+
+    const clearBtn = wrapper.find('.empty-state-search').findAll('button').find((b) => b.text() === 'Clear search')!
+    await clearBtn.trigger('click')
+
+    expect(lib.setFilter).toHaveBeenCalledWith('search', '')
+  })
+
+  it('reflects searchAnnouncement in the polite live region', async () => {
+    const { wrapper } = mountPage({ searchAnnouncement: '2 items match “dune”' })
+    await wrapper.vm.$nextTick()
+
+    const region = wrapper.find('[role="status"]')
+    expect(region.exists()).toBe(true)
+    expect(region.attributes('aria-live')).toBe('polite')
+    expect(region.text()).toBe('2 items match “dune”')
+  })
+
+  it('renders the generic empty state when there is no search query', async () => {
+    const { wrapper } = mountPage({ items: [], loading: false, searchQuery: '' })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.empty-state-search').exists()).toBe(false)
+    const generic = wrapper.find('.empty-state')
+    expect(generic.exists()).toBe(true)
+    expect(generic.text()).toContain('No items found')
+  })
+})

--- a/resources/js/components/pages/LibraryPage.vue
+++ b/resources/js/components/pages/LibraryPage.vue
@@ -50,6 +50,7 @@ function setupInfiniteScroll() {
 
 onUnmounted(() => {
   observer?.disconnect()
+  lib.cleanup()
 })
 
 </script>
@@ -66,15 +67,32 @@ onUnmounted(() => {
       :status-filter="lib.statusFilter"
       :enrichment-filter="lib.enrichmentFilter"
       :show-ignored="lib.showIgnored"
+      :search-query="lib.searchQuery"
+      :search-loading="lib.searchLoading"
       @filter-change="lib.setFilter"
       @export="lib.exportLibrary"
     />
+
+    <p class="sr-only" role="status" aria-live="polite">{{ lib.searchAnnouncement }}</p>
 
     <div v-if="lib.error" class="status-bar error" role="alert" style="display: block">
       Failed to load library: {{ lib.error }}
     </div>
 
-    <div v-if="lib.items.length === 0 && !lib.loading" class="empty-state">
+    <div
+      v-if="lib.items.length === 0 && !lib.loading && lib.searchQuery"
+      class="empty-state empty-state-search"
+    >
+      <svg class="empty-state-icon" aria-hidden="true" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <circle cx="11" cy="11" r="8" />
+        <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      </svg>
+      <p class="empty-state-title">No items match “{{ lib.searchQuery }}”</p>
+      <p class="empty-state-hint">Try a different title, or check your spelling.</p>
+      <button class="btn btn-secondary" @click="lib.setFilter('search', '')">Clear search</button>
+    </div>
+
+    <div v-else-if="lib.items.length === 0 && !lib.loading" class="empty-state">
       No items found. Try syncing your sources.
     </div>
 

--- a/resources/js/stores/library.test.ts
+++ b/resources/js/stores/library.test.ts
@@ -95,6 +95,218 @@ describe('useLibraryStore', () => {
     expect(params.enrichment).toBeUndefined()
   })
 
+  it('has empty search state initially', () => {
+    const store = useLibraryStore()
+    expect(store.searchQuery).toBe('')
+    expect(store.searchLoading).toBe(false)
+    expect(store.searchAnnouncement).toBe('')
+  })
+
+  it('setFilter search passes the search param and resets pagination', async () => {
+    vi.useFakeTimers()
+    try {
+      mockGet.mockResolvedValue([
+        { db_id: 1, title: 'Dune', content_type: 'book', status: 'unread', ignored: false },
+      ])
+      const store = useLibraryStore()
+      store.setFilter('search', 'dune')
+      expect(store.searchQuery).toBe('dune')
+
+      await vi.runAllTimersAsync()
+
+      expect(store.offset).toBe(1)
+      const params = mockGet.mock.calls[mockGet.mock.calls.length - 1][1]
+      expect(params.search).toBe('dune')
+      expect(params.offset).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('debounce coalesces rapid search changes into one request', async () => {
+    vi.useFakeTimers()
+    try {
+      mockGet.mockResolvedValue([])
+      const store = useLibraryStore()
+
+      store.setFilter('search', 'd')
+      store.setFilter('search', 'du')
+      store.setFilter('search', 'dune')
+
+      expect(mockGet).not.toHaveBeenCalled()
+      await vi.runAllTimersAsync()
+
+      expect(mockGet).toHaveBeenCalledTimes(1)
+      expect(mockGet.mock.calls[0][1].search).toBe('dune')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('toggles searchLoading around a search request', async () => {
+    vi.useFakeTimers()
+    try {
+      let resolve: (v: unknown) => void = () => {}
+      mockGet.mockReturnValue(new Promise((r) => { resolve = r }))
+      const store = useLibraryStore()
+
+      store.setFilter('search', 'dune')
+      expect(store.searchLoading).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(250)
+      expect(store.searchLoading).toBe(true)
+
+      resolve([])
+      await vi.runAllTimersAsync()
+      expect(store.searchLoading).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('announces plural results for an active query', async () => {
+    vi.useFakeTimers()
+    try {
+      mockGet.mockResolvedValue([
+        { db_id: 1, title: 'A', content_type: 'book', status: 'unread', ignored: false },
+        { db_id: 2, title: 'B', content_type: 'book', status: 'unread', ignored: false },
+      ])
+      const store = useLibraryStore()
+      store.setFilter('search', 'a')
+      await vi.runAllTimersAsync()
+      expect(store.searchAnnouncement).toBe('2 items match “a”')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('announces a singular result for an active query', async () => {
+    vi.useFakeTimers()
+    try {
+      mockGet.mockResolvedValue([
+        { db_id: 1, title: 'A', content_type: 'book', status: 'unread', ignored: false },
+      ])
+      const store = useLibraryStore()
+      store.setFilter('search', 'a')
+      await vi.runAllTimersAsync()
+      expect(store.searchAnnouncement).toBe('1 item matches “a”')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('announces no results for an active query', async () => {
+    vi.useFakeTimers()
+    try {
+      mockGet.mockResolvedValue([])
+      const store = useLibraryStore()
+      store.setFilter('search', 'zzz')
+      await vi.runAllTimersAsync()
+      expect(store.searchAnnouncement).toBe('No items match “zzz”')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clearing the search resets the query and announcement', async () => {
+    vi.useFakeTimers()
+    try {
+      mockGet.mockResolvedValue([])
+      const store = useLibraryStore()
+      store.setFilter('search', 'zzz')
+      await vi.runAllTimersAsync()
+      expect(store.searchAnnouncement).toBe('No items match “zzz”')
+
+      store.setFilter('search', '')
+      await vi.runAllTimersAsync()
+      expect(store.searchQuery).toBe('')
+      expect(store.searchAnnouncement).toBe('')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears searchLoading when a search is triggered while a load is in flight', async () => {
+    vi.useFakeTimers()
+    try {
+      let resolveFirst: (v: unknown) => void = () => {}
+      mockGet.mockReturnValueOnce(new Promise((r) => { resolveFirst = r }))
+      const store = useLibraryStore()
+
+      // Kick off a load that stays in flight.
+      const firstLoad = store.resetAndLoad()
+      expect(store.loading).toBe(true)
+
+      // Type a search while that load is still running: the debounced
+      // runSearch must await the real settle, not strand searchLoading.
+      mockGet.mockResolvedValue([])
+      store.setFilter('search', 'dune')
+      await vi.advanceTimersByTimeAsync(250)
+      expect(store.searchLoading).toBe(true)
+
+      resolveFirst([])
+      await firstLoad
+      await vi.runAllTimersAsync()
+      expect(store.searchLoading).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cleanup cancels a pending debounced search', async () => {
+    vi.useFakeTimers()
+    try {
+      mockGet.mockResolvedValue([])
+      const store = useLibraryStore()
+
+      store.setFilter('search', 'dune')
+      store.cleanup()
+      await vi.runAllTimersAsync()
+
+      expect(mockGet).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resets searchLoading and sets error when the search request rejects', async () => {
+    vi.useFakeTimers()
+    try {
+      mockGet.mockRejectedValue(new Error('network down'))
+      const store = useLibraryStore()
+
+      store.setFilter('search', 'dune')
+      await vi.runAllTimersAsync()
+
+      expect(store.searchLoading).toBe(false)
+      expect(store.error).toBe('network down')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('refreshes the announcement when a non-search filter changes during an active search', async () => {
+    vi.useFakeTimers()
+    try {
+      mockGet.mockResolvedValue([
+        { db_id: 1, title: 'A', content_type: 'book', status: 'unread', ignored: false },
+        { db_id: 2, title: 'B', content_type: 'book', status: 'unread', ignored: false },
+      ])
+      const store = useLibraryStore()
+      store.setFilter('search', 'a')
+      await vi.runAllTimersAsync()
+      expect(store.searchAnnouncement).toBe('2 items match “a”')
+
+      mockGet.mockResolvedValue([
+        { db_id: 1, title: 'A', content_type: 'book', status: 'unread', ignored: false },
+      ])
+      await store.setFilter('type', 'book')
+      expect(store.searchAnnouncement).toBe('1 item matches “a”')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('saveEdit updates item in list', async () => {
     const item = { db_id: 1, title: 'Book A', content_type: 'book', status: 'unread', rating: null, ignored: false }
     mockGet.mockResolvedValue([item])

--- a/resources/js/stores/library.ts
+++ b/resources/js/stores/library.ts
@@ -5,6 +5,7 @@ import { useAppStore } from '@/stores/app'
 import type { ContentItemResponse, ItemEditRequest } from '@/types/api'
 
 const PAGE_SIZE = 50
+const SEARCH_DEBOUNCE_MS = 250
 
 export const useLibraryStore = defineStore('library', () => {
   const api = useApi()
@@ -22,6 +23,16 @@ export const useLibraryStore = defineStore('library', () => {
   const enrichmentFilter = ref('')
   const showIgnored = ref(false)
 
+  // Search
+  const searchQuery = ref('')
+  const searchLoading = ref(false)
+  const searchAnnouncement = ref('')
+  let searchTimer: ReturnType<typeof setTimeout> | null = null
+  // Tracks the in-flight load so a search triggered while a request is
+  // already running awaits the real settle instead of an instantly-resolved
+  // promise, keeping searchLoading bound to the true request lifecycle.
+  let inFlightLoad: Promise<void> | null = null
+
   // Edit modal
   const editingItem = ref<ContentItemResponse | null>(null)
   const editSaving = ref(false)
@@ -38,8 +49,17 @@ export const useLibraryStore = defineStore('library', () => {
     return load(true)
   }
 
-  async function load(isReset = false) {
-    if (loading.value) return
+  function load(isReset = false): Promise<void> {
+    // Never return undefined: a search triggered while a load is already in
+    // flight must await that settle so its finally clears searchLoading.
+    if (loading.value) return inFlightLoad ?? Promise.resolve()
+    inFlightLoad = runLoad(isReset).finally(() => {
+      inFlightLoad = null
+    })
+    return inFlightLoad
+  }
+
+  async function runLoad(isReset: boolean): Promise<void> {
     const app = useAppStore()
     loading.value = true
     error.value = ''
@@ -54,6 +74,7 @@ export const useLibraryStore = defineStore('library', () => {
       if (statusFilter.value) params.status = statusFilter.value
       if (enrichmentFilter.value) params.enrichment = enrichmentFilter.value
       if (showIgnored.value) params.include_ignored = true
+      if (searchQuery.value) params.search = searchQuery.value
 
       const result = await api.get<ContentItemResponse[]>('/items', params)
 
@@ -68,10 +89,41 @@ export const useLibraryStore = defineStore('library', () => {
       }
 
       offset.value += result.length
+
+      if (isReset) announceSearch(result.length)
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to load library'
     } finally {
       loading.value = false
+    }
+  }
+
+  function announceSearch(count: number) {
+    const query = searchQuery.value
+    if (!query) {
+      searchAnnouncement.value = ''
+    } else if (count === 0) {
+      searchAnnouncement.value = `No items match “${query}”`
+    } else if (count === 1) {
+      searchAnnouncement.value = `1 item matches “${query}”`
+    } else {
+      searchAnnouncement.value = `${count} items match “${query}”`
+    }
+  }
+
+  async function runSearch(): Promise<void> {
+    searchLoading.value = true
+    try {
+      await resetAndLoad()
+    } finally {
+      searchLoading.value = false
+    }
+  }
+
+  function cleanup() {
+    if (searchTimer) {
+      clearTimeout(searchTimer)
+      searchTimer = null
     }
   }
 
@@ -81,7 +133,19 @@ export const useLibraryStore = defineStore('library', () => {
     }
   }
 
-  function setFilter(key: 'type' | 'status' | 'enrichment' | 'showIgnored', value: string | boolean) {
+  function setFilter(
+    key: 'type' | 'status' | 'enrichment' | 'showIgnored' | 'search',
+    value: string | boolean,
+  ) {
+    if (key === 'search') {
+      searchQuery.value = value as string
+      if (searchTimer) clearTimeout(searchTimer)
+      searchTimer = setTimeout(() => {
+        searchTimer = null
+        runSearch()
+      }, SEARCH_DEBOUNCE_MS)
+      return
+    }
     if (key === 'type') typeFilter.value = value as string
     else if (key === 'status') statusFilter.value = value as string
     else if (key === 'enrichment') enrichmentFilter.value = value as string
@@ -170,12 +234,16 @@ export const useLibraryStore = defineStore('library', () => {
     statusFilter,
     enrichmentFilter,
     showIgnored,
+    searchQuery,
+    searchLoading,
+    searchAnnouncement,
     editingItem,
     editSaving,
     totalLoaded,
     resetAndLoad,
     load,
     loadMore,
+    cleanup,
     setFilter,
     openEdit,
     closeEdit,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1193,6 +1193,11 @@ def library() -> None:
     help="Sort order (default: title)",
 )
 @click.option(
+    "--search",
+    default=None,
+    help="Filter by title or creator (matches web API search)",
+)
+@click.option(
     "--show-ignored",
     is_flag=True,
     help="Include ignored items",
@@ -1236,6 +1241,7 @@ def library_list(
     content_type_str: str | None,
     status_str: str | None,
     sort_by: str,
+    search: str | None,
     show_ignored: bool,
     enrichment_str: str | None,
     limit: int | None,
@@ -1259,6 +1265,7 @@ def library_list(
         content_type=content_type,
         status=consumption_status,
         sort_by=sort_by,
+        search=search,
         include_ignored=show_ignored,
         limit=limit,
         offset=offset,

--- a/src/enrichment/providers/tmdb/README.md
+++ b/src/enrichment/providers/tmdb/README.md
@@ -31,6 +31,11 @@ enrichment:
 - Searches by title, with year-aware disambiguation when available.
 - Uses gap-filling — never overwrites existing fields.
 - Rate-limited to TMDB's 40 requests/sec ceiling.
+- Enriches genres, description, tags (keywords), and extra metadata. For movies
+  this includes runtime, ratings, release date/year, language, studio, series
+  ordering, and `director` (from credits, up to 3 directors comma-joined). For
+  TV shows it includes seasons, episodes, networks, status, and `creators` (up
+  to 3 creators comma-joined).
 
 ## Development
 - Implementation: [`tmdb.py`](tmdb.py)

--- a/src/enrichment/providers/tmdb/test_tmdb.py
+++ b/src/enrichment/providers/tmdb/test_tmdb.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from src.enrichment.provider_base import ProviderError
+from src.enrichment.provider_base import EnrichmentResult, ProviderError
 from src.enrichment.providers.tmdb.tmdb import (
     TMDBProvider,
     clean_media_title_for_search,
@@ -188,6 +188,8 @@ class TestTMDBProviderMovieEnrichment:
         assert result.provider == "tmdb"
         assert result.extra_metadata.get("runtime") == 136
         assert result.extra_metadata.get("release_year") == 1999
+        # Backward compat: a response without a 'credits' key degrades cleanly.
+        assert "director" not in result.extra_metadata
 
     def test_enrich_movie_with_search(
         self, provider: TMDBProvider, movie_item: ContentItem, config: dict[str, Any]
@@ -351,6 +353,301 @@ class TestTMDBProviderMovieEnrichment:
         assert result is not None
         assert result.external_id == "tmdb:603"
 
+    def test_enrich_movie_requests_credits_via_append_to_response(
+        self, provider: TMDBProvider, config: dict[str, Any]
+    ) -> None:
+        """Test that movie detail request appends credits in one round trip."""
+        item = ContentItem(
+            id="movie123",
+            title="The Matrix",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"tmdb_id": 603},
+        )
+
+        mock_movie_response = {
+            "id": 603,
+            "title": "The Matrix",
+            "genres": [{"id": 28, "name": "Action"}],
+            "credits": {"crew": []},
+        }
+        mock_keywords_response = {"keywords": []}
+
+        with patch("src.enrichment.providers.tmdb.tmdb.requests.get") as mock_get:
+            mock_get.side_effect = [
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: mock_movie_response,
+                ),
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: mock_keywords_response,
+                ),
+            ]
+
+            provider.enrich(item, config)
+
+        detail_call = mock_get.call_args_list[0]
+        # The append_to_response must be on the movie DETAIL call, not keywords.
+        assert detail_call.args[0].endswith("/movie/603")
+        assert detail_call.kwargs["params"]["append_to_response"] == "credits"
+
+    def test_enrich_movie_sets_director_and_excludes_non_director_roles(
+        self, provider: TMDBProvider, config: dict[str, Any]
+    ) -> None:
+        """Test that only Director-job crew is stored, excluding other roles.
+
+        The crew below includes a Writer that must NOT be picked up: only the
+        Director-job entry should land in the 'director' field.
+        """
+        item = ContentItem(
+            id="movie123",
+            title="Pulp Fiction",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"tmdb_id": 680},
+        )
+
+        mock_movie_response = {
+            "id": 680,
+            "title": "Pulp Fiction",
+            "genres": [{"id": 80, "name": "Crime"}],
+            "credits": {
+                "crew": [
+                    {"job": "Writer", "name": "Roger Avary"},
+                    {"job": "Director", "name": "Quentin Tarantino"},
+                ]
+            },
+        }
+        mock_keywords_response = {"keywords": []}
+
+        with patch("src.enrichment.providers.tmdb.tmdb.requests.get") as mock_get:
+            mock_get.side_effect = [
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: mock_movie_response,
+                ),
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: mock_keywords_response,
+                ),
+            ]
+
+            result = provider.enrich(item, config)
+
+        assert result is not None
+        # The Writer (Roger Avary) is excluded; only the Director remains.
+        assert result.extra_metadata.get("director") == "Quentin Tarantino"
+
+    def test_enrich_movie_comma_joins_multiple_directors(
+        self, provider: TMDBProvider, config: dict[str, Any]
+    ) -> None:
+        """Test that multiple directors are comma-joined and capped at three."""
+        item = ContentItem(
+            id="movie123",
+            title="Cloud Atlas",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"tmdb_id": 83542},
+        )
+
+        mock_movie_response = {
+            "id": 83542,
+            "title": "Cloud Atlas",
+            "genres": [{"id": 18, "name": "Drama"}],
+            "credits": {
+                "crew": [
+                    {"job": "Director", "name": "Lana Wachowski"},
+                    {"job": "Director", "name": "Tom Tykwer"},
+                    {"job": "Director", "name": "Lilly Wachowski"},
+                    {"job": "Director", "name": "Extra Director"},
+                ]
+            },
+        }
+        mock_keywords_response = {"keywords": []}
+
+        with patch("src.enrichment.providers.tmdb.tmdb.requests.get") as mock_get:
+            mock_get.side_effect = [
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: mock_movie_response,
+                ),
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: mock_keywords_response,
+                ),
+            ]
+
+            result = provider.enrich(item, config)
+
+        assert result is not None
+        assert (
+            result.extra_metadata.get("director")
+            == "Lana Wachowski, Tom Tykwer, Lilly Wachowski"
+        )
+
+    def _enrich_movie_with_credits(
+        self,
+        provider: TMDBProvider,
+        config: dict[str, Any],
+        movie_response: dict[str, Any],
+    ) -> EnrichmentResult | None:
+        """Enrich a movie via tmdb_id lookup with the given detail payload.
+
+        Mocks the movie-detail call (returning ``movie_response``) followed by an
+        empty keywords call, then returns the enrichment result.
+
+        Note: the item fixture is hardcoded with ``tmdb_id`` 603, so the movie
+        detail call always targets ``/movie/603`` regardless of the ``id`` field
+        in ``movie_response``.
+        """
+        item = ContentItem(
+            id="movie123",
+            title="The Matrix",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"tmdb_id": 603},
+        )
+        mock_keywords_response = {"keywords": []}
+
+        with patch("src.enrichment.providers.tmdb.tmdb.requests.get") as mock_get:
+            mock_get.side_effect = [
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: movie_response,
+                ),
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: mock_keywords_response,
+                ),
+            ]
+
+            return provider.enrich(item, config)
+
+    def test_enrich_movie_without_credits_key_omits_director(
+        self, provider: TMDBProvider, config: dict[str, Any]
+    ) -> None:
+        """Test that a response with no 'credits' key omits 'director', no raise."""
+        result = self._enrich_movie_with_credits(
+            provider,
+            config,
+            {
+                "id": 603,
+                "title": "The Matrix",
+                "genres": [{"id": 28, "name": "Action"}],
+            },
+        )
+
+        assert result is not None
+        assert "director" not in result.extra_metadata
+
+    def test_enrich_movie_with_credits_but_no_crew_omits_director(
+        self, provider: TMDBProvider, config: dict[str, Any]
+    ) -> None:
+        """Test that 'credits' present without 'crew' omits 'director', no raise."""
+        result = self._enrich_movie_with_credits(
+            provider,
+            config,
+            {
+                "id": 603,
+                "title": "The Matrix",
+                "genres": [{"id": 28, "name": "Action"}],
+                "credits": {},
+            },
+        )
+
+        assert result is not None
+        assert "director" not in result.extra_metadata
+
+    def test_enrich_movie_with_no_director_in_crew_omits_director(
+        self, provider: TMDBProvider, config: dict[str, Any]
+    ) -> None:
+        """Test that crew with no Director job omits 'director'."""
+        result = self._enrich_movie_with_credits(
+            provider,
+            config,
+            {
+                "id": 603,
+                "title": "The Matrix",
+                "genres": [{"id": 28, "name": "Action"}],
+                "credits": {"crew": [{"job": "Producer", "name": "Joel Silver"}]},
+            },
+        )
+
+        assert result is not None
+        assert "director" not in result.extra_metadata
+
+    def test_enrich_movie_director_missing_name_is_excluded(
+        self, provider: TMDBProvider, config: dict[str, Any]
+    ) -> None:
+        """Test that a Director entry missing the 'name' key is excluded, no raise."""
+        result = self._enrich_movie_with_credits(
+            provider,
+            config,
+            {
+                "id": 603,
+                "title": "The Matrix",
+                "genres": [{"id": 28, "name": "Action"}],
+                "credits": {"crew": [{"job": "Director"}]},
+            },
+        )
+
+        assert result is not None
+        assert "director" not in result.extra_metadata
+
+    def test_enrich_movie_director_empty_name_is_excluded(
+        self, provider: TMDBProvider, config: dict[str, Any]
+    ) -> None:
+        """Test that a Director entry with an empty-string name is excluded."""
+        result = self._enrich_movie_with_credits(
+            provider,
+            config,
+            {
+                "id": 603,
+                "title": "The Matrix",
+                "genres": [{"id": 28, "name": "Action"}],
+                "credits": {"crew": [{"job": "Director", "name": ""}]},
+            },
+        )
+
+        assert result is not None
+        assert "director" not in result.extra_metadata
+
+    def test_enrich_movie_non_exact_director_jobs_excluded(
+        self, provider: TMDBProvider, config: dict[str, Any]
+    ) -> None:
+        """Test that only the exact 'Director' job matches, not variants.
+
+        'Co-Director' and lowercase 'director' must be excluded so the match
+        stays an exact, case-sensitive equality.
+        """
+        result = self._enrich_movie_with_credits(
+            provider,
+            config,
+            {
+                "id": 603,
+                "title": "The Matrix",
+                "genres": [{"id": 28, "name": "Action"}],
+                "credits": {
+                    "crew": [
+                        {"job": "Co-Director", "name": "Someone Else"},
+                        {"job": "director", "name": "Lowercase Name"},
+                    ]
+                },
+            },
+        )
+
+        assert result is not None
+        assert "director" not in result.extra_metadata
+
 
 class TestTMDBProviderTVShowEnrichment:
     """Tests for TMDB TV show enrichment."""
@@ -489,6 +786,104 @@ class TestTMDBProviderTVShowEnrichment:
 
         assert result is not None
         assert result.external_id == "tmdb:1396"
+
+    def test_enrich_tv_show_creator_missing_or_empty_name_is_excluded(
+        self, provider: TMDBProvider, config: dict[str, Any]
+    ) -> None:
+        """Test that creators missing or with empty 'name' are excluded, no raise.
+
+        The 'created_by' list mixes a valid creator with one missing the 'name'
+        key and one with an empty-string name. Only the valid creator should be
+        captured, and the malformed entries must not raise.
+        """
+        item = ContentItem(
+            id="show123",
+            title="Breaking Bad",
+            content_type=ContentType.TV_SHOW,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"tmdb_id": 1396},
+        )
+
+        mock_tv_response = {
+            "id": 1396,
+            "name": "Breaking Bad",
+            "overview": "A great show.",
+            "genres": [{"id": 18, "name": "Drama"}],
+            "created_by": [
+                {"id": 1},
+                {"name": ""},
+                {"name": "Vince Gilligan"},
+            ],
+        }
+        mock_keywords_response = {"results": []}
+
+        with patch("src.enrichment.providers.tmdb.tmdb.requests.get") as mock_get:
+            mock_get.side_effect = [
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: mock_tv_response,
+                ),
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: mock_keywords_response,
+                ),
+            ]
+
+            result = provider.enrich(item, config)
+
+        assert result is not None
+        # Malformed entries are skipped; the valid creator is still captured.
+        assert result.extra_metadata.get("creators") == "Vince Gilligan"
+
+    def test_enrich_tv_show_comma_joins_multiple_creators(
+        self, provider: TMDBProvider, config: dict[str, Any]
+    ) -> None:
+        """Test that multiple creators are comma-joined and capped at three."""
+        item = ContentItem(
+            id="show123",
+            title="Game of Thrones",
+            content_type=ContentType.TV_SHOW,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"tmdb_id": 1399},
+        )
+
+        mock_tv_response = {
+            "id": 1399,
+            "name": "Game of Thrones",
+            "overview": "Noble families vie for control of the Iron Throne.",
+            "genres": [{"id": 18, "name": "Drama"}],
+            "created_by": [
+                {"name": "David Benioff"},
+                {"name": "D. B. Weiss"},
+                {"name": "George R. R. Martin"},
+                {"name": "Extra Creator"},
+            ],
+        }
+        mock_keywords_response = {"results": []}
+
+        with patch("src.enrichment.providers.tmdb.tmdb.requests.get") as mock_get:
+            mock_get.side_effect = [
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: mock_tv_response,
+                ),
+                MagicMock(
+                    spec=requests.Response,
+                    status_code=200,
+                    json=lambda: mock_keywords_response,
+                ),
+            ]
+
+            result = provider.enrich(item, config)
+
+        assert result is not None
+        assert (
+            result.extra_metadata.get("creators")
+            == "David Benioff, D. B. Weiss, George R. R. Martin"
+        )
 
 
 class TestTMDBProviderKeywords:

--- a/src/enrichment/providers/tmdb/tmdb.py
+++ b/src/enrichment/providers/tmdb/tmdb.py
@@ -329,7 +329,11 @@ class TMDBProvider(EnrichmentProvider):
         try:
             response = requests.get(
                 f"{TMDB_API_BASE}/movie/{tmdb_id}",
-                params={"api_key": api_key, "language": language},
+                params={
+                    "api_key": api_key,
+                    "language": language,
+                    "append_to_response": "credits",
+                },
                 timeout=10,
             )
             response.raise_for_status()
@@ -364,6 +368,18 @@ class TMDBProvider(EnrichmentProvider):
                 ]
                 if studios:
                     extra_metadata["studio"] = studios[0]
+
+            # Extract director(s) from credits (requested via append_to_response).
+            # The truthiness guard on `name` excludes missing/None/empty values;
+            # the str() cast hardens against non-string names in the API payload.
+            crew = movie.get("credits", {}).get("crew", [])
+            directors = [
+                str(member["name"])
+                for member in crew
+                if member.get("job") == "Director" and member.get("name")
+            ][:3]
+            if directors:
+                extra_metadata["director"] = ", ".join(directors)
 
             # Extract collection/franchise info for series ordering
             collection = movie.get("belongs_to_collection")
@@ -447,10 +463,16 @@ class TMDBProvider(EnrichmentProvider):
                 networks = [network["name"] for network in show["networks"][:2]]
                 if networks:
                     extra_metadata["network"] = networks[0]
-            if show.get("created_by"):
-                creators = [creator["name"] for creator in show["created_by"][:3]]
-                if creators:
-                    extra_metadata["creators"] = ", ".join(creators)
+            # Extract creator(s). The truthiness guard on `name` excludes
+            # missing/None/empty values; the str() cast hardens against
+            # non-string names in the API payload.
+            creators = [
+                str(creator["name"])
+                for creator in show.get("created_by", [])
+                if creator.get("name")
+            ][:3]
+            if creators:
+                extra_metadata["creators"] = ", ".join(creators)
             if show.get("status"):
                 extra_metadata["status"] = show["status"]
 

--- a/src/storage/manager.py
+++ b/src/storage/manager.py
@@ -263,6 +263,7 @@ class StorageManager:
         sort_by: str = "title",
         include_ignored: bool = True,
         enrichment: EnrichmentFilter | None = None,
+        search: str | None = None,
     ) -> list[ContentItem]:
         """Get content items with optional filters.
 
@@ -280,6 +281,7 @@ class StorageManager:
                 for backward compatibility)
             enrichment: Filter by enrichment state ("enriched" or
                 "not_enriched"). None returns all items.
+            search: Optional search term matched against title and creator
 
         Returns:
             List of ContentItem objects
@@ -294,6 +296,7 @@ class StorageManager:
             sort_by=sort_by,
             include_ignored=include_ignored,
             enrichment=enrichment,
+            search=search,
         )
 
     def get_unconsumed_items(

--- a/src/storage/sqlite_db.py
+++ b/src/storage/sqlite_db.py
@@ -31,7 +31,7 @@ from src.storage.schema import (
     write_enrichment_complete,
 )
 from src.utils.list_merge import merge_string_lists
-from src.utils.sorting import get_sort_title
+from src.utils.sorting import get_sort_title, matches_search
 
 # Status ordering for forward-only progression.
 # A status can only be overwritten by a status later in this sequence.
@@ -802,6 +802,7 @@ class SQLiteDB:
         sort_by: str = "title",
         include_ignored: bool = True,
         enrichment: EnrichmentFilter | None = None,
+        search: str | None = None,
     ) -> list[ContentItem]:
         """Get content items with optional filters.
 
@@ -819,13 +820,32 @@ class SQLiteDB:
                 for backward compatibility)
             enrichment: Filter by enrichment state ("enriched" or
                 "not_enriched"). None returns all items.
+            search: Optional search term. When non-empty (after strip),
+                results are filtered to items whose title or creator
+                (author/director/creators/developer) matches the term via
+                exact, substring, or fuzzy matching. ANDs with all other
+                filters. Filtering happens before limit/offset so pagination
+                pages over the full matched set.
 
         Returns:
             List of ContentItem objects
+
+        Note:
+            Search filtering runs in Python over the full candidate set (rows
+            remaining after the SQL type/status/rating filters) because it
+            inspects per-type creator metadata that is not queryable in SQL.
+            limit/offset are then applied to the filtered list so pagination
+            always covers the full matched set with no dropped matches. This
+            loads the candidate set into memory, which is acceptable at
+            personal-library scale; it would need an index-backed approach if
+            libraries grew into the hundreds of thousands of items.
         """
         # An empty status list matches nothing by definition.
         if isinstance(status, list) and not status:
             return []
+
+        # Normalize the search term; an empty/whitespace term is a no-op.
+        search_term = search.strip() if search else ""
 
         # Default to default user if not specified
         effective_user_id = user_id if user_id is not None else get_default_user_id()
@@ -874,8 +894,13 @@ class SQLiteDB:
                 query += " ORDER BY ci.rating DESC NULLS LAST, ci.title ASC"
             # For "title" sort, we do it in Python after fetching
 
-            if sort_by != "title":
-                # Apply SQL LIMIT/OFFSET for non-title sorts
+            # Search filtering happens in Python (it inspects creator metadata),
+            # so when searching we must fetch the full result set and defer
+            # limit/offset slicing until after filtering. Title sorting is also
+            # always done in Python (article stripping).
+            slice_in_python = sort_by == "title" or bool(search_term)
+            if not slice_in_python:
+                # Apply SQL LIMIT/OFFSET for non-title, non-search queries
                 if limit:
                     query += " LIMIT ?"
                     params.append(limit)
@@ -887,16 +912,59 @@ class SQLiteDB:
             rows = cursor.fetchall()
             items = [self._row_to_content_item(row) for row in rows]
 
-            # Apply title sorting in Python (ignoring articles)
+            if search_term:
+                items = [
+                    item for item in items if self._matches_item(item, search_term)
+                ]
+
+            # Apply title sorting in Python (ignoring articles). The SQL ORDER BY
+            # already ordered non-title sorts, but search filtering preserves
+            # that order, so no re-sort is needed for those.
             if sort_by == "title":
                 items.sort(key=lambda item: get_sort_title(item.title))
-                # Apply offset and limit after sorting
+
+            if slice_in_python:
                 if offset > 0:
                     items = items[offset:]
                 if limit:
                     items = items[:limit]
 
             return items
+
+    # Metadata key holding the "creator" for each non-book content type.
+    # Books expose their creator via the ContentItem.author attribute instead.
+    _SEARCH_CREATOR_METADATA_KEYS: dict[str, str] = {
+        "movie": "director",
+        "tv_show": "creators",
+        "video_game": "developer",
+    }
+
+    @classmethod
+    def _matches_item(cls, item: ContentItem, search_term: str) -> bool:
+        """Return True if *item*'s title or creator matches *search_term*.
+
+        The creator is the author (books) or the type-specific metadata field
+        (director/creators/developer). Matching is delegated to
+        :func:`matches_search` for exact/substring/fuzzy tiers.
+
+        Args:
+            item: The content item to test.
+            search_term: The (already stripped) non-empty search term.
+
+        Returns:
+            True if the title or creator matches.
+        """
+        if matches_search(item.title, search_term):
+            return True
+
+        content_type = get_enum_value(item.content_type)
+        if content_type == "book":
+            creator = item.author
+        else:
+            creator_key = cls._SEARCH_CREATOR_METADATA_KEYS.get(content_type)
+            creator = item.metadata.get(creator_key) if creator_key else None
+
+        return bool(creator) and matches_search(str(creator), search_term)
 
     def get_unconsumed_items(
         self,

--- a/src/utils/sorting.py
+++ b/src/utils/sorting.py
@@ -1,6 +1,16 @@
 """Sorting utilities for content items."""
 
 import re
+from difflib import SequenceMatcher
+
+# Minimum SequenceMatcher ratio for a fuzzy (typo-tolerant) match.
+# The hard requirement is that "Die Heard" matches "Die Hard (1988)": after
+# punctuation normalization those are "die heard" vs "die hard 1988", whose best
+# window ("die heard" vs "die hard ") scores ~0.89, so the threshold must sit at
+# or below that. A near-miss like "Inception" vs "Insepton" scores 0.75 and must
+# be rejected, so the threshold must sit above that. 0.8 falls in that band and
+# separates real typos from unrelated terms.
+FUZZY_MATCH_THRESHOLD = 0.8
 
 # Articles to strip when sorting titles. Intentionally English-only: a
 # multilingual set collides with English words (German "die" in "Die Hard",
@@ -109,3 +119,89 @@ def titles_similar(title1: str, title2: str) -> bool:
     # other and the helper returns False regardless of ordering.
     shorter, longer = sorted((t1_norm, t2_norm), key=len)
     return _contains_on_word_boundary(shorter, longer)
+
+
+# Collapse runs of non-alphanumeric characters to single spaces.
+_NON_ALNUM_PATTERN = re.compile(r"[^0-9a-z]+")
+
+
+def normalize_for_search(text: str) -> str:
+    """Normalize a string for search matching.
+
+    Strips leading articles (via get_sort_title), lowercases, replaces
+    punctuation with spaces, and collapses whitespace.  This lets
+    "Die Hard (1988)" and "die hard" compare on equal footing.
+
+    Args:
+        text: The string to normalize.
+
+    Returns:
+        A normalized, article-stripped, punctuation-free string.
+    """
+    if not text:
+        return ""
+
+    normalized = get_sort_title(text)
+    normalized = _NON_ALNUM_PATTERN.sub(" ", normalized)
+    return normalized.strip()
+
+
+def _best_window_ratio(needle: str, haystack: str) -> float:
+    """Best SequenceMatcher ratio of *needle* against any window of *haystack*.
+
+    Slides a window the length of *needle* across *haystack* so that a typo'd
+    term still matches a longer title (e.g. "die heard" vs "die hard 1988")
+    without the trailing tokens diluting the score.
+
+    Args:
+        needle: The (normalized) search term.
+        haystack: The (normalized) candidate string.
+
+    Returns:
+        A ratio in the range 0.0 to 1.0.  If any window meets
+        FUZZY_MATCH_THRESHOLD the scan stops early and returns that window's
+        ratio; otherwise the highest ratio found across all windows is returned.
+    """
+    if len(needle) >= len(haystack):
+        return SequenceMatcher(None, needle, haystack).ratio()
+
+    best = 0.0
+    window = len(needle)
+    for start in range(len(haystack) - window + 1):
+        ratio = SequenceMatcher(None, needle, haystack[start : start + window]).ratio()
+        if ratio >= FUZZY_MATCH_THRESHOLD:
+            # The caller only needs to know the threshold is met; no window can
+            # raise the verdict beyond "matches", so stop scanning early.
+            return ratio
+        if ratio > best:
+            best = ratio
+    return best
+
+
+def matches_search(haystack: str, needle: str) -> bool:
+    """Check whether *haystack* matches the search term *needle*.
+
+    Matching is case-insensitive and article/punctuation-normalized across
+    three tiers: exact equality, substring containment, and fuzzy
+    (typo-tolerant) matching via FUZZY_MATCH_THRESHOLD.
+
+    Args:
+        haystack: The candidate string (e.g. a title or creator name).
+        needle: The search term.
+
+    Returns:
+        True if the haystack matches the search term at any tier.
+    """
+    if not haystack or not needle:
+        return False
+
+    haystack_norm = normalize_for_search(haystack)
+    needle_norm = normalize_for_search(needle)
+    if not haystack_norm or not needle_norm:
+        return False
+
+    if haystack_norm == needle_norm:
+        return True
+    if needle_norm in haystack_norm:
+        return True
+    return _best_window_ratio(needle_norm, haystack_norm) >= FUZZY_MATCH_THRESHOLD

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -808,6 +808,7 @@ async def list_items(
         None,
         description="Filter by enrichment state: enriched or not_enriched",
     ),
+    search: str | None = Query(None, description="Search term for title/creator"),
 ) -> list[ContentItemResponse]:
     """List content items with optional filters.
 
@@ -820,6 +821,7 @@ async def list_items(
         sort_by: Sort order (default: title, which ignores leading articles).
         include_ignored: Whether to include ignored items (default: False).
         enrichment: Optional enrichment-state filter (enriched/not_enriched).
+        search: Optional search term matched against title and creator.
 
     Returns:
         List of content items.
@@ -864,6 +866,7 @@ async def list_items(
         sort_by=sort_by.lower(),
         include_ignored=include_ignored,
         enrichment=enrichment,
+        search=search,
     )
 
     return [_item_to_response(item) for item in items]

--- a/tests/cli/test_cli_library.py
+++ b/tests/cli/test_cli_library.py
@@ -215,6 +215,66 @@ class TestLibraryList:
         assert result.exit_code == 0
         assert "Enriched" in result.output
 
+    def test_list_search_filters_results(self, cli_runner: CliRunner) -> None:
+        """Test that --search forwards the query and shows matching items."""
+        items = [_make_item(db_id=1, title="Dune", author="Frank Herbert")]
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = items
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "list", "--search", "Dune"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        assert "Dune" in result.output
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["search"] == "Dune"
+
+    def test_list_search_json_output(self, cli_runner: CliRunner) -> None:
+        """Test that --search works with JSON output."""
+        items = [_make_item(db_id=1, title="Dune", author="Frank Herbert")]
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = items
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "list", "--search", "Dune", "--format", "json"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed[0]["title"] == "Dune"
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["search"] == "Dune"
+
+    def test_list_search_combines_with_type(self, cli_runner: CliRunner) -> None:
+        """Test that --search ANDs with --type."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "list", "--search", "Dune", "--type", "book"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["search"] == "Dune"
+        assert call_kwargs["content_type"] == ContentType.BOOK
+
+    def test_list_without_search_passes_none(self, cli_runner: CliRunner) -> None:
+        """Test that omitting --search forwards search=None (unchanged behavior)."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(cli_runner, ["library", "list"], mock_storage)
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["search"] is None
+
     def test_list_forwards_sort_limit_offset(self, cli_runner: CliRunner) -> None:
         """Test that --sort, --limit, --offset, --show-ignored reach storage."""
         mock_storage = MagicMock(spec=StorageManager)

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -1,6 +1,13 @@
 """Tests for sorting utilities."""
 
-from src.utils.sorting import get_sort_title, titles_similar
+from src.utils.sorting import (
+    FUZZY_MATCH_THRESHOLD,
+    _best_window_ratio,
+    get_sort_title,
+    matches_search,
+    normalize_for_search,
+    titles_similar,
+)
 
 
 class TestGetSortTitle:
@@ -271,3 +278,129 @@ class TestTitlesSimilarWordBoundaryRegression:
     def test_whitespace_only_title_does_not_match_regression(self) -> None:
         """A title that normalizes to empty must not match (no infinite loop)."""
         assert titles_similar("   ", "Spirited Away") is False
+
+
+class TestNormalizeForSearch:
+    """Tests for normalize_for_search function."""
+
+    def test_lowercases_and_strips_articles(self) -> None:
+        assert normalize_for_search("The Matrix") == "matrix"
+
+    def test_strips_punctuation(self) -> None:
+        # Hyphens, parentheses, and the like collapse to single spaces so a
+        # search term and a title normalize onto equal footing.
+        assert normalize_for_search("Sci-Fi (1988)") == "sci fi 1988"
+
+    def test_collapses_whitespace(self) -> None:
+        assert (
+            normalize_for_search("Spider-Man:  Homecoming") == "spider man homecoming"
+        )
+
+    def test_empty_string(self) -> None:
+        assert normalize_for_search("") == ""
+
+    def test_punctuation_only(self) -> None:
+        assert normalize_for_search("!!!") == ""
+
+
+class TestMatchesSearch:
+    """Tests for the three matching tiers of matches_search."""
+
+    def test_exact_match(self) -> None:
+        assert matches_search("Die Hard", "die hard") is True
+
+    def test_exact_match_ignores_articles(self) -> None:
+        assert matches_search("The Matrix", "matrix") is True
+
+    def test_partial_substring_match(self) -> None:
+        assert matches_search("Die Hard (1988)", "Die Hard") is True
+
+    def test_fuzzy_typo_match(self) -> None:
+        # Hard PM requirement: "Die Heard" must match "Die Hard (1988)".
+        # After normalization this is "die heard" vs the "die hard " window of
+        # "die hard 1988", which scores ~0.89, above FUZZY_MATCH_THRESHOLD.
+        assert matches_search("Die Hard (1988)", "Die Heard") is True
+
+    def test_fuzzy_match_on_non_article_first_token(self) -> None:
+        """Fuzzy matching works on a longer multi-token title.
+
+        "Apocalypse Now" keeps both tokens, and the single-character typo
+        "Apocalipse Now" scores ~0.93, comfortably above threshold.
+        """
+        assert matches_search("Apocalypse Now", "Apocalipse Now") is True
+
+    def test_fuzzy_below_threshold_does_not_match(self) -> None:
+        """A typo whose ratio falls below threshold is rejected.
+
+        "Inception" vs "Insepton" scores ~0.75, below FUZZY_MATCH_THRESHOLD
+        (0.80), so it must not match.  This pins that the threshold genuinely
+        rejects near-misses rather than waving everything through.
+        """
+        assert _best_window_ratio("insepton", "inception") < FUZZY_MATCH_THRESHOLD
+        assert matches_search("Inception", "Insepton") is False
+
+    def test_short_query_fuzzy_false_positive(self) -> None:
+        """QA probe: a 3-letter query fuzzy-matches a 1-letter-different word.
+
+        This characterizes (does not condemn) a known property of a low
+        difflib threshold: "cat" vs "bat" scores 0.667 and is rejected, but
+        "cat" vs "car" / "cot" (also one letter off) likewise score 0.667.
+        At length 3 a single substitution never reaches 0.80, so short-query
+        false positives via substitution do not occur. A 4-letter query with
+        one substitution, however, scores 0.75 and is still rejected. This
+        pins that the threshold does not silently surface near-miss noise for
+        short terms.
+        """
+        assert matches_search("Bat", "cat") is False
+        assert matches_search("Cot", "cat") is False
+        assert matches_search("Card", "cart") is False
+
+    def test_unrelated_does_not_match(self) -> None:
+        assert matches_search("The Matrix", "Die Heard") is False
+
+    def test_empty_needle_does_not_match(self) -> None:
+        assert matches_search("Die Hard", "") is False
+
+    def test_empty_haystack_does_not_match(self) -> None:
+        assert matches_search("", "Die Hard") is False
+
+
+class TestBestWindowRatio:
+    """Tests for the _best_window_ratio fuzzy helper."""
+
+    def test_die_heard_clears_threshold(self) -> None:
+        """The required typo match clears the threshold with margin.
+
+        Normalized "die heard" against "die hard 1988" scores ~0.89 (best
+        window "die heard" vs "die hard "), above FUZZY_MATCH_THRESHOLD, which
+        is why "Die Heard" matches "Die Hard (1988)".
+        """
+        ratio = _best_window_ratio(
+            normalize_for_search("Die Heard"), normalize_for_search("Die Hard (1988)")
+        )
+        assert ratio > FUZZY_MATCH_THRESHOLD
+
+    def test_die_hardy_also_clears_threshold(self) -> None:
+        """A different one-letter variant scores the same as "Die Heard".
+
+        "die hardy" against "die hard 1988" also scores ~0.89, so the
+        threshold cannot distinguish it from "Die Heard"; both are accepted.
+        """
+        ratio = _best_window_ratio(
+            normalize_for_search("Die Hardy"), normalize_for_search("Die Hard (1988)")
+        )
+        assert ratio > FUZZY_MATCH_THRESHOLD
+
+    def test_needle_longer_than_haystack_uses_full_ratio(self) -> None:
+        """When the needle is longer than the haystack the fallback path runs.
+
+        With no window to slide, the helper compares the whole strings.
+        "akira kurosawa" (needle) is longer than the title "akira" (haystack),
+        exercising the ``len(needle) >= len(haystack)`` branch; the partial
+        overlap stays well below threshold.
+        """
+        ratio = _best_window_ratio(
+            normalize_for_search("Akira Kurosawa"), normalize_for_search("Akira")
+        )
+        assert ratio < FUZZY_MATCH_THRESHOLD
+        assert matches_search("Akira", "Akira Kurosawa") is False

--- a/tests/test_sqlite_db.py
+++ b/tests/test_sqlite_db.py
@@ -879,6 +879,403 @@ def test_get_content_items_include_ignored_false(temp_db: SQLiteDB) -> None:
     assert filtered_items[0].title == "Normal Book"
 
 
+class TestGetContentItemsSearch:
+    """Tests for the search capability of get_content_items."""
+
+    @staticmethod
+    def _seed_movies(temp_db: SQLiteDB) -> None:
+        """Seed a small movie library used by title-matching tests."""
+        movies = [
+            ContentItem(
+                id="movie_die_hard",
+                title="Die Hard (1988)",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+            ),
+            ContentItem(
+                id="movie_matrix",
+                title="The Matrix",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+            ),
+            ContentItem(
+                id="movie_star_wars",
+                title="Star Wars",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+            ),
+        ]
+        for movie in movies:
+            temp_db.save_content_item(movie)
+
+    def test_search_none_is_noop(self, temp_db: SQLiteDB) -> None:
+        """search=None returns the full unfiltered set (unchanged behavior)."""
+        self._seed_movies(temp_db)
+        assert len(temp_db.get_content_items(search=None)) == 3
+
+    def test_search_empty_string_is_noop(self, temp_db: SQLiteDB) -> None:
+        """An empty or whitespace search term does not filter."""
+        self._seed_movies(temp_db)
+        assert len(temp_db.get_content_items(search="")) == 3
+        assert len(temp_db.get_content_items(search="   ")) == 3
+
+    def test_search_exact_match(self, temp_db: SQLiteDB) -> None:
+        """An exact (article/case-insensitive) title matches."""
+        self._seed_movies(temp_db)
+        results = temp_db.get_content_items(search="the matrix")
+        assert [item.title for item in results] == ["The Matrix"]
+
+    def test_search_partial_match(self, temp_db: SQLiteDB) -> None:
+        """A substring term matches the longer title."""
+        self._seed_movies(temp_db)
+        results = temp_db.get_content_items(search="Die Hard")
+        assert [item.title for item in results] == ["Die Hard (1988)"]
+
+    def test_search_fuzzy_match(self, temp_db: SQLiteDB) -> None:
+        """A typo'd term still matches via fuzzy matching."""
+        self._seed_movies(temp_db)
+        results = temp_db.get_content_items(search="Die Heard")
+        assert [item.title for item in results] == ["Die Hard (1988)"]
+
+    def test_search_no_results(self, temp_db: SQLiteDB) -> None:
+        """An unrelated term returns nothing."""
+        self._seed_movies(temp_db)
+        assert temp_db.get_content_items(search="nonexistent zzz") == []
+
+    def test_search_matches_book_author(self, temp_db: SQLiteDB) -> None:
+        """Search matches a book's creator (author)."""
+        temp_db.save_content_item(
+            ContentItem(
+                id="book_1",
+                title="The Hobbit",
+                author="J.R.R. Tolkien",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.COMPLETED,
+            )
+        )
+        results = temp_db.get_content_items(search="Tolkien")
+        assert [item.title for item in results] == ["The Hobbit"]
+
+    def test_search_matches_movie_director(self, temp_db: SQLiteDB) -> None:
+        """Search matches a movie's creator (director)."""
+        temp_db.save_content_item(
+            ContentItem(
+                id="movie_1",
+                title="Jurassic Park",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+                metadata={"director": "Steven Spielberg"},
+            )
+        )
+        results = temp_db.get_content_items(search="Spielberg")
+        assert [item.title for item in results] == ["Jurassic Park"]
+
+    def test_search_matches_tv_creator(self, temp_db: SQLiteDB) -> None:
+        """Search matches a TV show's creator (creators)."""
+        temp_db.save_content_item(
+            ContentItem(
+                id="tv_1",
+                title="Breaking Bad",
+                content_type=ContentType.TV_SHOW,
+                status=ConsumptionStatus.COMPLETED,
+                metadata={"creators": "Vince Gilligan"},
+            )
+        )
+        results = temp_db.get_content_items(search="Gilligan")
+        assert [item.title for item in results] == ["Breaking Bad"]
+
+    def test_search_matches_game_developer(self, temp_db: SQLiteDB) -> None:
+        """Search matches a video game's creator (developer)."""
+        temp_db.save_content_item(
+            ContentItem(
+                id="game_1",
+                title="Half-Life",
+                content_type=ContentType.VIDEO_GAME,
+                status=ConsumptionStatus.COMPLETED,
+                metadata={"developer": "Valve"},
+            )
+        )
+        results = temp_db.get_content_items(search="Valve")
+        assert [item.title for item in results] == ["Half-Life"]
+
+    def test_search_ands_with_type_filter(self, temp_db: SQLiteDB) -> None:
+        """Search combines with a content_type filter (AND)."""
+        temp_db.save_content_item(
+            ContentItem(
+                id="movie_avatar",
+                title="Avatar",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+            )
+        )
+        temp_db.save_content_item(
+            ContentItem(
+                id="game_avatar",
+                title="Avatar: Frontiers of Pandora",
+                content_type=ContentType.VIDEO_GAME,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+        results = temp_db.get_content_items(
+            search="Avatar", content_type=ContentType.MOVIE
+        )
+        assert [item.title for item in results] == ["Avatar"]
+
+    def test_search_ands_with_status_filter(self, temp_db: SQLiteDB) -> None:
+        """Search combines with a status filter (AND)."""
+        temp_db.save_content_item(
+            ContentItem(
+                id="alien_done",
+                title="Alien",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+            )
+        )
+        temp_db.save_content_item(
+            ContentItem(
+                id="aliens_unread",
+                title="Aliens",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.UNREAD,
+            )
+        )
+        results = temp_db.get_content_items(
+            search="Alien", status=ConsumptionStatus.UNREAD
+        )
+        assert [item.title for item in results] == ["Aliens"]
+
+    def test_search_pagination_pages_over_filtered_set(self, temp_db: SQLiteDB) -> None:
+        """limit/offset page over the full searched+sorted set, not one DB page.
+
+        Twelve "Hero" movies match the search alongside non-matching noise.
+        Paging with limit=5 must walk the matching set in title order, so
+        offset=5 returns the next five matches (not five raw rows from the
+        unfiltered query that happen to follow).
+        """
+        for i in range(12):
+            temp_db.save_content_item(
+                ContentItem(
+                    id=f"hero_{i:02d}",
+                    title=f"Hero {i:02d}",
+                    content_type=ContentType.MOVIE,
+                    status=ConsumptionStatus.COMPLETED,
+                )
+            )
+        # Non-matching noise interleaved in the table.
+        for i in range(8):
+            temp_db.save_content_item(
+                ContentItem(
+                    id=f"noise_{i:02d}",
+                    title=f"Villain {i:02d}",
+                    content_type=ContentType.MOVIE,
+                    status=ConsumptionStatus.COMPLETED,
+                )
+            )
+
+        page1 = temp_db.get_content_items(search="Hero", limit=5, offset=0)
+        page2 = temp_db.get_content_items(search="Hero", limit=5, offset=5)
+        page3 = temp_db.get_content_items(search="Hero", limit=5, offset=10)
+
+        assert [item.title for item in page1] == [f"Hero {i:02d}" for i in range(5)]
+        assert [item.title for item in page2] == [f"Hero {i:02d}" for i in range(5, 10)]
+        assert [item.title for item in page3] == [
+            f"Hero {i:02d}" for i in range(10, 12)
+        ]
+
+        all_matches = temp_db.get_content_items(search="Hero")
+        assert len(all_matches) == 12
+
+    def test_search_book_without_author_does_not_match_creator(
+        self, temp_db: SQLiteDB
+    ) -> None:
+        """A book with author=None must not raise or spuriously creator-match.
+
+        The creator lookup falls back to ``item.author`` for books; when that
+        is None the bool(creator) guard must short-circuit so a creator-style
+        search neither errors nor returns the authorless book.
+        """
+        temp_db.save_content_item(
+            ContentItem(
+                id="book_no_author",
+                title="Untitled Manuscript",
+                author=None,
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.COMPLETED,
+            )
+        )
+        # Searching for an author name does not match the authorless book.
+        assert temp_db.get_content_items(search="Tolkien") == []
+        # The same book still matches on its title.
+        title_results = temp_db.get_content_items(search="Untitled Manuscript")
+        assert [item.title for item in title_results] == ["Untitled Manuscript"]
+
+    def test_search_item_missing_creator_metadata_key(self, temp_db: SQLiteDB) -> None:
+        """Items whose metadata lacks the creator key match on title only.
+
+        A movie with no "director" key must not raise (the metadata.get returns
+        None) and must not match a creator-style search, while still matching
+        its own title.
+        """
+        temp_db.save_content_item(
+            ContentItem(
+                id="movie_no_director",
+                title="Mystery Film",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+                metadata={},
+            )
+        )
+        assert temp_db.get_content_items(search="Spielberg") == []
+        title_results = temp_db.get_content_items(search="Mystery Film")
+        assert [item.title for item in title_results] == ["Mystery Film"]
+
+    def test_search_with_rating_sort_orders_and_paginates(
+        self, temp_db: SQLiteDB
+    ) -> None:
+        """Search combined with a non-title sort preserves SQL ordering.
+
+        With sort_by="rating", the SQL ORDER BY (rating DESC, title ASC) drives
+        ordering; Python search filtering must keep that order, and limit/offset
+        must page over the matched set. Three "Quest" movies with distinct
+        ratings (plus non-matching noise) verify both ordering and pagination.
+        """
+        temp_db.save_content_item(
+            ContentItem(
+                id="quest_low",
+                title="Quest Alpha",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+                rating=2,
+            )
+        )
+        temp_db.save_content_item(
+            ContentItem(
+                id="quest_high",
+                title="Quest Bravo",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+                rating=5,
+            )
+        )
+        temp_db.save_content_item(
+            ContentItem(
+                id="quest_mid",
+                title="Quest Charlie",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+                rating=4,
+            )
+        )
+        temp_db.save_content_item(
+            ContentItem(
+                id="noise_high",
+                title="Unrelated Film",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+                rating=5,
+            )
+        )
+
+        ordered = temp_db.get_content_items(search="Quest", sort_by="rating")
+        assert [item.title for item in ordered] == [
+            "Quest Bravo",
+            "Quest Charlie",
+            "Quest Alpha",
+        ]
+
+        page1 = temp_db.get_content_items(
+            search="Quest", sort_by="rating", limit=2, offset=0
+        )
+        page2 = temp_db.get_content_items(
+            search="Quest", sort_by="rating", limit=2, offset=2
+        )
+        assert [item.title for item in page1] == ["Quest Bravo", "Quest Charlie"]
+        assert [item.title for item in page2] == ["Quest Alpha"]
+
+    def test_search_empty_library(self, temp_db: SQLiteDB) -> None:
+        """Searching an empty library returns an empty list, not an error."""
+        assert temp_db.get_content_items(search="anything") == []
+
+    def test_search_pagination_exact_multiple_boundary(self, temp_db: SQLiteDB) -> None:
+        """When matched count is an exact multiple of the page size.
+
+        Edge probed by QA: ten matches with limit=5 yields two full pages and
+        an empty third page (offset past the end), with no dropped or
+        duplicated matches at the boundary.
+        """
+        for i in range(10):
+            temp_db.save_content_item(
+                ContentItem(
+                    id=f"page_match_{i:02d}",
+                    title=f"Boundary {i:02d}",
+                    content_type=ContentType.MOVIE,
+                    status=ConsumptionStatus.COMPLETED,
+                )
+            )
+        page1 = temp_db.get_content_items(search="Boundary", limit=5, offset=0)
+        page2 = temp_db.get_content_items(search="Boundary", limit=5, offset=5)
+        page3 = temp_db.get_content_items(search="Boundary", limit=5, offset=10)
+
+        assert [item.title for item in page1] == [f"Boundary {i:02d}" for i in range(5)]
+        assert [item.title for item in page2] == [
+            f"Boundary {i:02d}" for i in range(5, 10)
+        ]
+        assert page3 == []
+        # No overlap or gaps across the two full pages.
+        combined = [item.id for item in page1] + [item.id for item in page2]
+        assert len(set(combined)) == 10
+
+    def test_search_offset_beyond_matched_set(self, temp_db: SQLiteDB) -> None:
+        """An offset past the end of the matched set returns an empty list."""
+        temp_db.save_content_item(
+            ContentItem(
+                id="solo_match",
+                title="Solitary",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+            )
+        )
+        assert temp_db.get_content_items(search="Solitary", offset=10) == []
+
+    def test_search_case_and_punctuation_insensitive(self, temp_db: SQLiteDB) -> None:
+        """Mixed case and punctuation differences still match.
+
+        Edge probed by QA: a loud, punctuation-heavy query must match a title
+        whose only difference is case and surrounding punctuation.
+        """
+        temp_db.save_content_item(
+            ContentItem(
+                id="spiderman",
+                title="Spider-Man: Homecoming",
+                content_type=ContentType.MOVIE,
+                status=ConsumptionStatus.COMPLETED,
+            )
+        )
+        results = temp_db.get_content_items(search="  SPIDER MAN homecoming!!  ")
+        assert [item.title for item in results] == ["Spider-Man: Homecoming"]
+
+    def test_search_matches_one_of_multiple_tv_creators(
+        self, temp_db: SQLiteDB
+    ) -> None:
+        """A TV show with several comma-joined creators matches on any one.
+
+        TMDB stores the plural ``creators`` field as a comma-joined string
+        (e.g. "Vince Gilligan, Peter Gould"); searching for the second name
+        must still surface the show.
+        """
+        temp_db.save_content_item(
+            ContentItem(
+                id="bcs",
+                title="Better Call Saul",
+                content_type=ContentType.TV_SHOW,
+                status=ConsumptionStatus.COMPLETED,
+                metadata={"creators": "Vince Gilligan, Peter Gould"},
+            )
+        )
+        results = temp_db.get_content_items(search="Peter Gould")
+        assert [item.title for item in results] == ["Better Call Saul"]
+
+
 class TestToJsonArrayRegression:
     """Regression tests for _to_json_array() bare string handling.
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1827,6 +1827,78 @@ class TestPaginationAndSorting:
         assert call_kwargs["limit"] == 20
 
 
+class TestSearchParam:
+    """Tests for the search query param on /api/items."""
+
+    def test_search_is_passed_to_storage(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """GET /api/items?search=dune forwards the term to storage."""
+        mock_components["storage"].get_content_items = Mock(
+            spec=StorageManager.get_content_items, return_value=[]
+        )
+
+        response = client.get("/api/items?search=dune")
+        assert response.status_code == 200
+
+        call_kwargs = mock_components["storage"].get_content_items.call_args[1]
+        assert call_kwargs["search"] == "dune"
+
+    def test_search_defaults_to_none(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """GET /api/items without search forwards search=None to storage."""
+        mock_components["storage"].get_content_items = Mock(
+            spec=StorageManager.get_content_items, return_value=[]
+        )
+
+        response = client.get("/api/items")
+        assert response.status_code == 200
+
+        call_kwargs = mock_components["storage"].get_content_items.call_args[1]
+        assert call_kwargs["search"] is None
+
+    def test_search_combined_with_type_filter(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """GET /api/items?search=dune&type=book forwards both to storage."""
+        mock_components["storage"].get_content_items = Mock(
+            spec=StorageManager.get_content_items, return_value=[]
+        )
+
+        response = client.get("/api/items?search=dune&type=book")
+        assert response.status_code == 200
+
+        call_kwargs = mock_components["storage"].get_content_items.call_args[1]
+        assert call_kwargs["search"] == "dune"
+        assert call_kwargs["content_type"] == ContentType.BOOK
+
+    def test_search_returns_matching_items(
+        self, client: TestClient, mock_components: dict
+    ) -> None:
+        """GET /api/items?search=dune returns the items storage matched."""
+        mock_items = [
+            ContentItem(
+                id="1",
+                title="Dune",
+                author="Frank Herbert",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.COMPLETED,
+                rating=5,
+                source="goodreads",
+            )
+        ]
+        mock_components["storage"].get_content_items = Mock(
+            spec=StorageManager.get_content_items, return_value=mock_items
+        )
+
+        response = client.get("/api/items?search=dune")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["title"] == "Dune"
+
+
 # ---------------------------------------------------------------------------
 # Count > max_count validation (8J)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #57

Adds search to the library view so you can type a term and quickly narrow things down, which is especially nicer on mobile where scrolling a long library is the painful part.

## What it does
- Matches on **title and creator** (author for books, director for movies, creators for TV, developer for games).
- Three tiers of matching: exact ("Die Hard"), partial ("Die Hard" finds "Die Hard (1988)"), and typo tolerant fuzzy ("Die Heard" finds "Die Hard (1988)"). The fuzzy threshold is tuned to keep that match while rejecting unrelated near misses.
- Combines with the existing type and status filters rather than replacing them, and paginates over the full matched set, not just the page already loaded.
- The search box is debounced at 250ms so we are not firing a query on every keystroke, sticks to the top on mobile, has a clear button and a loading indicator, and shows a friendly empty state that names the term when nothing matches.
- Screen readers get a live region announcing how many items matched.

## Where the work lives
Search runs in one place in the storage layer, and both interfaces call it, so the web and CLI stay in parity by construction:
- Web: a `search` query param on `GET /api/items` plus the search box in the library view.
- CLI: a `--search` flag on `library list`.

## TMDB director enrichment
While building this I found the TMDB provider never populated a director field for movies (it set studio and TV creators only), so director search would have come up empty for TMDB enriched movies. This PR also fixes that: the movie detail call now pulls credits in the same request and stores the director(s), so director search works across the board. The TV creators extraction got the same defensive treatment so a malformed credit cannot crash enrichment.

## How to test
- Web: open the library, type a title (try a partial like "matrix" or a typo like "inceptipn"), confirm results narrow live and combine with the type/status filters. Clear it and confirm the full list comes back. Search something nonsense to see the empty state. Try it on a narrow viewport to see the sticky box.
- CLI: `python3.11 -m src.cli library list --search "die hard"` and `--search "<a creator name>"`, including with `--type` and `--format json`.
- Director: enrich a movie via TMDB, then search the director's name and confirm the movie comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
