### PR TITLE
fix: redact API keys from provider request errors

### DIFF
--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -226,6 +226,7 @@ from typing import Any, Iterator
 
 from src.ingestion.plugin_base import ConfigField, ProgressCallback, SourceError, SourcePlugin
 from src.models.content import ContentItem, ContentType, ConsumptionStatus
+from src.utils.request_errors import scrub_request_error
 
 class MovieApiPlugin(SourcePlugin):
     API_BASE = "https://api.example.com/v1"
@@ -277,7 +278,7 @@ class MovieApiPlugin(SourcePlugin):
             response.raise_for_status()
             data = response.json()
         except requests.RequestException as e:
-            raise SourceError("movie_api", f"API request failed: {e}") from e
+            raise SourceError("movie_api", f"API request failed: {scrub_request_error(e)}") from e
         
         for movie in data.get("movies", []):
             yield ContentItem(
@@ -416,6 +417,7 @@ class TestMyPlugin:
    total_items, current_item)`. Use `total_items=None` when unknown.
 10. **Respect the `ignored` field** - If your source provides a way to mark items as excluded, set `ignored=True` on the `ContentItem`. Use `parse_boolean_field()` from `generic_csv` for flexible boolean parsing.
 11. **Use list format for `seasons_watched`** - For TV shows, store `seasons_watched` as a list of specific season numbers (e.g., `[1, 2, 5, 6]`) in metadata. Use `parse_seasons_watched()` from `generic_csv` if converting from string input. A single integer is treated as a count for backward compatibility (e.g., `5` → `[1, 2, 3, 4, 5]`).
+12. **Scrub `requests` errors that may carry secrets** - If your plugin passes a secret in the URL or query params (an `?api_key=` / `?key=` style API), the default `str()` of a `requests` exception embeds the full request URL and leaks that credential into raised errors and logs. Pass the exception through `scrub_request_error()` from `src.utils.request_errors` before interpolating it — it returns only `HTTP <status>` (or the bare exception class name), never the URL. The TMDB and RAWG enrichment providers and the Steam source all do this.
 
 ## Thread Safety
 

--- a/src/enrichment/manager.py
+++ b/src/enrichment/manager.py
@@ -13,15 +13,39 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+import requests
+
 from src.enrichment.provider_base import EnrichmentResult, ProviderError
 from src.enrichment.rate_limiter import RateLimiter
 from src.enrichment.registry import EnrichmentRegistry, get_enrichment_registry
 from src.models.content import ContentItem, ContentType, get_enum_value
+from src.utils.request_errors import scrub_request_error
 
 if TYPE_CHECKING:
     from src.storage.manager import StorageManager
 
 logger = logging.getLogger(__name__)
+
+
+def _render_error(error: Exception) -> str:
+    """Render an exception for the user-facing status without leaking secrets.
+
+    ``requests`` exceptions can embed a request URL carrying an API key in its
+    query string. If a provider ever lets one escape unwrapped, stringifying it
+    here would leak that key into ``status.errors`` (surfaced by the web API and
+    CLI). Scrub those; keep the full message for all other exception types,
+    which carry no credential and whose detail aids debugging.
+
+    Args:
+        error: The caught exception to render.
+
+    Returns:
+        The scrubbed ``HTTP <status>`` / class name for request exceptions,
+        otherwise ``str(error)``.
+    """
+    if isinstance(error, requests.RequestException):
+        return scrub_request_error(error)
+    return str(error)
 
 
 @dataclass
@@ -332,10 +356,11 @@ class EnrichmentManager:
             )
 
         except Exception as error:
-            logger.exception("Enrichment job failed with error: %s", error)
+            rendered = _render_error(error)
+            logger.exception("Enrichment job failed with error: %s", rendered)
             with self._lock:
                 self._status.running = False
-                self._status.errors.append(f"Job error: {error}")
+                self._status.errors.append(f"Job error: {rendered}")
 
     def _process_batch(self, items: list[tuple[int, ContentItem]]) -> None:
         """Process a batch of items.
@@ -447,11 +472,14 @@ class EnrichmentManager:
                     self._status.errors.append(f"{provider.name}: {error.message}")
 
             except Exception as error:
+                rendered = _render_error(error)
                 logger.warning(
-                    "[ENRICHMENT] Unexpected error from %s: %s", provider.name, error
+                    "[ENRICHMENT] Unexpected error from %s: %s",
+                    provider.name,
+                    rendered,
                 )
                 with self._lock:
-                    self._status.errors.append(f"{provider.name}: {error}")
+                    self._status.errors.append(f"{provider.name}: {rendered}")
 
         # No provider found a match
         logger.debug(

--- a/src/enrichment/providers/rawg/rawg.py
+++ b/src/enrichment/providers/rawg/rawg.py
@@ -18,6 +18,7 @@ from src.enrichment.provider_base import (
     ProviderError,
 )
 from src.models.content import ContentItem, ContentType
+from src.utils.request_errors import scrub_request_error
 
 logger = logging.getLogger(__name__)
 
@@ -338,7 +339,9 @@ class RAWGProvider(EnrichmentProvider):
             return int(results[0]["id"])
 
         except requests.RequestException as error:
-            raise ProviderError(self.name, f"Failed to search RAWG: {error}") from error
+            raise ProviderError(
+                self.name, f"Failed to search RAWG: {scrub_request_error(error)}"
+            ) from error
 
     def _fetch_game_details(self, game_id: int, api_key: str) -> EnrichmentResult:
         """Fetch detailed game information.
@@ -433,7 +436,8 @@ class RAWGProvider(EnrichmentProvider):
 
         except requests.RequestException as error:
             raise ProviderError(
-                self.name, f"Failed to fetch game details: {error}"
+                self.name,
+                f"Failed to fetch game details: {scrub_request_error(error)}",
             ) from error
 
     def _fetch_game_series(

--- a/src/enrichment/providers/rawg/test_rawg.py
+++ b/src/enrichment/providers/rawg/test_rawg.py
@@ -1,7 +1,7 @@
 """Tests for the RAWG enrichment provider."""
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import requests
@@ -705,3 +705,106 @@ class TestRAWGFranchiseExtraction:
         assert result.genres == ["RPG", "Action"]
         assert "franchise" not in result.extra_metadata
         assert "series_position" not in result.extra_metadata
+
+
+class TestRAWGApiKeyScrubbingRegression:
+    """Regression tests for the RAWG API key leaking via error messages.
+
+    Bug: RAWG requests pass the key as a query parameter (``?key=<secret>``).
+    On a failed request, ``requests.HTTPError``'s ``str()`` embeds the full
+    request URL — key and all. The provider interpolated the raw exception
+    into ``ProviderError(... f"...: {error}")``, and that message flows into
+    the enrichment status the web API and CLI surface to users and logs,
+    leaking the key.
+
+    Root cause: ``f"...: {error}"`` called the default
+    ``RequestException.__str__`` containing the request URL with the ``key``
+    query parameter.
+
+    Fix: each ``except requests.RequestException`` block now renders the
+    error through :func:`src.utils.request_errors.scrub_request_error`, which
+    emits only ``HTTP <status>`` or the exception class name.
+    """
+
+    _API_KEY = "SECRET_RAWG_KEY_123"
+
+    def _http_error(self, status_code: int) -> requests.HTTPError:
+        """Build an HTTPError whose str() embeds the key, like requests."""
+        response = MagicMock(spec=requests.Response)
+        response.status_code = status_code
+        url = f"https://api.rawg.io/api/games?key={self._API_KEY}&search=Doom"
+        return requests.HTTPError(
+            f"{status_code} Client Error for url: {url}", response=response
+        )
+
+    def _game_item(self) -> ContentItem:
+        return ContentItem(
+            id="game1",
+            title="The Witcher 3: Wild Hunt",
+            content_type=ContentType.VIDEO_GAME,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"release_year": 2015},
+        )
+
+    def test_search_error_does_not_leak_api_key(self) -> None:
+        """A failed search surfaces only the status code, not the key."""
+        provider = RAWGProvider()
+
+        with patch("src.enrichment.providers.rawg.rawg.requests.get") as mock_get:
+            response = mock_get.return_value
+            response.raise_for_status.side_effect = self._http_error(401)
+
+            with pytest.raises(ProviderError) as exc_info:
+                provider.enrich(self._game_item(), {"api_key": self._API_KEY})
+
+        message = str(exc_info.value)
+        assert self._API_KEY not in message
+        assert "key=" not in message
+        assert "Failed to search RAWG: HTTP 401" in message
+
+    def test_game_details_error_does_not_leak_api_key(self) -> None:
+        """A failed game-details fetch surfaces only the status code."""
+        provider = RAWGProvider()
+        mock_search = {
+            "results": [
+                {
+                    "id": 3328,
+                    "name": "The Witcher 3: Wild Hunt",
+                    "released": "2015-05-18",
+                }
+            ]
+        }
+
+        with patch("src.enrichment.providers.rawg.rawg.requests.get") as mock_get:
+            search_response = MagicMock(
+                spec=requests.Response, status_code=200, json=lambda: mock_search
+            )
+            search_response.raise_for_status = Mock(return_value=None)
+            details_response = MagicMock(spec=requests.Response)
+            details_response.raise_for_status.side_effect = self._http_error(503)
+            mock_get.side_effect = [search_response, details_response]
+
+            with pytest.raises(ProviderError) as exc_info:
+                provider.enrich(self._game_item(), {"api_key": self._API_KEY})
+
+        message = str(exc_info.value)
+        assert self._API_KEY not in message
+        assert "key=" not in message
+        assert "Failed to fetch game details: HTTP 503" in message
+
+    def test_transport_error_surfaces_only_exception_type(self) -> None:
+        """A connection error surfaces only the class name, not its message."""
+        provider = RAWGProvider()
+
+        with patch("src.enrichment.providers.rawg.rawg.requests.get") as mock_get:
+            mock_get.side_effect = requests.ConnectionError(
+                f"Failed to connect; key={self._API_KEY} was in URL"
+            )
+
+            with pytest.raises(ProviderError) as exc_info:
+                provider.enrich(self._game_item(), {"api_key": self._API_KEY})
+
+        message = str(exc_info.value)
+        assert self._API_KEY not in message
+        assert "key=" not in message
+        assert "ConnectionError" in message

--- a/src/enrichment/providers/tmdb/test_tmdb.py
+++ b/src/enrichment/providers/tmdb/test_tmdb.py
@@ -994,3 +994,167 @@ class TestTMDBProviderUnsupportedTypes:
 
         result = provider.enrich(item, {"api_key": "test"})
         assert result is None
+
+
+class TestTMDBApiKeyScrubbingRegression:
+    """Regression tests for the TMDB API key leaking via error messages.
+
+    Bug: TMDB requests pass the key as a query parameter
+    (``?api_key=<secret>``). On a failed request, ``requests.HTTPError``'s
+    ``str()`` embeds the full request URL — key and all. The provider
+    interpolated the raw exception into ``ProviderError(... f"...: {error}")``,
+    and that message flows into the enrichment status the web API and CLI
+    surface to users and logs, leaking the key.
+
+    Root cause: ``f"...: {error}"`` called the default
+    ``RequestException.__str__`` containing the request URL with the
+    ``api_key`` query parameter.
+
+    Fix: each ``except requests.RequestException`` block now renders the
+    error through :func:`src.utils.request_errors.scrub_request_error`, which
+    emits only ``HTTP <status>`` or the exception class name.
+    """
+
+    _API_KEY = "SECRET_TMDB_KEY_123"
+
+    def _http_error(self, status_code: int) -> requests.HTTPError:
+        """Build an HTTPError whose str() embeds the api_key, like requests."""
+        response = MagicMock(spec=requests.Response)
+        response.status_code = status_code
+        url = (
+            "https://api.themoviedb.org/3/movie/603"
+            f"?api_key={self._API_KEY}&language=en-US"
+        )
+        return requests.HTTPError(
+            f"{status_code} Client Error for url: {url}", response=response
+        )
+
+    def _config(self) -> dict[str, Any]:
+        return {"api_key": self._API_KEY, "language": "en-US"}
+
+    def test_search_error_does_not_leak_api_key(self) -> None:
+        """A failed search surfaces only the status code, not the key."""
+        provider = TMDBProvider()
+        item = ContentItem(
+            id="movie1",
+            title="The Matrix",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"release_year": 1999},
+        )
+
+        with patch("src.enrichment.providers.tmdb.tmdb.requests.get") as mock_get:
+            response = mock_get.return_value
+            response.raise_for_status.side_effect = self._http_error(401)
+
+            with pytest.raises(ProviderError) as exc_info:
+                provider.enrich(item, self._config())
+
+        message = str(exc_info.value)
+        assert self._API_KEY not in message
+        assert "api_key=" not in message
+        assert "Failed to search TMDB: HTTP 401" in message
+
+    def test_search_retry_error_does_not_leak_api_key(self) -> None:
+        """A failed year-less retry search surfaces only the status code.
+
+        The first request returns empty results, triggering the year-less
+        retry; that second request fails. Its error must still be scrubbed.
+        """
+        provider = TMDBProvider()
+        item = ContentItem(
+            id="movie1",
+            title="The Matrix",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"release_year": 1999},
+        )
+
+        empty_response = MagicMock(spec=requests.Response)
+        empty_response.raise_for_status.return_value = None
+        empty_response.json.return_value = {"results": []}
+
+        retry_response = MagicMock(spec=requests.Response)
+        retry_response.raise_for_status.side_effect = self._http_error(502)
+
+        with patch("src.enrichment.providers.tmdb.tmdb.requests.get") as mock_get:
+            mock_get.side_effect = [empty_response, retry_response]
+
+            with pytest.raises(ProviderError) as exc_info:
+                provider.enrich(item, self._config())
+
+        assert mock_get.call_count == 2
+        message = str(exc_info.value)
+        assert self._API_KEY not in message
+        assert "api_key=" not in message
+        assert "Failed to search TMDB: HTTP 502" in message
+
+    def test_movie_details_error_does_not_leak_api_key(self) -> None:
+        """A failed movie-details fetch surfaces only the status code."""
+        provider = TMDBProvider()
+        item = ContentItem(
+            id="movie1",
+            title="The Matrix",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"tmdb_id": 603},
+        )
+
+        with patch("src.enrichment.providers.tmdb.tmdb.requests.get") as mock_get:
+            response = mock_get.return_value
+            response.raise_for_status.side_effect = self._http_error(503)
+
+            with pytest.raises(ProviderError) as exc_info:
+                provider.enrich(item, self._config())
+
+        message = str(exc_info.value)
+        assert self._API_KEY not in message
+        assert "api_key=" not in message
+        assert "Failed to fetch movie details: HTTP 503" in message
+
+    def test_tv_details_error_does_not_leak_api_key(self) -> None:
+        """A failed TV-details fetch surfaces only the status code."""
+        provider = TMDBProvider()
+        item = ContentItem(
+            id="show1",
+            title="Breaking Bad",
+            content_type=ContentType.TV_SHOW,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"tmdb_id": 1396},
+        )
+
+        with patch("src.enrichment.providers.tmdb.tmdb.requests.get") as mock_get:
+            response = mock_get.return_value
+            response.raise_for_status.side_effect = self._http_error(500)
+
+            with pytest.raises(ProviderError) as exc_info:
+                provider.enrich(item, self._config())
+
+        message = str(exc_info.value)
+        assert self._API_KEY not in message
+        assert "api_key=" not in message
+        assert "Failed to fetch TV show details: HTTP 500" in message
+
+    def test_transport_error_surfaces_only_exception_type(self) -> None:
+        """A connection error surfaces only the class name, not its message."""
+        provider = TMDBProvider()
+        item = ContentItem(
+            id="movie1",
+            title="The Matrix",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"release_year": 1999},
+        )
+
+        with patch("src.enrichment.providers.tmdb.tmdb.requests.get") as mock_get:
+            mock_get.side_effect = requests.ConnectionError(
+                f"Failed to connect; api_key={self._API_KEY} was in URL"
+            )
+
+            with pytest.raises(ProviderError) as exc_info:
+                provider.enrich(item, self._config())
+
+        message = str(exc_info.value)
+        assert self._API_KEY not in message
+        assert "api_key=" not in message
+        assert "ConnectionError" in message

--- a/src/enrichment/providers/tmdb/tmdb.py
+++ b/src/enrichment/providers/tmdb/tmdb.py
@@ -17,6 +17,7 @@ from src.enrichment.provider_base import (
     ProviderError,
 )
 from src.models.content import ContentItem, ContentType
+from src.utils.request_errors import scrub_request_error
 
 logger = logging.getLogger(__name__)
 
@@ -292,7 +293,9 @@ class TMDBProvider(EnrichmentProvider):
             return None
 
         except requests.RequestException as error:
-            raise ProviderError(self.name, f"Failed to search TMDB: {error}") from error
+            raise ProviderError(
+                self.name, f"Failed to search TMDB: {scrub_request_error(error)}"
+            ) from error
 
     def _search_movie(
         self, item: ContentItem, api_key: str, language: str
@@ -405,7 +408,8 @@ class TMDBProvider(EnrichmentProvider):
 
         except requests.RequestException as error:
             raise ProviderError(
-                self.name, f"Failed to fetch movie details: {error}"
+                self.name,
+                f"Failed to fetch movie details: {scrub_request_error(error)}",
             ) from error
 
     def _fetch_tv_details(
@@ -488,7 +492,8 @@ class TMDBProvider(EnrichmentProvider):
 
         except requests.RequestException as error:
             raise ProviderError(
-                self.name, f"Failed to fetch TV show details: {error}"
+                self.name,
+                f"Failed to fetch TV show details: {scrub_request_error(error)}",
             ) from error
 
     def _fetch_keywords(

--- a/src/ingestion/sources/steam/steam.py
+++ b/src/ingestion/sources/steam/steam.py
@@ -15,6 +15,7 @@ from src.ingestion.plugin_base import (
     SourcePlugin,
 )
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
+from src.utils.request_errors import scrub_request_error
 
 if TYPE_CHECKING:
     from src.storage.manager import StorageManager
@@ -29,20 +30,6 @@ class SteamAPIError(Exception):
     """Exception raised for Steam API errors."""
 
     pass
-
-
-def _scrub_request_error(error: requests.RequestException) -> str:
-    """Render a requests exception without leaking the URL/query string.
-
-    The default ``str()`` of ``requests.HTTPError`` includes the request URL,
-    which embeds the Steam Web API key (``?key=<api_key>&...``). The wrapped
-    exception flows into ``SourceError`` and from there into the sync job's
-    ``error_message`` field that the web API returns to the browser. Strip the
-    URL and surface only the HTTP status (when known) plus the exception type.
-    """
-    if isinstance(error, requests.HTTPError) and error.response is not None:
-        return f"HTTP {error.response.status_code}"
-    return type(error).__name__
 
 
 def get_steam_id_from_vanity_url(api_key: str, vanity_url: str) -> str | None:
@@ -67,7 +54,7 @@ def get_steam_id_from_vanity_url(api_key: str, vanity_url: str) -> str | None:
             return str(steamid) if steamid else None
         return None
     except requests.RequestException as error:
-        scrubbed = _scrub_request_error(error)
+        scrubbed = scrub_request_error(error)
         logger.error("Error resolving Steam vanity URL: %s", scrubbed)
         raise SteamAPIError(f"Failed to resolve Steam ID: {scrubbed}") from error
 
@@ -100,7 +87,7 @@ def get_owned_games(
         games = data.get("response", {}).get("games", [])
         return list(games) if games else []
     except requests.RequestException as error:
-        scrubbed = _scrub_request_error(error)
+        scrubbed = scrub_request_error(error)
         logger.error("Error fetching Steam games: %s", scrubbed)
         raise SteamAPIError(f"Failed to fetch Steam games: {scrubbed}") from error
 

--- a/src/ingestion/sources/steam/test_steam.py
+++ b/src/ingestion/sources/steam/test_steam.py
@@ -647,7 +647,8 @@ class TestSteamApiKeyScrubbingRegression:
     ``RequestException.__str__``, which contains the full URL (including the
     ``key`` query parameter) for HTTPErrors raised by ``raise_for_status()``.
 
-    Fix: ``_scrub_request_error`` renders only ``HTTP <status>`` for HTTP
+    Fix: the shared ``scrub_request_error`` helper (extracted into
+    :mod:`src.utils.request_errors`) renders only ``HTTP <status>`` for HTTP
     errors and the bare exception class name for transport errors, before the
     string ever reaches ``SteamAPIError`` or any logger.
     """

--- a/src/utils/request_errors.py
+++ b/src/utils/request_errors.py
@@ -1,0 +1,32 @@
+"""Helpers for rendering ``requests`` exceptions without leaking credentials."""
+
+from __future__ import annotations
+
+import requests
+
+
+def scrub_request_error(error: requests.RequestException) -> str:
+    """Render a ``requests`` exception without leaking the request URL.
+
+    The default ``str()`` of a ``requests.HTTPError`` (and other request
+    exceptions) embeds the full request URL. When a source or enrichment
+    provider passes its API key as a query parameter (``?api_key=<secret>``
+    / ``?key=<secret>``), that key ends up in the exception message — and
+    from there in sync/enrichment error fields the web API and CLI surface
+    to users and logs.
+
+    This deliberately omits the URL and the raw exception message. It
+    returns only the HTTP status code for HTTP errors and the bare
+    exception class name for transport errors (connection, timeout, etc.),
+    neither of which can carry the credential.
+
+    Args:
+        error: The ``requests`` exception to render.
+
+    Returns:
+        ``"HTTP <status>"`` for an HTTP error with a response, otherwise the
+        exception class name (e.g. ``"ConnectionError"``).
+    """
+    if isinstance(error, requests.HTTPError) and error.response is not None:
+        return f"HTTP {error.response.status_code}"
+    return type(error).__name__

--- a/tests/enrichment/test_enrichment_manager.py
+++ b/tests/enrichment/test_enrichment_manager.py
@@ -1,11 +1,13 @@
 """Tests for the enrichment manager."""
 
+import logging
 import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from src.enrichment.manager import (
     EnrichmentJobStatus,
@@ -85,6 +87,50 @@ class MockProvider(EnrichmentProvider):
             match_quality="high",
             provider=self._name,
         )
+
+
+class RawRequestErrorProvider(EnrichmentProvider):
+    """Provider that lets a raw requests.HTTPError escape from enrich().
+
+    Models the failure mode where a provider forgets to wrap a ``requests``
+    exception in ``ProviderError``, so it falls through to the manager's
+    broad ``except Exception`` catch-all rather than the ``ProviderError``
+    branch.
+    """
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    @property
+    def name(self) -> str:
+        return "raw_request"
+
+    @property
+    def display_name(self) -> str:
+        return "Raw Request Provider"
+
+    @property
+    def content_types(self) -> list[ContentType]:
+        return [ContentType.MOVIE]
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    @property
+    def rate_limit_requests_per_second(self) -> float:
+        return 100.0
+
+    def get_config_schema(self) -> list[ConfigField]:
+        return []
+
+    def validate_config(self, config: dict[str, Any]) -> list[str]:
+        return []
+
+    def enrich(
+        self, item: ContentItem, config: dict[str, Any]
+    ) -> EnrichmentResult | None:
+        raise self._error
 
 
 class TestEnrichmentJobStatus:
@@ -516,6 +562,94 @@ class TestEnrichmentManager:
 
         status = manager.get_status()
         assert status.items_not_found == 1
+
+
+class TestEnrichmentStatusApiKeyScrubbingRegression:
+    """Regression tests for an api_key leaking through status.errors.
+
+    The provider raise sites already scrub ``requests`` exceptions, but the
+    manager's broad ``except Exception`` catch-alls stringify the raw error
+    into ``status.errors`` — which the web ``/enrichment/status`` endpoint and
+    CLI surface to users and logs. If a future provider ever lets a raw
+    ``requests.RequestException`` escape unwrapped (i.e. not inside
+    ``ProviderError``), the request URL — and the ``?api_key=<secret>`` it
+    carries — would leak there.
+
+    Fix: the catch-all sites render ``requests`` exceptions through
+    ``scrub_request_error`` (via ``_render_error``) while leaving genuine
+    non-request errors untouched, so they keep their useful detail.
+    """
+
+    _API_KEY = "SECRET_MANAGER_KEY_123"
+
+    @pytest.fixture
+    def mock_storage(self) -> MagicMock:
+        storage = MagicMock(spec=StorageManager)
+        storage.get_items_needing_enrichment.return_value = []
+        storage.count_items_needing_enrichment.return_value = 0
+        return storage
+
+    @pytest.fixture
+    def mock_registry(self) -> EnrichmentRegistry:
+        registry = EnrichmentRegistry()
+        registry._discovered = True
+        return registry
+
+    @pytest.fixture
+    def config(self) -> dict[str, Any]:
+        return {
+            "enrichment": {
+                "batch_size": 10,
+                "providers": {"raw_request": {"enabled": True}},
+            }
+        }
+
+    def _http_error(self) -> requests.HTTPError:
+        """Build an HTTPError whose str() embeds the api_key, like requests."""
+        response = MagicMock(spec=requests.Response)
+        response.status_code = 401
+        url = (
+            "https://api.themoviedb.org/3/search/movie"
+            f"?api_key={self._API_KEY}&query=The+Matrix"
+        )
+        return requests.HTTPError(f"401 Client Error for url: {url}", response=response)
+
+    def test_raw_request_error_does_not_leak_api_key_in_status(
+        self,
+        mock_storage: MagicMock,
+        mock_registry: EnrichmentRegistry,
+        config: dict[str, Any],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A raw, unwrapped requests error must be scrubbed in status and logs."""
+        item = ContentItem(
+            id="movie1",
+            title="The Matrix",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+        )
+        mock_storage.get_items_needing_enrichment.side_effect = [[(1, item)], []]
+        mock_storage.count_items_needing_enrichment.return_value = 1
+
+        mock_registry.register(RawRequestErrorProvider(self._http_error()))
+
+        manager = EnrichmentManager(mock_storage, config, mock_registry)
+        with caplog.at_level(logging.WARNING, logger="src.enrichment.manager"):
+            manager.start_enrichment()
+            manager._wait_for_completion()
+
+        status = manager.get_status()
+        assert status.errors, "expected the unwrapped request error to be recorded"
+        joined = " ".join(status.errors)
+        assert self._API_KEY not in joined
+        assert "api_key=" not in joined
+        assert "raw_request: HTTP 401" in joined
+
+        # The same scrubbed value must reach the logs (CWE-532): the catch-all
+        # logger call must not lazily stringify the raw error's leaky URL.
+        assert "raw_request" in caplog.text, "expected the error to be logged"
+        assert self._API_KEY not in caplog.text
+        assert "api_key=" not in caplog.text
 
 
 class TestEnrichmentProgressRegression:

--- a/tests/test_request_errors.py
+++ b/tests/test_request_errors.py
@@ -1,0 +1,64 @@
+"""Tests for the request-error scrubbing utility."""
+
+from unittest.mock import Mock
+
+import requests
+
+from src.utils.request_errors import scrub_request_error
+
+
+class TestScrubRequestError:
+    """Tests for scrub_request_error()."""
+
+    def test_http_error_with_response_returns_status_only(self) -> None:
+        """An HTTPError with a response surfaces only the status code."""
+        response = Mock(spec=requests.Response)
+        response.status_code = 401
+        error = requests.HTTPError("401 Client Error", response=response)
+
+        assert scrub_request_error(error) == "HTTP 401"
+
+    def test_http_error_without_response_returns_class_name(self) -> None:
+        """An HTTPError lacking a response falls back to the class name."""
+        error = requests.HTTPError("boom")
+
+        assert scrub_request_error(error) == "HTTPError"
+
+    def test_connection_error_returns_class_name(self) -> None:
+        """Transport errors surface only the exception class name."""
+        error = requests.ConnectionError("connection refused")
+
+        assert scrub_request_error(error) == "ConnectionError"
+
+    def test_timeout_returns_class_name(self) -> None:
+        """Timeouts surface only the exception class name."""
+        error = requests.Timeout("timed out")
+
+        assert scrub_request_error(error) == "Timeout"
+
+    def test_never_leaks_secret_from_http_error_message(self) -> None:
+        """A secret embedded in the HTTPError's URL never reaches the output."""
+        response = Mock(spec=requests.Response)
+        response.status_code = 403
+        error = requests.HTTPError(
+            "403 Client Error for url: https://api.example.com/x?api_key=SECRET123",
+            response=response,
+        )
+
+        result = scrub_request_error(error)
+
+        assert "SECRET123" not in result
+        assert "api_key=" not in result
+        assert result == "HTTP 403"
+
+    def test_never_leaks_secret_from_transport_error_message(self) -> None:
+        """A secret embedded in a transport error's message never leaks."""
+        error = requests.ConnectionError(
+            "Failed to connect to https://api.example.com/x?key=SECRET123"
+        )
+
+        result = scrub_request_error(error)
+
+        assert "SECRET123" not in result
+        assert "key=" not in result
+        assert result == "ConnectionError"


### PR DESCRIPTION
## What and why

Some enrichment providers pass their API key as a URL query parameter (TMDB `?api_key=...`, RAWG `?key=...`). When a request failed, the raw `requests` exception, whose string includes the full URL, got wrapped into the error that surfaces in the enrichment status (the web `/enrichment/status` endpoint and the CLI) and the server logs. That leaked the API key.

This redacts it at the source. A new `scrub_request_error` helper turns a failed request into either `HTTP <status>` or the bare exception class name, never the URL, and the providers use it before raising.

## What changed

- New `src/utils/request_errors.py::scrub_request_error`, generalized from the helper the Steam source already had.
- Applied at the TMDB and RAWG error sites so the key never reaches a `ProviderError` message.
- Hardened the enrichment manager so that even if a provider ever lets a raw `requests` error escape unwrapped, the key is scrubbed before it reaches the status or the logs (defense in depth, with a regression test that drives exactly that case).
- Refactored Steam onto the shared helper so there is one implementation.
- Fixed the plugin development guide, which had been demonstrating the unsafe pattern, and added a best practice note for future plugin authors.

## How to test

Point an enrichment provider at a deliberately bad key or break connectivity, run enrichment, and confirm the error shown in the UI/CLI and written to the logs reads like `Failed to fetch movie details: HTTP 401` with no `api_key=` and no URL. The regression tests assert the key value never appears in the surfaced message, the status, or the log output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
