### PR TITLE
feat: surface completed items that need a rating

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -45,6 +45,11 @@ python3.11 -m src.cli library list --enrichment not_enriched
 # combines with the type/status filters.
 python3.11 -m src.cli library list --search "die hard"
 
+# Surface completed items you haven't rated yet (forces completed status,
+# overriding --status; composes with --type). Rate them with `library edit`.
+python3.11 -m src.cli library list --needs-rating
+python3.11 -m src.cli library list --needs-rating --type movie
+
 # Show item details
 python3.11 -m src.cli library show --id 42
 

--- a/resources/js/components/organisms/LibraryFilters.test.ts
+++ b/resources/js/components/organisms/LibraryFilters.test.ts
@@ -8,6 +8,7 @@ describe('LibraryFilters', () => {
     statusFilter: '',
     enrichmentFilter: '',
     showIgnored: false,
+    needsRating: false,
     searchQuery: '',
     searchLoading: false,
   }
@@ -162,7 +163,7 @@ describe('LibraryFilters', () => {
   it('emits filterChange for showIgnored on toggle click', async () => {
     const wrapper = mount(LibraryFilters, { props: defaultProps })
 
-    await wrapper.find('.toggle-switch').trigger('click')
+    await wrapper.find('button[aria-label="Show ignored"]').trigger('click')
 
     expect(wrapper.emitted('filterChange')).toEqual([['showIgnored', true]])
   })
@@ -172,9 +173,58 @@ describe('LibraryFilters', () => {
       props: { ...defaultProps, showIgnored: true },
     })
 
-    await wrapper.find('.toggle-switch').trigger('click')
+    await wrapper.find('button[aria-label="Show ignored"]').trigger('click')
 
     expect(wrapper.emitted('filterChange')).toEqual([['showIgnored', false]])
+  })
+
+  it('renders the Needs rating toggle', () => {
+    const wrapper = mount(LibraryFilters, { props: defaultProps })
+
+    expect(wrapper.find('button[aria-label="Needs rating"]').exists()).toBe(true)
+  })
+
+  it('emits filterChange for needsRating on toggle click', async () => {
+    const wrapper = mount(LibraryFilters, { props: defaultProps })
+
+    await wrapper.find('button[aria-label="Needs rating"]').trigger('click')
+
+    expect(wrapper.emitted('filterChange')).toEqual([['needsRating', true]])
+  })
+
+  it('emits filterChange with false when toggling off needsRating', async () => {
+    const wrapper = mount(LibraryFilters, {
+      props: { ...defaultProps, needsRating: true },
+    })
+
+    await wrapper.find('button[aria-label="Needs rating"]').trigger('click')
+
+    expect(wrapper.emitted('filterChange')).toEqual([['needsRating', false]])
+  })
+
+  it('disables and displays Completed without mutating an empty statusFilter', () => {
+    const wrapper = mount(LibraryFilters, {
+      props: { ...defaultProps, needsRating: true, statusFilter: '' },
+    })
+
+    const select = wrapper.find('select[aria-label="Status"]')
+    expect(select.attributes('disabled')).toBeDefined()
+    // Display-only: the select shows Completed even though statusFilter is ''.
+    expect((select.element as HTMLSelectElement).value).toBe('completed')
+    expect(select.attributes('aria-describedby')).toBe('status-locked-hint')
+    expect(wrapper.find('#status-locked-hint').classes()).toContain('sr-only')
+  })
+
+  it('shows the real statusFilter and is editable when needsRating is inactive', () => {
+    const wrapper = mount(LibraryFilters, {
+      props: { ...defaultProps, statusFilter: 'unread' },
+    })
+
+    const select = wrapper.find('select[aria-label="Status"]')
+    expect(select.attributes('disabled')).toBeUndefined()
+    expect((select.element as HTMLSelectElement).value).toBe('unread')
+    expect(select.attributes('aria-describedby')).toBeUndefined()
+    expect(wrapper.find('#status-locked-hint').exists()).toBe(false)
   })
 
   it('renders export dropdown button with title', () => {

--- a/resources/js/components/organisms/LibraryFilters.vue
+++ b/resources/js/components/organisms/LibraryFilters.vue
@@ -10,13 +10,14 @@ const props = defineProps<{
   statusFilter: string
   enrichmentFilter: string
   showIgnored: boolean
+  needsRating: boolean
   searchQuery: string
   searchLoading: boolean
 }>()
 
 const emit = defineEmits<{
   filterChange: [
-    key: 'type' | 'status' | 'enrichment' | 'showIgnored' | 'search',
+    key: 'type' | 'status' | 'enrichment' | 'showIgnored' | 'search' | 'needsRating',
     value: string | boolean,
   ]
   export: [format: 'csv' | 'json']
@@ -87,12 +88,20 @@ onUnmounted(() => {
           :model-value="typeFilter"
           @update:model-value="emit('filterChange', 'type', $event)"
         />
-        <select class="toolbar-select" aria-label="Status" :value="statusFilter" @change="emit('filterChange', 'status', ($event.target as HTMLSelectElement).value)">
+        <select
+          class="toolbar-select"
+          aria-label="Status"
+          :value="needsRating ? 'completed' : statusFilter"
+          :disabled="needsRating"
+          :aria-describedby="needsRating ? 'status-locked-hint' : undefined"
+          @change="emit('filterChange', 'status', ($event.target as HTMLSelectElement).value)"
+        >
           <option value="">All Statuses</option>
           <option value="unread">{{ unreadLabel }}</option>
           <option value="currently_consuming">In Progress</option>
           <option value="completed">Completed</option>
         </select>
+        <span v-if="needsRating" id="status-locked-hint" class="sr-only">Locked to Completed while Needs rating is on.</span>
         <select class="toolbar-select" aria-label="Enrichment" :value="enrichmentFilter" @change="emit('filterChange', 'enrichment', ($event.target as HTMLSelectElement).value)">
           <option value="">All Items</option>
           <option value="enriched">Enriched</option>
@@ -104,6 +113,11 @@ onUnmounted(() => {
 
       <!-- Ignored toggle + Export (mobile: row 2; desktop: inline in toolbar) -->
       <div class="lib-actions-row">
+        <ToggleSwitch
+          :model-value="needsRating"
+          label="Needs rating"
+          @update:model-value="emit('filterChange', 'needsRating', $event)"
+        />
         <ToggleSwitch
           :model-value="showIgnored"
           label="Show ignored"

--- a/resources/js/components/pages/LibraryPage.vue
+++ b/resources/js/components/pages/LibraryPage.vue
@@ -67,6 +67,7 @@ onUnmounted(() => {
       :status-filter="lib.statusFilter"
       :enrichment-filter="lib.enrichmentFilter"
       :show-ignored="lib.showIgnored"
+      :needs-rating="lib.needsRating"
       :search-query="lib.searchQuery"
       :search-loading="lib.searchLoading"
       @filter-change="lib.setFilter"
@@ -79,21 +80,24 @@ onUnmounted(() => {
       Failed to load library: {{ lib.error }}
     </div>
 
-    <div
-      v-if="lib.items.length === 0 && !lib.loading && lib.searchQuery"
-      class="empty-state empty-state-search"
-    >
-      <svg class="empty-state-icon" aria-hidden="true" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <circle cx="11" cy="11" r="8" />
-        <line x1="21" y1="21" x2="16.65" y2="16.65" />
-      </svg>
-      <p class="empty-state-title">No items match “{{ lib.searchQuery }}”</p>
-      <p class="empty-state-hint">Try a different title, or check your spelling.</p>
-      <button class="btn btn-secondary" @click="lib.setFilter('search', '')">Clear search</button>
-    </div>
+    <div aria-live="polite" aria-atomic="true">
+      <div
+        v-if="lib.items.length === 0 && !lib.loading && lib.searchQuery"
+        class="empty-state empty-state-search"
+      >
+        <svg class="empty-state-icon" aria-hidden="true" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+        <p class="empty-state-title">No items match “{{ lib.searchQuery }}”</p>
+        <p class="empty-state-hint">Try a different title, or check your spelling.</p>
+        <button class="btn btn-secondary" @click="lib.setFilter('search', '')">Clear search</button>
+      </div>
 
-    <div v-else-if="lib.items.length === 0 && !lib.loading" class="empty-state">
-      No items found. Try syncing your sources.
+      <div v-else-if="lib.items.length === 0 && !lib.loading" class="empty-state">
+        <template v-if="lib.needsRating">Nothing needs a rating. All your completed items are rated.</template>
+        <template v-else>No items found. Try syncing your sources.</template>
+      </div>
     </div>
 
     <div v-if="lib.items.length > 0" class="library-grid">

--- a/resources/js/stores/library.test.ts
+++ b/resources/js/stores/library.test.ts
@@ -30,6 +30,7 @@ describe('useLibraryStore', () => {
     expect(store.loading).toBe(false)
     expect(store.typeFilter).toBe('')
     expect(store.statusFilter).toBe('')
+    expect(store.needsRating).toBe(false)
   })
 
   it('resetAndLoad fetches items', async () => {
@@ -305,6 +306,64 @@ describe('useLibraryStore', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('setFilter needsRating sends needs_rating, omits status, and leaves statusFilter untouched', async () => {
+    mockGet.mockResolvedValue([])
+    const store = useLibraryStore()
+
+    await store.setFilter('needsRating', true)
+
+    expect(store.needsRating).toBe(true)
+    // statusFilter is independent — the toggle must not mutate it.
+    expect(store.statusFilter).toBe('')
+    const params = mockGet.mock.lastCall![1] as Record<string, unknown>
+    expect(params.needs_rating).toBe(true)
+    expect(params.status).toBeUndefined()
+    expect(store.offset).toBe(0)
+  })
+
+  it('needsRating composes with the type filter and still omits status', async () => {
+    mockGet.mockResolvedValue([])
+    const store = useLibraryStore()
+
+    await store.setFilter('type', 'book')
+    await store.setFilter('needsRating', true)
+
+    const params = mockGet.mock.lastCall![1] as Record<string, unknown>
+    expect(params.type).toBe('book')
+    expect(params.needs_rating).toBe(true)
+    expect(params.status).toBeUndefined()
+  })
+
+  it('needsRating composes with showIgnored and still omits status', async () => {
+    mockGet.mockResolvedValue([])
+    const store = useLibraryStore()
+
+    await store.setFilter('showIgnored', true)
+    await store.setFilter('needsRating', true)
+
+    const params = mockGet.mock.lastCall![1] as Record<string, unknown>
+    expect(params.needs_rating).toBe(true)
+    expect(params.include_ignored).toBe(true)
+    expect(params.status).toBeUndefined()
+  })
+
+  it('toggling needsRating off restores the user\'s prior status filter', async () => {
+    mockGet.mockResolvedValue([])
+    const store = useLibraryStore()
+
+    // User picks a real status, then toggles needsRating on and back off.
+    await store.setFilter('status', 'unread')
+    await store.setFilter('needsRating', true)
+    await store.setFilter('needsRating', false)
+
+    expect(store.needsRating).toBe(false)
+    // The orthogonal redesign means the prior status survives the round-trip.
+    expect(store.statusFilter).toBe('unread')
+    const params = mockGet.mock.lastCall![1] as Record<string, unknown>
+    expect(params.needs_rating).toBeUndefined()
+    expect(params.status).toBe('unread')
   })
 
   it('saveEdit updates item in list', async () => {

--- a/resources/js/stores/library.ts
+++ b/resources/js/stores/library.ts
@@ -22,6 +22,7 @@ export const useLibraryStore = defineStore('library', () => {
   const statusFilter = ref('')
   const enrichmentFilter = ref('')
   const showIgnored = ref(false)
+  const needsRating = ref(false)
 
   // Search
   const searchQuery = ref('')
@@ -71,7 +72,14 @@ export const useLibraryStore = defineStore('library', () => {
         offset: offset.value,
       }
       if (typeFilter.value) params.type = typeFilter.value
-      if (statusFilter.value) params.status = statusFilter.value
+      if (needsRating.value) {
+        // The backend forces completed items for needs-rating, so the user's
+        // own status filter is irrelevant here — omit it to avoid a redundant
+        // or contradictory param.
+        params.needs_rating = true
+      } else if (statusFilter.value) {
+        params.status = statusFilter.value
+      }
       if (enrichmentFilter.value) params.enrichment = enrichmentFilter.value
       if (showIgnored.value) params.include_ignored = true
       if (searchQuery.value) params.search = searchQuery.value
@@ -134,7 +142,7 @@ export const useLibraryStore = defineStore('library', () => {
   }
 
   function setFilter(
-    key: 'type' | 'status' | 'enrichment' | 'showIgnored' | 'search',
+    key: 'type' | 'status' | 'enrichment' | 'showIgnored' | 'search' | 'needsRating',
     value: string | boolean,
   ) {
     if (key === 'search') {
@@ -150,6 +158,7 @@ export const useLibraryStore = defineStore('library', () => {
     else if (key === 'status') statusFilter.value = value as string
     else if (key === 'enrichment') enrichmentFilter.value = value as string
     else if (key === 'showIgnored') showIgnored.value = value as boolean
+    else if (key === 'needsRating') needsRating.value = value as boolean
     return resetAndLoad()
   }
 
@@ -234,6 +243,7 @@ export const useLibraryStore = defineStore('library', () => {
     statusFilter,
     enrichmentFilter,
     showIgnored,
+    needsRating,
     searchQuery,
     searchLoading,
     searchAnnouncement,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1210,6 +1210,11 @@ def library() -> None:
     help="Filter by enrichment state (default: all)",
 )
 @click.option(
+    "--needs-rating",
+    is_flag=True,
+    help="Only completed items with no rating (overrides --status)",
+)
+@click.option(
     "--limit",
     type=click.IntRange(min=1, max=200),
     default=50,
@@ -1244,6 +1249,7 @@ def library_list(
     search: str | None,
     show_ignored: bool,
     enrichment_str: str | None,
+    needs_rating: bool,
     limit: int | None,
     offset: int,
     output_format: str,
@@ -1260,10 +1266,16 @@ def library_list(
         cast(EnrichmentFilter, enrichment_str.lower()) if enrichment_str else None
     )
 
+    # needs_rating means "completed AND unrated": completed status is implied
+    # and takes precedence over any explicitly-passed --status (matches web API).
+    if needs_rating:
+        consumption_status = ConsumptionStatus.COMPLETED
+
     items: list[ContentItem] = storage.get_content_items(
         user_id=user_id,
         content_type=content_type,
         status=consumption_status,
+        unrated_only=needs_rating,
         sort_by=sort_by,
         search=search,
         include_ignored=show_ignored,

--- a/src/storage/manager.py
+++ b/src/storage/manager.py
@@ -258,6 +258,7 @@ class StorageManager:
         content_type: ContentType | None = None,
         status: ConsumptionStatus | list[ConsumptionStatus] | None = None,
         min_rating: int | None = None,
+        unrated_only: bool = False,
         limit: int | None = None,
         offset: int = 0,
         sort_by: str = "title",
@@ -273,6 +274,8 @@ class StorageManager:
             status: Filter by consumption status (single value or list for
                 IN-clause filtering)
             min_rating: Minimum rating (inclusive)
+            unrated_only: When True, only return items with no rating set
+                (rating IS NULL)
             limit: Maximum number of results
             offset: Number of results to skip (for pagination)
             sort_by: Sort order - "title" (default, ignores articles),
@@ -291,6 +294,7 @@ class StorageManager:
             content_type=content_type,
             status=status,
             min_rating=min_rating,
+            unrated_only=unrated_only,
             limit=limit,
             offset=offset,
             sort_by=sort_by,

--- a/src/storage/sqlite_db.py
+++ b/src/storage/sqlite_db.py
@@ -797,6 +797,7 @@ class SQLiteDB:
         content_type: ContentType | None = None,
         status: ConsumptionStatus | list[ConsumptionStatus] | None = None,
         min_rating: int | None = None,
+        unrated_only: bool = False,
         limit: int | None = None,
         offset: int = 0,
         sort_by: str = "title",
@@ -812,6 +813,8 @@ class SQLiteDB:
             status: Filter by consumption status (single value or list for
                 IN-clause filtering)
             min_rating: Minimum rating (inclusive)
+            unrated_only: When True, only return items with no rating set
+                (rating IS NULL)
             limit: Maximum number of results
             offset: Number of results to skip (for pagination)
             sort_by: Sort order - "title" (default, ignores articles),
@@ -878,6 +881,9 @@ class SQLiteDB:
             if min_rating is not None:
                 query += " AND ci.rating >= ?"
                 params.append(min_rating)
+
+            if unrated_only:
+                query += " AND ci.rating IS NULL"
 
             if not include_ignored:
                 query += " AND (ci.ignored = 0 OR ci.ignored IS NULL)"

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -809,6 +809,10 @@ async def list_items(
         description="Filter by enrichment state: enriched or not_enriched",
     ),
     search: str | None = Query(None, description="Search term for title/creator"),
+    needs_rating: bool = Query(
+        False,
+        description="Only return completed items that have no rating yet",
+    ),
 ) -> list[ContentItemResponse]:
     """List content items with optional filters.
 
@@ -822,6 +826,8 @@ async def list_items(
         include_ignored: Whether to include ignored items (default: False).
         enrichment: Optional enrichment-state filter (enriched/not_enriched).
         search: Optional search term matched against title and creator.
+        needs_rating: When True, return only completed items with no rating.
+            Forces status to completed (overriding any status param).
 
     Returns:
         List of content items.
@@ -857,10 +863,16 @@ async def list_items(
             detail="Invalid sort_by. Valid options: created_at, rating, title, updated_at",
         )
 
+    # needs_rating means "completed AND unrated": completed status is implied
+    # and takes precedence over any explicitly-passed status param.
+    if needs_rating:
+        consumption_status = ConsumptionStatus.COMPLETED
+
     items = storage.get_content_items(
         user_id=user_id,
         content_type=content_type,
         status=consumption_status,
+        unrated_only=needs_rating,
         limit=limit,
         offset=offset,
         sort_by=sort_by.lower(),

--- a/tests/cli/test_cli_library.py
+++ b/tests/cli/test_cli_library.py
@@ -303,6 +303,92 @@ class TestLibraryList:
         assert call_kwargs["offset"] == 10
         assert call_kwargs["include_ignored"] is True
 
+    def test_list_needs_rating_forces_completed_unrated(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """--needs-rating lists completed items with no rating."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(
+            cli_runner, ["library", "list", "--needs-rating"], mock_storage
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["status"] == ConsumptionStatus.COMPLETED
+        assert call_kwargs["unrated_only"] is True
+
+    def test_list_needs_rating_overrides_explicit_status(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """--needs-rating takes precedence over an explicit --status."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "list", "--needs-rating", "--status", "unread"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["status"] == ConsumptionStatus.COMPLETED
+        assert call_kwargs["unrated_only"] is True
+
+    def test_list_needs_rating_composes_with_type(self, cli_runner: CliRunner) -> None:
+        """--needs-rating composes with --type, forwarding both filters."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "list", "--needs-rating", "--type", "book"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["content_type"] == ContentType.BOOK
+        assert call_kwargs["status"] == ConsumptionStatus.COMPLETED
+        assert call_kwargs["unrated_only"] is True
+
+    def test_list_without_needs_rating_does_not_force(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Without --needs-rating, status is not forced and unrated_only is False."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(cli_runner, ["library", "list"], mock_storage)
+
+        assert result.exit_code == 0
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["status"] is None
+        assert call_kwargs["unrated_only"] is False
+
+    def test_list_needs_rating_composes_with_limit_and_offset(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """--needs-rating forwards limit/offset alongside the forced filters."""
+        mock_storage = MagicMock(spec=StorageManager)
+        mock_storage.get_content_items.return_value = []
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["library", "list", "--needs-rating", "--limit", "10", "--offset", "5"],
+            mock_storage,
+        )
+
+        assert result.exit_code == 0
+        mock_storage.get_content_items.assert_called_once()
+        call_kwargs = mock_storage.get_content_items.call_args[1]
+        assert call_kwargs["limit"] == 10
+        assert call_kwargs["offset"] == 5
+        assert call_kwargs["status"] == ConsumptionStatus.COMPLETED
+        assert call_kwargs["unrated_only"] is True
+
 
 class TestLibraryShow:
     """Tests for library show command."""

--- a/tests/test_sqlite_db.py
+++ b/tests/test_sqlite_db.py
@@ -193,6 +193,178 @@ def test_get_content_items_with_filters(temp_db: SQLiteDB) -> None:
     assert len(books) == 6
 
 
+def test_get_content_items_unrated_only(temp_db: SQLiteDB) -> None:
+    """unrated_only should return only items with rating IS NULL."""
+    items = [
+        ContentItem(
+            id="completed_rated",
+            title="Completed Rated",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+        ),
+        ContentItem(
+            id="completed_unrated",
+            title="Completed Unrated",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=None,
+        ),
+        ContentItem(
+            id="unread_unrated",
+            title="Unread Unrated",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.UNREAD,
+            rating=None,
+        ),
+    ]
+    for item in items:
+        temp_db.save_content_item(item)
+
+    # rating IS NULL across all statuses when status is not constrained
+    unrated = temp_db.get_content_items(unrated_only=True)
+    assert {item.id for item in unrated} == {"completed_unrated", "unread_unrated"}
+
+    # Composes with status: only completed + unrated
+    completed_unrated = temp_db.get_content_items(
+        status=ConsumptionStatus.COMPLETED, unrated_only=True
+    )
+    assert {item.id for item in completed_unrated} == {"completed_unrated"}
+
+    # Composes with content_type
+    movie_unrated = temp_db.get_content_items(
+        content_type=ContentType.MOVIE, unrated_only=True
+    )
+    assert {item.id for item in movie_unrated} == {"unread_unrated"}
+
+
+def test_get_content_items_unrated_only_respects_ignored(temp_db: SQLiteDB) -> None:
+    """unrated_only must still honor the ignored filter, not bypass it.
+
+    The web/CLI needs-rating path passes include_ignored=False by default, so an
+    ignored completed+unrated item must not leak into that set; it only surfaces
+    when ignored items are explicitly requested. unrated_only composes with the
+    ignored filter rather than overriding it.
+    """
+    visible = ContentItem(
+        id="visible_unrated",
+        title="Visible Unrated",
+        content_type=ContentType.BOOK,
+        status=ConsumptionStatus.COMPLETED,
+        rating=None,
+        ignored=False,
+    )
+    hidden = ContentItem(
+        id="ignored_unrated",
+        title="Ignored Unrated",
+        content_type=ContentType.BOOK,
+        status=ConsumptionStatus.COMPLETED,
+        rating=None,
+        ignored=True,
+    )
+    temp_db.save_content_item(visible)
+    temp_db.save_content_item(hidden)
+
+    # include_ignored=False (what the web/CLI default to): ignored item excluded.
+    visible_only = temp_db.get_content_items(
+        status=ConsumptionStatus.COMPLETED, unrated_only=True, include_ignored=False
+    )
+    assert {item.id for item in visible_only} == {"visible_unrated"}
+
+    # include_ignored=True: ignored item is surfaced alongside the visible one.
+    with_ignored = temp_db.get_content_items(
+        status=ConsumptionStatus.COMPLETED, unrated_only=True, include_ignored=True
+    )
+    assert {item.id for item in with_ignored} == {
+        "visible_unrated",
+        "ignored_unrated",
+    }
+
+
+def test_get_content_items_unrated_only_pagination(temp_db: SQLiteDB) -> None:
+    """unrated_only composes with limit/offset for paginated needs-rating views."""
+    for letter in ("A", "B", "C"):
+        temp_db.save_content_item(
+            ContentItem(
+                id=f"unrated_{letter}",
+                title=f"Title {letter}",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.COMPLETED,
+                rating=None,
+            )
+        )
+
+    first_page = temp_db.get_content_items(
+        status=ConsumptionStatus.COMPLETED, unrated_only=True, limit=2, offset=0
+    )
+    assert [item.id for item in first_page] == ["unrated_A", "unrated_B"]
+
+    second_page = temp_db.get_content_items(
+        status=ConsumptionStatus.COMPLETED, unrated_only=True, limit=2, offset=2
+    )
+    assert [item.id for item in second_page] == ["unrated_C"]
+
+
+def test_get_content_items_unrated_only_sql_paginated_sort(temp_db: SQLiteDB) -> None:
+    """unrated_only composes with SQL LIMIT/OFFSET under a non-title sort.
+
+    The default "title" sort paginates in Python; "updated_at"/"created_at"/
+    "rating" apply LIMIT/OFFSET in SQL, a separate code path. This pins that
+    path: rated completed items must never leak across pages, and the unrated
+    items must paginate in the requested updated_at DESC order. updated_at is
+    set explicitly per row so the ordering is deterministic (the schema default
+    CURRENT_TIMESTAMP has only second granularity and would tie within a test).
+    """
+    # external_id -> (rating, updated_at). Newest updated_at sorts first.
+    # Rated rows are interleaved by timestamp to prove they are filtered, not
+    # merely paginated off the end.
+    rows = {
+        "unrated_1": (None, "2025-01-06 00:00:00"),
+        "rated_1": (4, "2025-01-05 00:00:00"),
+        "unrated_2": (None, "2025-01-04 00:00:00"),
+        "unrated_3": (None, "2025-01-03 00:00:00"),
+        "rated_2": (5, "2025-01-02 00:00:00"),
+        "unrated_4": (None, "2025-01-01 00:00:00"),
+    }
+    for external_id, (rating, _) in rows.items():
+        temp_db.save_content_item(
+            ContentItem(
+                id=external_id,
+                title=external_id.replace("_", " ").title(),
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.COMPLETED,
+                rating=rating,
+            )
+        )
+
+    with temp_db.connection() as conn:
+        cursor = conn.cursor()
+        for external_id, (_, updated_at) in rows.items():
+            cursor.execute(
+                "UPDATE content_items SET updated_at = ? WHERE external_id = ?",
+                (updated_at, external_id),
+            )
+        conn.commit()
+
+    first_page = temp_db.get_content_items(
+        status=ConsumptionStatus.COMPLETED,
+        unrated_only=True,
+        sort_by="updated_at",
+        limit=2,
+        offset=0,
+    )
+    assert [item.id for item in first_page] == ["unrated_1", "unrated_2"]
+
+    second_page = temp_db.get_content_items(
+        status=ConsumptionStatus.COMPLETED,
+        unrated_only=True,
+        sort_by="updated_at",
+        limit=2,
+        offset=2,
+    )
+    assert [item.id for item in second_page] == ["unrated_3", "unrated_4"]
+
+
 def test_get_unconsumed_items(temp_db: SQLiteDB) -> None:
     """Test getting unconsumed items (UNREAD + CURRENTLY_CONSUMING)."""
     items = [

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1107,6 +1107,96 @@ def test_list_items_include_ignored_true(client, mock_components):
     assert call_kwargs["include_ignored"] is True
 
 
+def test_list_items_needs_rating_forces_completed_and_unrated(client, mock_components):
+    """GET /api/items?needs_rating=true forwards status=completed + unrated_only."""
+    mock_components["storage"].get_content_items.return_value = []
+
+    response = client.get("/api/items?user_id=1&needs_rating=true")
+    assert response.status_code == 200
+
+    mock_components["storage"].get_content_items.assert_called_once()
+    call_kwargs = mock_components["storage"].get_content_items.call_args[1]
+    assert call_kwargs["status"] == ConsumptionStatus.COMPLETED
+    assert call_kwargs["unrated_only"] is True
+
+
+def test_list_items_needs_rating_overrides_explicit_status(client, mock_components):
+    """needs_rating forces completed status even when a different status is passed."""
+    mock_components["storage"].get_content_items.return_value = []
+
+    response = client.get("/api/items?user_id=1&status=unread&needs_rating=true")
+    assert response.status_code == 200
+
+    call_kwargs = mock_components["storage"].get_content_items.call_args[1]
+    assert call_kwargs["status"] == ConsumptionStatus.COMPLETED
+    assert call_kwargs["unrated_only"] is True
+
+
+def test_list_items_default_does_not_filter_unrated(client, mock_components):
+    """GET /api/items without needs_rating passes unrated_only=False to storage."""
+    mock_components["storage"].get_content_items.return_value = []
+
+    response = client.get("/api/items?user_id=1")
+    assert response.status_code == 200
+
+    call_kwargs = mock_components["storage"].get_content_items.call_args[1]
+    assert call_kwargs["unrated_only"] is False
+
+
+def test_list_items_needs_rating_returns_only_completed_unrated(
+    client, mock_components
+):
+    """needs_rating returns the completed+unrated set the storage layer produces.
+
+    Storage applies the actual filter (covered by storage-layer tests); the
+    endpoint must return whatever that filtered query yields unmodified.
+    """
+    completed_unrated = ContentItem(
+        id="1",
+        title="Completed Unrated",
+        content_type=ContentType.BOOK,
+        status=ConsumptionStatus.COMPLETED,
+        rating=None,
+    )
+    mock_components["storage"].get_content_items.return_value = [completed_unrated]
+
+    response = client.get("/api/items?user_id=1&needs_rating=true")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["title"] == "Completed Unrated"
+    assert data[0]["status"] == "completed"
+    assert data[0]["rating"] is None
+
+
+def test_list_items_needs_rating_composes_with_type(client, mock_components):
+    """needs_rating + type forwards content_type, completed status, and unrated_only."""
+    mock_components["storage"].get_content_items.return_value = []
+
+    response = client.get("/api/items?user_id=1&needs_rating=true&type=book")
+    assert response.status_code == 200
+
+    mock_components["storage"].get_content_items.assert_called_once()
+    call_kwargs = mock_components["storage"].get_content_items.call_args[1]
+    assert call_kwargs["content_type"] == ContentType.BOOK
+    assert call_kwargs["status"] == ConsumptionStatus.COMPLETED
+    assert call_kwargs["unrated_only"] is True
+
+
+def test_list_items_needs_rating_composes_with_include_ignored(client, mock_components):
+    """needs_rating + include_ignored forwards both flags plus completed status."""
+    mock_components["storage"].get_content_items.return_value = []
+
+    response = client.get("/api/items?user_id=1&needs_rating=true&include_ignored=true")
+    assert response.status_code == 200
+
+    mock_components["storage"].get_content_items.assert_called_once()
+    call_kwargs = mock_components["storage"].get_content_items.call_args[1]
+    assert call_kwargs["status"] == ConsumptionStatus.COMPLETED
+    assert call_kwargs["unrated_only"] is True
+    assert call_kwargs["include_ignored"] is True
+
+
 def test_recommendations_include_db_id(client, mock_components):
     """GET /api/recommendations includes db_id in response."""
     mock_item = ContentItem(


### PR DESCRIPTION
## What this does

Adds a "Needs rating" filter that surfaces completed library items you haven't rated yet, so you can find them and set a rating through the edit modal you already use. This is the follow-on to the completed-but-unrated state that sources like Calibre-Web (#88) introduce: a book can land as completed with no rating, and until now there was no good way to find those again.

Closes #90.

## How it works

- **Storage:** `get_content_items` gains an `unrated_only` flag that adds `rating IS NULL` to the query. It composes with the existing status, content-type, ignored, and pagination filters rather than replacing them.
- **Web API:** `GET /api/items` takes a `needs_rating` boolean. When it's true the endpoint returns only completed + unrated items: it forces completed status and passes `unrated_only` through to storage. Completed is implied by the feature, so `needs_rating` takes precedence over any status the caller also sends.
- **Library view:** a standalone "Needs rating" toggle sits alongside the type, status, and show-ignored filters. While it's on, the status dropdown is pinned to Completed and disabled so the two filters can't contradict each other. The toggle and the status filter stay orthogonal in the store, so turning the toggle off restores exactly the status you had before. From there it's the existing edit modal to set a rating, and the item drops off the list on the next load.
- **CLI:** `library list --needs-rating` returns the same set, forces completed status (overriding `--status`), and composes with `--type`/`--limit`/`--offset`. Ratings are set with the existing `library edit --rating`.

## Accessibility

The empty state lives in an `aria-live` region so "Nothing needs a rating" is announced after you flip the toggle, and the locked status dropdown carries an sr-only hint explaining why it's disabled. The toggle reuses the existing switch component.

## Testing

- Storage tests for the `unrated_only` filter alone and composed with status, content-type, the ignored flag, and both Python- and SQL-path pagination, plus a regression that a rated completed item never leaks into the set.
- Web API tests that `needs_rating` forces completed + unrated, overrides an explicit status, and composes with type and include_ignored.
- CLI tests for the flag's precedence and composition.
- Vitest coverage for the store (orthogonal toggle/status state, param composition, round-trip toggle) and the filter component (locking, displayed value, ARIA wiring).
- `make check` is green (Black, Ruff, MyPy strict, pytest, vue-tsc, Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)