### PR TITLE
feat(ingestion): upload files to import instead of pointing config at them

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,15 +10,14 @@ body:
         Describe the bug: what you did, what you expected, what happened instead.
         Include reproduction steps and any error output (remove secrets first).
       placeholder: |
-        Syncing my Goodreads library fails after ~50 items.
+        Importing my Goodreads library fails after ~50 items.
         Expected all items to import; instead got a KeyError.
 
         Repro:
-        1. Configure goodreads source in config.yaml
-        2. Run `python3.11 -m src.cli update --source goodreads`
+        1. Run `python3.11 -m src.cli import --source goodreads --file goodreads_library_export.csv`
 
         Traceback (most recent call last):
-          File "src/ingestion/sources/goodreads.py", line 42, in fetch
+          File "src/ingestion/sources/goodreads/goodreads.py", line 42, in fetch
             ...
         KeyError: 'Date Read'
     validations:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,8 @@ Responsible for parsing and normalizing data from various sources.
 **Design:**
 - Plugin-based architecture (`SourcePlugin` ABC in `plugin_base.py`)
 - Auto-discovered from `src/ingestion/sources/` via `PluginRegistry`
-- **Named source instances**: Each entry under `inputs:` has a user-defined key name (e.g., `my_books`, `tv_shows`) with a `plugin:` field specifying the plugin type. Multiple instances of the same plugin are supported (e.g., two `json_import` sources with different files). The `resolve_inputs()` function in `src/web/sync_sources.py` is the central resolver that maps config entries to `(source_id, plugin, config)` tuples.
+- **Named source instances**: Each entry under `inputs:` has a user-defined key name (e.g., `my_movies`, `tv_shows`) with a `plugin:` field specifying the plugin type. Multiple instances of the same plugin are supported (e.g., two `sonarr` sources pointed at different servers). The `resolve_inputs()` function in `src/web/sync_sources.py` is the central resolver that maps config entries to `(source_id, plugin, config)` tuples; it skips file-import plugins (see below) so they never appear as syncable sources.
+- **One-shot file imports**: Goodreads and the generic CSV/JSON/Markdown plugins set `is_file_import = True` (on `SourcePlugin`). They have no persistent `inputs:` config — a file is supplied at invocation time (a web upload or the CLI `import --file` flag), run through the pipeline once by `src/ingestion/import_service.py` (`import_file`), and discarded. They are exposed via `GET /api/import/sources` / `import --source list` and driven by `POST /api/import` / the CLI `import` command, not the sync path. A leftover path-based `inputs:` block for one of them logs a non-fatal warning in `resolve_inputs` and is skipped.
 - `ContentItem.source` reflects the user-defined key name, not the plugin name, enabling per-instance tracking
 - Each plugin handles config validation, fetching, and rating normalization
 - Shared sync executor (`execute_multi_source_sync`) used by both CLI and web
@@ -195,7 +196,7 @@ view your profile). New capabilities are expected to land in both interfaces; th
 
 #### CLI (`src/cli/`)
 - Click-based command structure
-- Commands: `status`, `recommend`, `update`, `complete`, `source`, `preferences`, `enrichment`, `library`, `auth`, `memory`, `profile`, `chat` (full reference: [docs/CLI.md](docs/CLI.md))
+- Commands: `status`, `recommend`, `update`, `import`, `complete`, `source`, `preferences`, `enrichment`, `library`, `auth`, `memory`, `profile`, `chat` (full reference: [docs/CLI.md](docs/CLI.md))
 - Supports batch operations and multiple output formats
 
 #### Web (`src/web/` + `resources/`)
@@ -242,19 +243,19 @@ Configuration files in `config/`:
 
 Key sections: `features`, `ollama`, `storage`, `inputs`, `web`, `recommendations`, `conversation`, `enrichment`, `logging`.
 
-The `inputs` section uses **named source instances**: each key is a user-defined name and must include a `plugin:` field to identify the plugin type. This allows multiple instances of the same plugin (e.g., separate JSON imports for books and movies). File-based plugins use a standardized `path` field. Example:
+The `inputs` section uses **named source instances**: each key is a user-defined name and must include a `plugin:` field to identify the plugin type. This allows multiple instances of the same plugin (e.g., two Sonarr servers under different keys). Only syncable sources live here; one-shot file imports (Goodreads, CSV, JSON, Markdown) are not configured in `inputs:` — they are uploaded through the web **Data** tab or the CLI `import --file` command (see [docs/DATA_SOURCES.md](docs/DATA_SOURCES.md#importing-from-a-file)). Example:
 
 ```yaml
 inputs:
-  my_books:
-    plugin: json_import
-    path: "inputs/books.json"
-    content_type: "book"
+  shows_main:
+    plugin: sonarr
+    url: "http://localhost:8989"
+    content_type: "tv_show"
     enabled: true
-  my_movies:
-    plugin: json_import
-    path: "inputs/movies.json"
-    content_type: "movie"
+  shows_anime:
+    plugin: sonarr
+    url: "http://localhost:8990"
+    content_type: "tv_show"
     enabled: true
 ```
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -114,15 +114,10 @@ The system supports multiple data sources through a plugin architecture. See `co
 
 ### Configure a source
 
-Each source is configured under `inputs:` in `config/config.yaml`. Enable the ones you want and fill in any required fields (API keys, file paths, etc.):
+Syncable sources (Steam, GOG, Epic Games, Sonarr, Radarr, ROM Library) are configured under `inputs:` in `config/config.yaml`. Enable the ones you want and fill in any required fields (API keys, etc.):
 
 ```yaml
 inputs:
-  goodreads:
-    plugin: goodreads
-    path: "inputs/goodreads_library_export.csv"
-    enabled: true
-
   steam:
     plugin: steam
     api_key: "your-steam-api-key"
@@ -130,38 +125,42 @@ inputs:
     enabled: true
 ```
 
+Goodreads, CSV, JSON, and Markdown are **file imports**, not `inputs:` entries — see [Import a file](#import-a-file) below.
+
 Some sources (GOG, Epic Games) require OAuth setup — see that source's setup guide
 (e.g. [GOG](src/ingestion/sources/gog/README.md), [Epic Games](src/ingestion/sources/epic_games/README.md))
 for step-by-step instructions. [docs/DATA_SOURCES.md](docs/DATA_SOURCES.md) lists
 every source and covers managing them in the UI.
 
-### Generic CSV/JSON/Markdown
+### Import a file
 
-For sources without a dedicated plugin, use the generic importers. Templates for each content type are in the `templates/` directory:
+Goodreads exports and generic CSV/JSON/Markdown files are imported in one shot — you hand the file to the app and it runs immediately. There is nothing to put under `inputs:` and nothing to re-sync. Templates for the generic formats are in the `templates/` directory:
 
 ```bash
 # Copy a template and fill in your data
-cp templates/movies.csv inputs/my_movies.csv
+cp templates/movies.csv my_movies.csv
 ```
 
-Then configure the source in your config:
+Import it from the web **Data** tab's **Import from file** button, or from the CLI:
 
-```yaml
-inputs:
-  my_movies:
-    plugin: csv_import
-    path: "inputs/my_movies.csv"
-    content_type: "movie"
-    enabled: true
+```bash
+# Goodreads takes no options (always books)
+python3.11 -m src.cli import --source goodreads --file goodreads_library_export.csv
+
+# Generic formats need a content type
+python3.11 -m src.cli import --source csv_import --file my_movies.csv --content-type movie
+
+# List importable sources and their options
+python3.11 -m src.cli import --source list
 ```
 
-You can have multiple instances of the same plugin (e.g., two `json_import` sources for different files) — just give each a unique name.
+See [docs/DATA_SOURCES.md](docs/DATA_SOURCES.md#importing-from-a-file) for the full reference.
 
 ### Sync your data
 
 ```bash
 # Sync a specific source
-python3.11 -m src.cli update --source goodreads
+python3.11 -m src.cli update --source steam
 
 # Sync all enabled sources
 python3.11 -m src.cli update --source all
@@ -178,44 +177,46 @@ that expands to reveal settings) or from the CLI. YAML is no longer
 required for new sources — sources can live in YAML (bootstrap), in the
 database (post-migration or freshly created), or both.
 
+The `source` group manages syncable sources. File imports (Goodreads, CSV, JSON,
+Markdown) have no persistent config — import them with the `import` command above.
+
 ```bash
 # Create a brand-new source directly in the database (no YAML edit needed)
 python3.11 -m src.cli source plugins             # see what plugins are available
-python3.11 -m src.cli source create my_books goodreads
-python3.11 -m src.cli source set-secret my_books api_key   # add credentials
+python3.11 -m src.cli source create my_steam steam
+python3.11 -m src.cli source set-secret my_steam api_key   # add credentials
 
 # Move an existing YAML source into the database (one-time, idempotent)
-python3.11 -m src.cli source migrate goodreads
+python3.11 -m src.cli source migrate steam
 
 # Inspect / edit fields after migration or creation
-python3.11 -m src.cli source show goodreads
-python3.11 -m src.cli source set goodreads path inputs/new_export.csv
-python3.11 -m src.cli source disable goodreads          # disabled sources are skipped during sync
-python3.11 -m src.cli source enable goodreads
+python3.11 -m src.cli source show steam
+python3.11 -m src.cli source set steam vanity_url my-handle
+python3.11 -m src.cli source disable steam          # disabled sources are skipped during sync
+python3.11 -m src.cli source enable steam
 python3.11 -m src.cli source set-secret steam api_key   # hidden prompt
 
 # Remove a DB-backed source entirely (clears stored secrets too)
-python3.11 -m src.cli source remove my_books
+python3.11 -m src.cli source remove my_steam
 ```
 
 All `source` subcommands except `set-secret` and `clear-secret` accept
 `--format json` for scripting parity with the web API:
 
 ```bash
-python3.11 -m src.cli source show goodreads --format json
-python3.11 -m src.cli source migrate goodreads --format json
+python3.11 -m src.cli source show steam --format json
+python3.11 -m src.cli source migrate steam --format json
 ```
 
 For atomic multi-field updates (the CLI equivalent of the web
 `PUT /api/sync/sources/<id>/config` bulk endpoint), use `source apply` with
-a JSON dict of values from a file or stdin. The example below uses
-`generic_csv` because it has both `path` and `content_type` in its schema —
-plugin-specific sources like `goodreads` only expose the fields their
-schema declares (run `python3.11 -m src.cli source schema <id>` to see them):
+a JSON dict of values from a file or stdin. The example below uses `sonarr`
+because it has several non-sensitive fields in its schema — run
+`python3.11 -m src.cli source schema <id>` to see what a given source exposes:
 
 ```bash
-echo '{"path": "inputs/new.csv", "content_type": "book"}' \
-  | python3.11 -m src.cli source apply my_csv --from-json -
+echo '{"url": "http://localhost:8989", "content_type": "tv_show"}' \
+  | python3.11 -m src.cli source apply my_sonarr --from-json -
 ```
 
 For non-interactive secret rotation (Docker entrypoints, CI), set

--- a/README.md
+++ b/README.md
@@ -108,17 +108,23 @@ features:
   embeddings_enabled: false
   llm_reasoning_enabled: false
 
-# Configure your data sources (see each source's setup guide for fields)
+# Configure your syncable data sources (see each source's setup guide for fields)
 inputs:
-  goodreads:
-    plugin: goodreads
-    path: "inputs/goodreads_library_export.csv"
+  steam:
+    plugin: steam
+    api_key: "your-steam-api-key"
+    steam_id: "your-steam-id"
     enabled: true
 
 # Conflict resolution when an item is imported from multiple sources
 ingestion:
   conflict_strategy: "last_write_wins"  # or "source_priority" or "keep_existing"
 ```
+
+Goodreads, CSV, JSON, and Markdown are one-shot **file imports**, not entries
+under `inputs:`. Upload the file from the web **Data** tab (**Import from file**)
+or run `python3.11 -m src.cli import --file <path>` — see
+[docs/DATA_SOURCES.md](docs/DATA_SOURCES.md#importing-from-a-file).
 
 `config/example.yaml` documents every option (scorer weights, sync workers,
 enrichment providers, conversation tuning). Scorer weights are explained in
@@ -135,7 +141,8 @@ merged additively.
 The CLI is a full peer to the web UI. A taste:
 
 ```bash
-python3.11 -m src.cli update --source all          # import everything
+python3.11 -m src.cli update --source all          # sync every configured source
+python3.11 -m src.cli import --source goodreads --file goodreads_export.csv  # one-shot file import
 python3.11 -m src.cli recommend --type book --count 10
 python3.11 -m src.cli library list --type book --status completed --sort rating
 python3.11 -m src.cli library list --search "die hard"   # fuzzy title/creator search

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -66,13 +66,11 @@ ingestion:
 # all subsequent edits go through the web UI / source CLI commands and
 # write to the source_configs / credentials tables. See the "Source
 # configuration precedence" section in ARCHITECTURE.md.
+# File imports (Goodreads, CSV, JSON, Markdown) are no longer configured here.
+# Upload the file in the web UI (Data tab) or run
+# `python3.11 -m src.cli import --file <path>` instead — there is no
+# persistent source to sync for one-shot file imports.
 inputs:
-  goodreads:
-    plugin: goodreads
-    path: "inputs/goodreads_library_export.csv"
-    content_type: "book"  # Content type for enrichment (book, movie, tv_show, video_game)
-    enabled: true
-
   steam:
     plugin: steam
     # Steam Web API configuration
@@ -107,27 +105,6 @@ inputs:
   epic_games:
     plugin: epic_games
     content_type: "video_game"
-    enabled: false
-
-  # Generic CSV import — use templates from templates/ directory
-  csv_movies:
-    plugin: csv_import
-    path: "inputs/my_movies.csv"  # Path to your CSV file
-    content_type: "movie"  # book, movie, tv_show, or video_game
-    enabled: false
-
-  # Generic JSON import — use templates from templates/ directory
-  json_books:
-    plugin: json_import
-    path: "inputs/my_books.json"  # Path to your JSON or JSONL file
-    content_type: "book"  # book, movie, tv_show, or video_game
-    enabled: false
-
-  # Generic Markdown import — use templates from templates/ directory
-  md_tv_shows:
-    plugin: markdown_import
-    path: "inputs/my_tv_shows.md"  # Path to your Markdown file
-    content_type: "tv_show"  # book, movie, tv_show, or video_game
     enabled: false
 
   # Sonarr integration (TV show library manager)
@@ -173,12 +150,8 @@ inputs:
     extra_strip_patterns: []
     enabled: false
 
-  # You can add multiple instances of the same plugin. For example:
-  # tv_shows_json:
-  #   plugin: json_import
-  #   path: "inputs/tv_shows.json"
-  #   content_type: "tv_show"
-  #   enabled: true
+  # You can add multiple instances of the same plugin. For example, two Sonarr
+  # servers under different keys, each with its own url/api_key.
 
 # Web interface configuration
 web:

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -48,7 +48,9 @@ ingestion:
   # Options: last_write_wins, source_priority, keep_existing
   conflict_strategy: "last_write_wins"
   # Source priority ordering (highest priority first).
-  # Only used with source_priority strategy.
+  # Only used with source_priority strategy. These are item source labels
+  # (the plugin/instance name stored on each item, e.g. file-imported Goodreads
+  # items are tagged "goodreads"), not the `inputs:` keys below.
   source_priority: ["goodreads", "steam"]
 
 # Input sources configuration

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,13 +7,13 @@ Commands are organized into groups.
 All commands are run as `python3.11 -m src.cli <command>`. Most read-only
 commands accept `--format json` for scripting.
 
-## Import & recommend
+## Sync & recommend
 
 ```bash
-# Import data
-python3.11 -m src.cli update --source goodreads
+# Sync data from configured (syncable) sources
 python3.11 -m src.cli update --source steam
 python3.11 -m src.cli update --source all
+python3.11 -m src.cli update --source list   # show configured sources
 
 # Get recommendations
 python3.11 -m src.cli recommend --type book --count 10
@@ -22,6 +22,42 @@ python3.11 -m src.cli recommend --type video_game --count 5
 # Mark content as completed
 python3.11 -m src.cli complete --type book --title "Project Hail Mary" --rating 5
 ```
+
+`update` drives the syncable sources (Steam, GOG, Epic, Sonarr, Radarr, ROM
+Library). One-shot file imports (Goodreads, CSV, JSON, Markdown) use the separate
+`import` command below.
+
+## Importing from a file
+
+The `import` command runs a single file through a file-import plugin — the CLI
+peer of the web **Data** tab's **Import from file** button (`POST /api/import`).
+It reads a real path off disk, runs the file through the ingestion pipeline,
+streams progress, prints the item counts, and exits non-zero on failure.
+
+```bash
+# Import a Goodreads CSV export (Goodreads takes no extra options)
+python3.11 -m src.cli import --source goodreads --file inputs/goodreads_library_export.csv
+
+# Import a generic CSV/JSON/Markdown file (content type is required for these)
+python3.11 -m src.cli import --source csv_import --file my_movies.csv --content-type movie
+python3.11 -m src.cli import --source json_import --file my_books.json --content-type book
+python3.11 -m src.cli import --source markdown_import --file my_shows.md --content-type tv_show
+
+# List importable sources and the options each one accepts
+python3.11 -m src.cli import --source list
+python3.11 -m src.cli import --source list --format json   # matches GET /api/import/sources
+```
+
+Flags:
+
+- `--source` — the file-import plugin name (`goodreads`, `csv_import`,
+  `json_import`, `markdown_import`), or `list` to show importable sources.
+- `--file` — path to the file to import (required unless `--source list`).
+- `--content-type` — `book`, `movie`, `tv_show`, or `video_game`; required by the
+  three generic formats, ignored by Goodreads.
+- `--option KEY=VALUE` — additional import option, repeatable (for plugin options
+  beyond `content-type`).
+- `--format table|json` — output format for `--source list`.
 
 ## System status
 
@@ -88,24 +124,27 @@ these marks the item enriched via the `manual` provider, so it drops out of the
 Add, edit, enable/disable, and remove data sources without editing YAML. Sources
 can live in YAML (bootstrap), in the database (created or migrated), or both.
 
+The `source` group manages syncable sources only — file imports (Goodreads, CSV,
+JSON, Markdown) have no persistent config and are handled by `import` above.
+
 ```bash
 # Create a brand-new source directly in the database (no YAML edit needed)
 python3.11 -m src.cli source plugins             # see what plugins are available
-python3.11 -m src.cli source create my_books goodreads
-python3.11 -m src.cli source set-secret my_books api_key   # add credentials
+python3.11 -m src.cli source create my_steam steam
+python3.11 -m src.cli source set-secret my_steam api_key   # add credentials
 
 # Move an existing YAML source into the database (one-time, idempotent)
-python3.11 -m src.cli source migrate goodreads
+python3.11 -m src.cli source migrate steam
 
 # Inspect / edit fields after migration or creation
-python3.11 -m src.cli source show goodreads
-python3.11 -m src.cli source schema goodreads           # list editable fields
-python3.11 -m src.cli source set goodreads path inputs/new_export.csv
-python3.11 -m src.cli source disable goodreads          # disabled sources are skipped during sync
-python3.11 -m src.cli source enable goodreads
+python3.11 -m src.cli source show steam
+python3.11 -m src.cli source schema steam               # list editable fields
+python3.11 -m src.cli source set steam vanity_url my-handle
+python3.11 -m src.cli source disable steam              # disabled sources are skipped during sync
+python3.11 -m src.cli source enable steam
 
 # Remove a DB-backed source entirely (clears stored secrets too)
-python3.11 -m src.cli source remove my_books
+python3.11 -m src.cli source remove my_steam
 ```
 
 All `source` subcommands except `set-secret` and `clear-secret` accept
@@ -114,8 +153,8 @@ updates (the CLI equivalent of `PUT /api/sync/sources/<id>/config`), use
 `source apply` with a JSON dict from a file or stdin:
 
 ```bash
-echo '{"path": "inputs/new.csv", "content_type": "book"}' \
-  | python3.11 -m src.cli source apply my_csv --from-json -
+echo '{"url": "http://localhost:8989", "content_type": "tv_show"}' \
+  | python3.11 -m src.cli source apply my_sonarr --from-json -
 ```
 
 For non-interactive secret rotation (Docker entrypoints, CI), set

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -34,6 +34,10 @@ peer of the web **Data** tab's **Import from file** button (`POST /api/import`).
 It reads a real path off disk, runs the file through the ingestion pipeline,
 streams progress, prints the item counts, and exits non-zero on failure.
 
+The CLI reads local files directly with no size cap. The web upload is capped
+at 50 MB — files over the cap are rejected with HTTP 413. The cap applies only
+to the web upload, not the CLI.
+
 ```bash
 # Import a Goodreads CSV export (Goodreads takes no extra options)
 python3.11 -m src.cli import --source goodreads --file inputs/goodreads_library_export.csv
@@ -57,7 +61,9 @@ Flags:
   three generic formats, ignored by Goodreads.
 - `--option KEY=VALUE` — additional import option, repeatable (for plugin options
   beyond `content-type`).
-- `--format table|json` — output format for `--source list`.
+- `--format table|json` — output format (default `table`) for both the source
+  listing (`--source list`) and the final import result. In `json`, an import
+  emits `{message, source, items_synced, total_items, errors}`.
 
 ## System status
 

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -47,7 +47,9 @@ Sonarr, Radarr, ROM Library) are configured once and synced repeatedly. See
 source, choose the file, and set any options the source needs — the three generic
 formats require a `content_type` (book, movie, tv_show, or video_game); Goodreads
 takes no options because it is always books. Submit to import. The import is
-tracked as a job, so progress shows in the same place as a sync.
+tracked as a job, so progress shows in the same place as a sync. Web uploads are
+capped at 50 MB — files over the cap are rejected with HTTP 413. (The CLI reads
+local files directly with no size cap.)
 
 **CLI:** use the `import` command — see
 [CLI.md](CLI.md#importing-from-a-file). For example:

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -25,6 +25,39 @@ Import file examples live in the `templates/` directory. Templates support the
 use a `seasons_watched` list (e.g., `1,2,5,6` in CSV or `[1,2,5,6]` in JSON) to
 track specific seasons watched.
 
+**Goodreads, CSV, JSON, and Markdown are one-shot file imports, not syncable
+sources.** You hand the file to the app once — through the web **Data** tab's
+**Import from file** button or the CLI `import --file` command — and it runs
+through the ingestion pipeline immediately. There is nothing to configure under
+`inputs:` and nothing to re-sync. The remaining sources (Steam, GOG, Epic,
+Sonarr, Radarr, ROM Library) are configured once and synced repeatedly. See
+[Importing from a file](#importing-from-a-file) below.
+
+## Importing from a file
+
+> **Breaking change:** the path-based YAML config for the Goodreads, CSV
+> (`csv_import`), JSON (`json_import`), and Markdown (`markdown_import`) sources
+> has been removed. They no longer appear under `inputs:` and are not listed as
+> syncable sources. A leftover `inputs:` block for one of them logs a non-fatal
+> warning at startup and is skipped. Import those files through the web upload or
+> the CLI `import --file` flag instead. (ROM Library still scans directories and
+> is configured the old way.)
+
+**Web UI:** open the **Data** tab and click **Import from file**. Pick the
+source, choose the file, and set any options the source needs — the three generic
+formats require a `content_type` (book, movie, tv_show, or video_game); Goodreads
+takes no options because it is always books. Submit to import. The import is
+tracked as a job, so progress shows in the same place as a sync.
+
+**CLI:** use the `import` command — see
+[CLI.md](CLI.md#importing-from-a-file). For example:
+
+```bash
+python3.11 -m src.cli import --source goodreads --file inputs/goodreads_library_export.csv
+python3.11 -m src.cli import --source csv_import --file my_movies.csv --content-type movie
+python3.11 -m src.cli import --source list   # show importable sources and their options
+```
+
 ## Adding, editing, and removing sources in the UI
 
 The **Data** tab renders every configured source as an accordion. Both enabled
@@ -43,13 +76,15 @@ There are two ways to create a source:
   in the source's expanded panel to copy the YAML entry into the database. After
   migration the YAML entry is ignored — all edits go through the UI.
 
+This applies to syncable sources only — the file-import sources (Goodreads, CSV,
+JSON, Markdown) are not configured here; see [Importing from a file](#importing-from-a-file).
+
 Once a source is in the database, every field defined in its plugin's config
 schema is editable inline from the web UI or via the
 `python3.11 -m src.cli source` CLI commands. The exact set of fields differs per
-plugin (e.g. Steam exposes `api_key` and `vanity_url`; Goodreads exposes `path`);
-the generic CSV / JSON / Markdown plugins also expose `content_type`. Run
-`python3.11 -m src.cli source schema <id>` to see what is editable for a given
-source.
+plugin (e.g. Steam exposes `api_key` and `vanity_url`; Sonarr exposes `url` and
+`api_key`). Run `python3.11 -m src.cli source schema <id>` to see what is editable
+for a given source.
 
 Each source has an Enable/Disable toggle in its action row. Disabled sources stay
 in the list but are skipped during sync — `Sync All` and the per-source Sync
@@ -93,8 +128,10 @@ Export your library data from the web UI:
 4. Click **Export** to download.
 
 Exported files match the import template format, so you can edit them (e.g., mark
-items as `ignored`, update `seasons_watched`) and re-import via CSV or JSON sync.
-The CLI equivalent is `python3.11 -m src.cli library export` — see [CLI.md](CLI.md#library-management).
+items as `ignored`, update `seasons_watched`) and re-import via the CSV or JSON
+file import (web **Import from file** button or `import --file`). The CLI
+equivalent of export is `python3.11 -m src.cli library export` — see
+[CLI.md](CLI.md#library-management).
 
 ## Credential storage
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -104,7 +104,7 @@ volume entry — the application is happy without it.
 |----------------|------|---------|
 | `/app/config` | `rw` | Configuration. Container creates `config.yaml` from `example.yaml` on first run if missing; never overwrites an existing file. **Edit `./config/config.yaml` on the host.** |
 | `/app/data` | `rw` | SQLite database, ChromaDB vectors (AI variant), credential keys, cache. Backed by your host filesystem so it survives container restarts and updates. |
-| `/app/inputs` | `ro` | Source files for ingestion plugins (e.g., `goodreads_library_export.csv`). Read-only because the app shouldn't be modifying your exports. |
+| `/app/inputs` | `ro` | Files for CLI file imports (e.g., `goodreads_library_export.csv` for `import --file /app/inputs/...`). Read-only because the app shouldn't be modifying your exports. Web uploads via the **Import from file** button don't need this mount. |
 | `/app/private` | `ro` | Optional. Private/personal plugin code (gitignored from the repo). Leave the host directory empty if you don't have any. |
 
 ### Ports

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -336,28 +336,30 @@ python3.11 -m src.cli update --help  # Should show your source in the list
 
 ## Configuration Format
 
-Each input source in `config.yaml` uses a **named instance** model. The config key is a user-defined name, and the `plugin:` field specifies which plugin to use. This allows multiple instances of the same plugin:
+Each **syncable** source in `config.yaml` uses a **named instance** model. The config key is a user-defined name, and the `plugin:` field specifies which plugin to use. This allows multiple instances of the same plugin:
 
 ```yaml
 inputs:
-  # User-defined name "my_books" using the csv_import plugin
-  my_books:
-    plugin: csv_import
-    path: "inputs/books.csv"
-    content_type: "book"
+  # User-defined name "shows_main" using the sonarr plugin
+  shows_main:
+    plugin: sonarr
+    url: "http://localhost:8989"
+    content_type: "tv_show"
     enabled: true
 
-  # A second instance of csv_import with a different name
-  classic_movies:
-    plugin: csv_import
-    path: "inputs/classic_movies.csv"
-    content_type: "movie"
+  # A second instance of sonarr with a different name
+  shows_anime:
+    plugin: sonarr
+    url: "http://localhost:8990"
+    content_type: "tv_show"
     enabled: true
 ```
 
-File-based plugins use a standardized `path` field (not `csv_path`, `json_path`, or `markdown_path`).
-
 When your plugin's `fetch()` method is called, the config dict includes a `_source_id` key containing the user-defined name. The base class method `get_source_identifier(config)` returns this value, which is stored in `ContentItem.source`. This means items are tracked by user-defined name, not plugin name.
+
+### One-shot file-import plugins
+
+A plugin that imports a single user-supplied file (rather than syncing a persistent source) overrides `is_file_import` to return `True`. File-import plugins are **not** configured under `inputs:` — the file is supplied at invocation time (a web upload or the CLI `import --file` flag) and run through the ingestion pipeline once by `src/ingestion/import_service.py`. `resolve_inputs` skips them so they never appear as syncable sources, and they are listed via `GET /api/import/sources` / `import --source list` instead. The file path is injected by the import service as the config `path` key, so the plugin's `fetch()` reads `config["path"]`; declare any other per-import options (e.g. `content_type`) in `get_config_schema()` and the upload form / CLI will collect them. The bundled Goodreads, CSV, JSON, and Markdown plugins work this way.
 
 ## Testing Your Plugin
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "fastapi>=0.104.0,<1.0.0",
     "uvicorn[standard]>=0.24.0,<1.0.0",
     "click>=8.1.0,<9.0.0",
+    "python-multipart>=0.0.9,<1.0.0",
     "tabulate>=0.9.0,<1.0.0",
     "pandas>=2.0.0,<3.0.0",
     "python-dotenv>=1.0.0,<2.0.0",

--- a/resources/js/components/organisms/ImportFileModal.test.ts
+++ b/resources/js/components/organisms/ImportFileModal.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import ImportFileModal from './ImportFileModal.vue'
+import { useDataStore } from '@/stores/data'
+import { ApiError } from '@/composables/useApi'
+import type { ImportResultResponse, ImportSourceResponse } from '@/types/api'
+
+const csvSource: ImportSourceResponse = {
+  name: 'csv_import',
+  display_name: 'CSV Import',
+  description: 'Import a generic CSV file.',
+  content_types: ['book', 'movie', 'tv_show', 'video_game'],
+  fields: [
+    {
+      name: 'content_type',
+      field_type: 'str',
+      required: true,
+      default: 'book',
+      description: 'Content type for the imported rows.',
+      sensitive: false,
+    },
+  ],
+}
+
+const goodreadsSource: ImportSourceResponse = {
+  name: 'goodreads',
+  display_name: 'Goodreads',
+  description: 'Import a Goodreads CSV export.',
+  content_types: ['book'],
+  fields: [],
+}
+
+const jsonSource: ImportSourceResponse = {
+  name: 'json_import',
+  display_name: 'JSON Import',
+  description: 'Import a generic JSON file.',
+  content_types: ['book', 'movie'],
+  fields: [
+    {
+      name: 'content_type',
+      field_type: 'str',
+      required: true,
+      default: 'book',
+      description: 'Content type for the imported items.',
+      sensitive: false,
+    },
+  ],
+}
+
+function importResult(
+  overrides: Partial<ImportResultResponse> = {},
+): ImportResultResponse {
+  return {
+    message: 'Imported 2 item(s) from CSV Import.',
+    source: 'Import: CSV Import',
+    items_synced: 2,
+    total_items: 2,
+    errors: [],
+    ...overrides,
+  }
+}
+
+// The component loads import sources in onMounted, so the store must be primed
+// (and any runImport spy installed) BEFORE mounting.
+async function setup(sources: ImportSourceResponse[]) {
+  const store = useDataStore()
+  const load = vi
+    .spyOn(store, 'loadImportSources')
+    .mockImplementation(async () => {
+      store.importSources = sources
+      return sources
+    })
+  const wrapper = mount(ImportFileModal, { attachTo: document.body })
+  await flushPromises()
+  return { wrapper, store, load }
+}
+
+function setFile(
+  wrapper: ReturnType<typeof mount>,
+  name = 'books.csv',
+  type = 'text/csv',
+): File {
+  const input = wrapper.find('#import-file').element as HTMLInputElement
+  const file = new File(['title,author\nDune,Herbert'], name, { type })
+  Object.defineProperty(input, 'files', { value: [file], configurable: true })
+  wrapper.find('#import-file').trigger('change')
+  return file
+}
+
+describe('ImportFileModal', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('loads import sources on mount and renders them as options', async () => {
+    const { wrapper, load } = await setup([csvSource, goodreadsSource])
+
+    expect(load).toHaveBeenCalledTimes(1)
+    const options = wrapper.findAll('#import-source option')
+    expect(options).toHaveLength(2)
+    expect(options[0].text()).toBe('CSV Import')
+    expect(options[1].text()).toBe('Goodreads')
+    wrapper.unmount()
+  })
+
+  it('renders a content_type select for a generic format, intersected with content_types', async () => {
+    const { wrapper } = await setup([jsonSource])
+
+    const select = wrapper.find('#import-field-content_type')
+    expect(select.exists()).toBe(true)
+    const labels = select.findAll('option').map((o) => o.text())
+    // jsonSource only allows book + movie — tv_show / game must not appear.
+    expect(labels).toEqual(['Book', 'Movie'])
+    wrapper.unmount()
+  })
+
+  it('renders no option field for a source with an empty schema (Goodreads)', async () => {
+    const { wrapper } = await setup([goodreadsSource])
+
+    expect(wrapper.find('#import-field-content_type').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('keeps Import disabled until a file is chosen and required fields are filled', async () => {
+    const { wrapper } = await setup([csvSource])
+
+    const submit = wrapper.find('[data-testid="import-submit"]')
+    expect(submit.attributes('disabled')).toBeDefined()
+    expect(wrapper.text()).toContain('Choose a file to import.')
+
+    setFile(wrapper)
+    await flushPromises()
+
+    // content_type defaults to 'book', so once the file is chosen the
+    // required field is already satisfied and Import enables.
+    expect(submit.attributes('disabled')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('disables Import while another job is running', async () => {
+    const { wrapper, store } = await setup([csvSource])
+    setFile(wrapper)
+    store.syncStatus = 'running'
+    await flushPromises()
+
+    const submit = wrapper.find('[data-testid="import-submit"]')
+    expect(submit.attributes('disabled')).toBeDefined()
+    expect(wrapper.text()).toContain('Wait for the running job to finish')
+    wrapper.unmount()
+  })
+
+  it('submits the selected source, file, and option values to runImport', async () => {
+    const { wrapper, store } = await setup([csvSource])
+    const run = vi.spyOn(store, 'runImport').mockResolvedValue(importResult())
+
+    const file = setFile(wrapper)
+    await flushPromises()
+    await wrapper.find('[data-testid="import-submit"]').trigger('click')
+    await flushPromises()
+
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(run.mock.calls[0][0]).toBe('csv_import')
+    expect(run.mock.calls[0][1]).toBe(file)
+    expect(run.mock.calls[0][2]).toEqual({ content_type: 'book' })
+    wrapper.unmount()
+  })
+
+  it('shows the success banner with counts and a Done button after a successful import', async () => {
+    const { wrapper, store } = await setup([csvSource])
+    vi.spyOn(store, 'runImport').mockResolvedValue(
+      importResult({ items_synced: 5, total_items: 6 }),
+    )
+    setFile(wrapper)
+    await flushPromises()
+    await wrapper.find('[data-testid="import-submit"]').trigger('click')
+    await flushPromises()
+
+    const banner = wrapper.find('.sync-status-success')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain('Imported 5 of 6 items.')
+    expect(wrapper.find('[data-testid="import-done"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="import-submit"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders per-item errors in a disclosure when the import skips rows', async () => {
+    const { wrapper, store } = await setup([csvSource])
+    vi.spyOn(store, 'runImport').mockResolvedValue(
+      importResult({
+        items_synced: 1,
+        total_items: 3,
+        errors: ['Row 2: missing title', 'Row 3: bad rating'],
+      }),
+    )
+    setFile(wrapper)
+    await flushPromises()
+    await wrapper.find('[data-testid="import-submit"]').trigger('click')
+    await flushPromises()
+
+    const details = wrapper.find('details.import-modal-errors')
+    expect(details.exists()).toBe(true)
+    expect(details.find('summary').text()).toBe('2 rows skipped')
+    const items = details.findAll('li')
+    expect(items).toHaveLength(2)
+    expect(items[0].text()).toBe('Row 2: missing title')
+    wrapper.unmount()
+  })
+
+  it.each([
+    [422, "That import source isn't available."],
+    [400, "We couldn't read that file."],
+    [409, 'An import or sync is already running.'],
+  ])('maps a %i error to its banner message', async (status, expected) => {
+    const { wrapper, store } = await setup([csvSource])
+    vi.spyOn(store, 'runImport').mockRejectedValue(new ApiError(status, 'err'))
+    setFile(wrapper)
+    await flushPromises()
+    await wrapper.find('[data-testid="import-submit"]').trigger('click')
+    await flushPromises()
+
+    const banner = wrapper.find('.sync-status-error')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain(expected)
+    expect(banner.attributes('role')).toBe('alert')
+    expect(banner.attributes('aria-live')).toBe('assertive')
+    // A 400 must keep the form populated so the user can retry.
+    expect(wrapper.find('#import-file').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('surfaces a load failure in the result banner', async () => {
+    const store = useDataStore()
+    vi.spyOn(store, 'loadImportSources').mockRejectedValue(
+      new Error('network down'),
+    )
+    const wrapper = mount(ImportFileModal, { attachTo: document.body })
+    await flushPromises()
+
+    const banner = wrapper.find('.sync-status-error')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain("Couldn't load import sources")
+    wrapper.unmount()
+  })
+
+  it('wires the dialog role, labelledby, and labelled controls for a11y', async () => {
+    const { wrapper } = await setup([csvSource])
+
+    const dialog = wrapper.find('[role="dialog"]')
+    expect(dialog.attributes('aria-modal')).toBe('true')
+    expect(dialog.attributes('aria-labelledby')).toBe('import-modal-title')
+    expect(wrapper.find('#import-modal-title').text()).toBe('Import from file')
+    expect(wrapper.find('label[for="import-source"]').exists()).toBe(true)
+    expect(wrapper.find('label[for="import-file"]').exists()).toBe(true)
+    expect(
+      wrapper.find('label[for="import-field-content_type"]').exists(),
+    ).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('Escape key emits close', async () => {
+    const { wrapper } = await setup([csvSource])
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(wrapper.emitted('close')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  it('backdrop click emits close', async () => {
+    const { wrapper } = await setup([csvSource])
+
+    await wrapper.find('.import-modal').trigger('click')
+    expect(wrapper.emitted('close')).toBeTruthy()
+    wrapper.unmount()
+  })
+})

--- a/resources/js/components/organisms/ImportFileModal.test.ts
+++ b/resources/js/components/organisms/ImportFileModal.test.ts
@@ -179,8 +179,27 @@ describe('ImportFileModal', () => {
     const banner = wrapper.find('.sync-status-success')
     expect(banner.exists()).toBe(true)
     expect(banner.text()).toContain('Imported 5 of 6 items.')
+    // Success/progress live on a fixed polite-status node, separate from errors.
+    expect(banner.attributes('role')).toBe('status')
+    expect(banner.attributes('aria-live')).toBe('polite')
     expect(wrapper.find('[data-testid="import-done"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="import-submit"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('moves focus to the Done button after a successful import', async () => {
+    // The Import button is removed when the result arrives; focus must follow
+    // to Done so keyboard users stay inside the trap rather than dropping to
+    // <body> (WCAG 2.4.3).
+    const { wrapper, store } = await setup([csvSource])
+    vi.spyOn(store, 'runImport').mockResolvedValue(importResult())
+    setFile(wrapper)
+    await flushPromises()
+    await wrapper.find('[data-testid="import-submit"]').trigger('click')
+    await flushPromises()
+
+    const done = wrapper.find('[data-testid="import-done"]').element
+    expect(document.activeElement).toBe(done)
     wrapper.unmount()
   })
 
@@ -226,6 +245,23 @@ describe('ImportFileModal', () => {
     expect(banner.attributes('aria-live')).toBe('assertive')
     // A 400 must keep the form populated so the user can retry.
     expect(wrapper.find('#import-file').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('shows a generic error banner when runImport throws a non-ApiError', async () => {
+    const { wrapper, store } = await setup([csvSource])
+    vi.spyOn(store, 'runImport').mockRejectedValue(new Error('boom'))
+    setFile(wrapper)
+    await flushPromises()
+    await wrapper.find('[data-testid="import-submit"]').trigger('click')
+    await flushPromises()
+
+    const banner = wrapper.find('.sync-status-error')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain('Something went wrong during the import.')
+    // The error lives on its own fixed-role node so AT re-announces it.
+    expect(banner.attributes('role')).toBe('alert')
+    expect(banner.attributes('aria-live')).toBe('assertive')
     wrapper.unmount()
   })
 

--- a/resources/js/components/organisms/ImportFileModal.vue
+++ b/resources/js/components/organisms/ImportFileModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useFocusTrap } from '@/composables/useFocusTrap'
 import { ApiError } from '@/composables/useApi'
 import { useDataStore } from '@/stores/data'
@@ -7,13 +7,14 @@ import { truncate } from '@/utils/format'
 import { CONTENT_TYPE_OPTIONS } from '@/constants/contentTypes'
 import type { ImportResultResponse, ImportSourceResponse } from '@/types/api'
 
-const data = useDataStore()
-const modalContent = ref<HTMLElement | null>(null)
-useFocusTrap(modalContent, () => emit('close'))
-
 const emit = defineEmits<{
   close: []
 }>()
+
+const data = useDataStore()
+const modalContent = ref<HTMLElement | null>(null)
+const doneButton = ref<HTMLButtonElement | null>(null)
+useFocusTrap(modalContent, () => emit('close'))
 
 const sourceName = ref<string>('')
 const file = ref<File | null>(null)
@@ -61,6 +62,17 @@ watch(sourceName, () => {
   resultError.value = ''
 })
 
+// When the result banner arrives it swaps the Cancel/Import buttons for a
+// single Done button, so the focused Import button leaves the DOM and focus
+// would fall to <body>, escaping the trap. Move focus to Done (or the dialog
+// container as a fallback) to keep keyboard users inside the modal (WCAG 2.4.3).
+watch(result, (value) => {
+  if (!value) return
+  void nextTick(() => {
+    ;(doneButton.value ?? modalContent.value)?.focus()
+  })
+})
+
 const contentTypeOptions = computed(() => {
   const allowed = new Set(selectedSource.value?.content_types ?? [])
   return CONTENT_TYPE_OPTIONS.filter(
@@ -68,6 +80,9 @@ const contentTypeOptions = computed(() => {
   )
 })
 
+// The four controlled import plugins encode their format in the plugin name
+// (csv_import, json_import, markdown_import, goodreads → CSV), so we infer the
+// accepted file types from the name rather than widening the API contract.
 const importFormat = computed<'csv' | 'json' | 'markdown'>(() => {
   const name = selectedSource.value?.name ?? ''
   if (name.includes('json')) return 'json'
@@ -104,8 +119,10 @@ const requiredFilled = computed(() =>
   ),
 )
 
-// A sync or import job already running blocks a new import (the server
-// returns 409); disable Import up front rather than letting the request fail.
+// Conservative client-side gate: while ANY sync or import job is running we
+// disable Import to serialize all imports for a simpler UX. This is broader
+// than the server, which only returns 409 when an import with this same label
+// is already running — we intentionally block more to avoid surprising the user.
 const anyJobRunning = computed(() => data.syncStatus === 'running')
 
 const canSubmit = computed(
@@ -151,10 +168,6 @@ const successCounts = computed(() =>
 const skippedCount = computed(() => result.value?.errors.length ?? 0)
 const skippedSummary = computed(
   () => `${skippedCount.value} row${skippedCount.value === 1 ? '' : 's'} skipped`,
-)
-
-const bannerVisible = computed(
-  () => !!resultError.value || !!result.value || submitting.value,
 )
 
 function onFileChange(event: Event): void {
@@ -222,6 +235,7 @@ async function submit(): Promise<void> {
           id="import-source"
           v-model="sourceName"
           :disabled="submitting"
+          :aria-describedby="selectedSource ? 'import-source-desc' : undefined"
         >
           <option
             v-for="source in data.importSources"
@@ -229,7 +243,7 @@ async function submit(): Promise<void> {
             :value="source.name"
           >{{ source.display_name }}</option>
         </select>
-        <p v-if="selectedSource" class="help-text">
+        <p v-if="selectedSource" id="import-source-desc" class="help-text">
           {{ selectedSource.description }}
         </p>
       </div>
@@ -241,9 +255,10 @@ async function submit(): Promise<void> {
           type="file"
           :accept="acceptAttr"
           :disabled="submitting"
+          aria-describedby="import-file-accepted"
           @change="onFileChange"
         />
-        <p class="help-text">{{ acceptedExtensionsText }}</p>
+        <p id="import-file-accepted" class="help-text">{{ acceptedExtensionsText }}</p>
         <p v-if="file" class="help-text">Selected file: {{ file.name }}</p>
       </div>
 
@@ -334,24 +349,30 @@ async function submit(): Promise<void> {
       </div>
 
       <!--
-        Single banner kept mounted via v-show so assistive tech announces the
-        text change. Error uses an assertive alert; info/success are polite.
+        Two banners with FIXED roles, both kept mounted via v-show. Assistive
+        tech may not re-read a node whose role flips, so errors and progress/
+        success live in separate elements (WCAG 4.1.3). Each signals state with
+        text + an icon, never colour alone.
       -->
       <div
-        v-show="bannerVisible"
+        v-show="resultError"
+        class="sync-status-message sync-status-error"
+        role="alert"
+        aria-live="assertive"
+      >
+        <span aria-hidden="true">⚠ </span>{{ resultError }}
+      </div>
+      <div
+        v-show="(result && !resultError) || (submitting && !result)"
         class="sync-status-message"
-        :role="resultError ? 'alert' : 'status'"
-        :aria-live="resultError ? 'assertive' : 'polite'"
+        role="status"
+        aria-live="polite"
         :class="{
-          'sync-status-error': resultError,
           'sync-status-success': result && !resultError,
           'sync-status-info': submitting && !result && !resultError,
         }"
       >
-        <template v-if="resultError">
-          <span aria-hidden="true">⚠ </span>{{ resultError }}
-        </template>
-        <template v-else-if="result">
+        <template v-if="result && !resultError">
           <span aria-hidden="true">✓ </span>{{ result.message }} {{ successCounts }}
         </template>
         <template v-else-if="submitting">Importing…</template>
@@ -368,13 +389,15 @@ async function submit(): Promise<void> {
       </details>
 
       <p
-        v-if="!result && !submitting && disabledReason"
+        v-show="!result && !submitting && disabledReason"
+        id="import-disabled-reason"
         class="help-text"
       >{{ disabledReason }}</p>
 
       <div class="import-modal-actions">
         <template v-if="result">
           <button
+            ref="doneButton"
             type="button"
             class="btn btn-primary"
             data-testid="import-done"
@@ -393,6 +416,7 @@ async function submit(): Promise<void> {
             class="btn btn-primary"
             data-testid="import-submit"
             :disabled="!canSubmit"
+            :aria-describedby="disabledReason ? 'import-disabled-reason' : undefined"
             @click="submit"
           >{{ submitting ? 'Importing…' : 'Import' }}</button>
         </template>

--- a/resources/js/components/organisms/ImportFileModal.vue
+++ b/resources/js/components/organisms/ImportFileModal.vue
@@ -1,0 +1,514 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+import { ApiError } from '@/composables/useApi'
+import { useDataStore } from '@/stores/data'
+import { truncate } from '@/utils/format'
+import { CONTENT_TYPE_OPTIONS } from '@/constants/contentTypes'
+import type { ImportResultResponse, ImportSourceResponse } from '@/types/api'
+
+const data = useDataStore()
+const modalContent = ref<HTMLElement | null>(null)
+useFocusTrap(modalContent, () => emit('close'))
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const sourceName = ref<string>('')
+const file = ref<File | null>(null)
+const fieldValues = ref<Record<string, string>>({})
+const submitting = ref(false)
+const result = ref<ImportResultResponse | null>(null)
+const resultError = ref('')
+
+onMounted(async () => {
+  try {
+    await data.loadImportSources()
+  } catch (err) {
+    resultError.value =
+      err instanceof Error
+        ? `Couldn't load import sources: ${err.message}`
+        : "Couldn't load import sources."
+    return
+  }
+  if (data.importSources.length > 0 && !sourceName.value) {
+    sourceName.value = data.importSources[0].name
+  }
+})
+
+const selectedSource = computed<ImportSourceResponse | undefined>(() =>
+  data.importSources.find((s) => s.name === sourceName.value),
+)
+
+const visibleFields = computed(() =>
+  selectedSource.value
+    ? selectedSource.value.fields.filter((f) => !f.sensitive)
+    : [],
+)
+
+// Re-seed option defaults and clear any stale file/banner whenever the user
+// picks a different source — the accepted file types and option schema both
+// change with the source.
+watch(sourceName, () => {
+  const next: Record<string, string> = {}
+  for (const field of visibleFields.value) {
+    next[field.name] = field.default != null ? String(field.default) : ''
+  }
+  fieldValues.value = next
+  file.value = null
+  result.value = null
+  resultError.value = ''
+})
+
+const contentTypeOptions = computed(() => {
+  const allowed = new Set(selectedSource.value?.content_types ?? [])
+  return CONTENT_TYPE_OPTIONS.filter(
+    (option) => option.value !== '' && allowed.has(option.value),
+  )
+})
+
+const importFormat = computed<'csv' | 'json' | 'markdown'>(() => {
+  const name = selectedSource.value?.name ?? ''
+  if (name.includes('json')) return 'json'
+  if (name.includes('markdown')) return 'markdown'
+  return 'csv'
+})
+
+const acceptAttr = computed(() => {
+  switch (importFormat.value) {
+    case 'json':
+      return '.json,application/json'
+    case 'markdown':
+      return '.md,.markdown,text/markdown'
+    default:
+      return '.csv,text/csv'
+  }
+})
+
+const acceptedExtensionsText = computed(() => {
+  switch (importFormat.value) {
+    case 'json':
+      return 'Accepted file type: .json'
+    case 'markdown':
+      return 'Accepted file types: .md, .markdown'
+    default:
+      return 'Accepted file type: .csv'
+  }
+})
+
+const requiredFilled = computed(() =>
+  visibleFields.value.every(
+    (field) =>
+      !field.required || (fieldValues.value[field.name] ?? '') !== '',
+  ),
+)
+
+// A sync or import job already running blocks a new import (the server
+// returns 409); disable Import up front rather than letting the request fail.
+const anyJobRunning = computed(() => data.syncStatus === 'running')
+
+const canSubmit = computed(
+  () =>
+    !!file.value &&
+    requiredFilled.value &&
+    !submitting.value &&
+    !anyJobRunning.value,
+)
+
+const disabledReason = computed(() => {
+  if (!file.value) return 'Choose a file to import.'
+  if (!requiredFilled.value) return 'Fill in all required fields.'
+  if (anyJobRunning.value) {
+    return 'Wait for the running job to finish, then try again.'
+  }
+  return ''
+})
+
+const importJob = computed(() =>
+  selectedSource.value
+    ? data.jobForLabel(`Import: ${selectedSource.value.display_name}`)
+    : null,
+)
+
+const progressLabel = computed(() => {
+  const job = importJob.value
+  if (!job) return ''
+  if (job.total_items != null && job.total_items > 0) {
+    const pct =
+      job.progress_percent != null ? ` (${job.progress_percent}%)` : ''
+    return `${job.items_processed}/${job.total_items}${pct}`
+  }
+  return `${job.items_processed} items so far`
+})
+
+const successCounts = computed(() =>
+  result.value
+    ? `Imported ${result.value.items_synced} of ${result.value.total_items} items.`
+    : '',
+)
+
+const skippedCount = computed(() => result.value?.errors.length ?? 0)
+const skippedSummary = computed(
+  () => `${skippedCount.value} row${skippedCount.value === 1 ? '' : 's'} skipped`,
+)
+
+const bannerVisible = computed(
+  () => !!resultError.value || !!result.value || submitting.value,
+)
+
+function onFileChange(event: Event): void {
+  const input = event.target as HTMLInputElement
+  file.value = input.files && input.files.length > 0 ? input.files[0] : null
+}
+
+function messageForStatus(status: number): string {
+  if (status === 422) {
+    return "That import source isn't available. Pick another format."
+  }
+  if (status === 400) {
+    return "We couldn't read that file. Check that it matches the selected format and try again."
+  }
+  if (status === 409) {
+    return 'An import or sync is already running. Wait for it to finish, then try again.'
+  }
+  return 'Something went wrong during the import. Please try again.'
+}
+
+async function submit(): Promise<void> {
+  const source = selectedSource.value
+  if (!source || !file.value || !canSubmit.value) return
+  resultError.value = ''
+  result.value = null
+  submitting.value = true
+  const options: Record<string, string> = {}
+  for (const field of visibleFields.value) {
+    const value = fieldValues.value[field.name]
+    if (value !== undefined && value !== '') options[field.name] = value
+  }
+  try {
+    result.value = await data.runImport(source.name, file.value, options)
+  } catch (err) {
+    result.value = null
+    resultError.value =
+      err instanceof ApiError
+        ? messageForStatus(err.status)
+        : 'Something went wrong during the import. Please try again.'
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="import-modal" @click.self="emit('close')">
+    <div
+      ref="modalContent"
+      class="import-modal-content"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="import-modal-title"
+      tabindex="-1"
+    >
+      <h3 id="import-modal-title">Import from file</h3>
+      <p class="help-text">
+        Upload an export to add items in one shot. Supported formats are CSV,
+        JSON, and Markdown, plus Goodreads CSV exports.
+      </p>
+
+      <div class="import-modal-field">
+        <label for="import-source">Source</label>
+        <select
+          id="import-source"
+          v-model="sourceName"
+          :disabled="submitting"
+        >
+          <option
+            v-for="source in data.importSources"
+            :key="source.name"
+            :value="source.name"
+          >{{ source.display_name }}</option>
+        </select>
+        <p v-if="selectedSource" class="help-text">
+          {{ selectedSource.description }}
+        </p>
+      </div>
+
+      <div class="import-modal-field">
+        <label for="import-file">File</label>
+        <input
+          id="import-file"
+          type="file"
+          :accept="acceptAttr"
+          :disabled="submitting"
+          @change="onFileChange"
+        />
+        <p class="help-text">{{ acceptedExtensionsText }}</p>
+        <p v-if="file" class="help-text">Selected file: {{ file.name }}</p>
+      </div>
+
+      <div
+        v-for="field in visibleFields"
+        :key="field.name"
+        class="import-modal-field"
+      >
+        <label :for="`import-field-${field.name}`">
+          {{ field.name }}
+          <span v-if="field.required" aria-hidden="true">*</span>
+        </label>
+        <select
+          v-if="field.name === 'content_type'"
+          :id="`import-field-${field.name}`"
+          v-model="fieldValues[field.name]"
+          :required="field.required"
+          :disabled="submitting"
+        >
+          <option v-if="!field.required" value="">— default —</option>
+          <option
+            v-for="option in contentTypeOptions"
+            :key="option.value"
+            :value="option.value"
+          >{{ option.label }}</option>
+        </select>
+        <select
+          v-else-if="field.field_type === 'bool'"
+          :id="`import-field-${field.name}`"
+          v-model="fieldValues[field.name]"
+          :required="field.required"
+          :disabled="submitting"
+        >
+          <option value="">— default —</option>
+          <option value="true">true</option>
+          <option value="false">false</option>
+        </select>
+        <input
+          v-else
+          :id="`import-field-${field.name}`"
+          v-model="fieldValues[field.name]"
+          :type="
+            field.field_type === 'int' || field.field_type === 'float'
+              ? 'number'
+              : 'text'
+          "
+          :step="field.field_type === 'float' ? 'any' : '1'"
+          :required="field.required"
+          :disabled="submitting"
+          :placeholder="
+            field.field_type === 'list' ? 'comma,separated,values' : ''
+          "
+        />
+        <p v-if="field.description" class="help-text">{{ field.description }}</p>
+      </div>
+
+      <!--
+        v-show (not v-if) keeps the live progress region in the DOM while the
+        import runs so screen readers announce updates rather than treating
+        each poll as a fresh insertion (WCAG 4.1.3).
+      -->
+      <div
+        v-show="submitting"
+        class="import-modal-progress-region"
+        aria-live="polite"
+      >
+        <div v-if="importJob" class="import-modal-progress">
+          <span
+            v-if="importJob.progress_percent != null && importJob.total_items"
+            class="import-modal-progress-bar"
+            role="progressbar"
+            :aria-valuenow="importJob.progress_percent"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            :aria-label="`Import progress: ${importJob.progress_percent}%`"
+          >
+            <span
+              class="import-modal-progress-fill"
+              :style="{ width: `${Math.min(100, importJob.progress_percent)}%` }"
+            />
+          </span>
+          <span class="import-modal-progress-counts">{{ progressLabel }}</span>
+          <span
+            v-if="importJob.current_item"
+            class="import-modal-progress-item"
+          >{{ truncate(importJob.current_item, 50) }}</span>
+        </div>
+      </div>
+
+      <!--
+        Single banner kept mounted via v-show so assistive tech announces the
+        text change. Error uses an assertive alert; info/success are polite.
+      -->
+      <div
+        v-show="bannerVisible"
+        class="sync-status-message"
+        :role="resultError ? 'alert' : 'status'"
+        :aria-live="resultError ? 'assertive' : 'polite'"
+        :class="{
+          'sync-status-error': resultError,
+          'sync-status-success': result && !resultError,
+          'sync-status-info': submitting && !result && !resultError,
+        }"
+      >
+        <template v-if="resultError">
+          <span aria-hidden="true">⚠ </span>{{ resultError }}
+        </template>
+        <template v-else-if="result">
+          <span aria-hidden="true">✓ </span>{{ result.message }} {{ successCounts }}
+        </template>
+        <template v-else-if="submitting">Importing…</template>
+      </div>
+
+      <details
+        v-if="result && skippedCount > 0"
+        class="score-details import-modal-errors"
+      >
+        <summary>{{ skippedSummary }}</summary>
+        <ul>
+          <li v-for="(error, index) in result.errors" :key="index">{{ error }}</li>
+        </ul>
+      </details>
+
+      <p
+        v-if="!result && !submitting && disabledReason"
+        class="help-text"
+      >{{ disabledReason }}</p>
+
+      <div class="import-modal-actions">
+        <template v-if="result">
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-testid="import-done"
+            @click="emit('close')"
+          >Done</button>
+        </template>
+        <template v-else>
+          <button
+            type="button"
+            class="btn btn-secondary"
+            :disabled="submitting"
+            @click="emit('close')"
+          >Cancel</button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-testid="import-submit"
+            :disabled="!canSubmit"
+            @click="submit"
+          >{{ submitting ? 'Importing…' : 'Import' }}</button>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.import-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  padding: var(--space-3);
+}
+
+.import-modal-content {
+  background: var(--bg-card, var(--surface));
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  width: 100%;
+  max-width: 38rem;
+  max-height: 90vh;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.import-modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.import-modal-field label {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.import-modal-field input[type="text"],
+.import-modal-field input[type="number"],
+.import-modal-field input[type="file"],
+.import-modal-field select {
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-card, var(--surface));
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.import-modal-field input:focus-visible,
+.import-modal-field select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.import-modal-progress {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  flex-wrap: wrap;
+}
+
+.import-modal-progress-bar {
+  position: relative;
+  display: inline-block;
+  width: 80px;
+  height: 6px;
+  background: var(--border-default);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  vertical-align: middle;
+}
+
+.import-modal-progress-fill {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  transition: width 0.2s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .import-modal-progress-fill {
+    transition: none;
+  }
+}
+
+.import-modal-progress-counts {
+  font-variant-numeric: tabular-nums;
+}
+
+.import-modal-progress-item {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-style: italic;
+}
+
+.import-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-default);
+}
+</style>

--- a/resources/js/components/pages/DataPage.vue
+++ b/resources/js/components/pages/DataPage.vue
@@ -58,6 +58,7 @@ const orderedSources = computed(() => {
             type="button"
             class="btn btn-secondary"
             data-testid="import-file-btn"
+            aria-haspopup="dialog"
             @click="showImportModal = true"
           >Import from file</button>
         </div>

--- a/resources/js/components/pages/DataPage.vue
+++ b/resources/js/components/pages/DataPage.vue
@@ -3,10 +3,12 @@ import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useDataStore } from '@/stores/data'
 import SyncSourceAccordion from '@/components/organisms/SyncSourceAccordion.vue'
 import AddSourceModal from '@/components/organisms/AddSourceModal.vue'
+import ImportFileModal from '@/components/organisms/ImportFileModal.vue'
 import EnrichmentCard from '@/components/organisms/EnrichmentCard.vue'
 
 const data = useDataStore()
 const showAddSourceModal = ref(false)
+const showImportModal = ref(false)
 
 onMounted(() => {
   data.loadSyncSources()
@@ -45,12 +47,20 @@ const orderedSources = computed(() => {
     <div class="card">
       <div class="sync-sources-header">
         <h3>Sync Sources</h3>
-        <button
-          type="button"
-          class="btn btn-primary"
-          data-testid="add-source-btn"
-          @click="showAddSourceModal = true"
-        >+ Add source</button>
+        <div class="sync-sources-header-actions">
+          <button
+            type="button"
+            class="btn btn-primary"
+            data-testid="add-source-btn"
+            @click="showAddSourceModal = true"
+          >+ Add source</button>
+          <button
+            type="button"
+            class="btn btn-secondary"
+            data-testid="import-file-btn"
+            @click="showImportModal = true"
+          >Import from file</button>
+        </div>
       </div>
       <div
         v-if="data.syncMessage"
@@ -108,6 +118,11 @@ const orderedSources = computed(() => {
       @close="showAddSourceModal = false"
       @created="() => (showAddSourceModal = false)"
     />
+
+    <ImportFileModal
+      v-if="showImportModal"
+      @close="showImportModal = false"
+    />
   </div>
 </template>
 
@@ -118,6 +133,12 @@ const orderedSources = computed(() => {
   justify-content: space-between;
   gap: var(--space-3);
   margin-bottom: var(--space-3);
+}
+
+.sync-sources-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
 }
 
 .sync-accordion-list {

--- a/resources/js/composables/useApi.ts
+++ b/resources/js/composables/useApi.ts
@@ -37,7 +37,12 @@ async function request<T>(path: string, options: ApiOptions = {}): Promise<T> {
   const url = buildUrl(path, params)
 
   const headers: HeadersInit = { ...fetchOptions.headers }
-  if (fetchOptions.body !== undefined) {
+  // FormData sets its own multipart Content-Type (with boundary); only force
+  // JSON for plain-object bodies.
+  if (
+    fetchOptions.body !== undefined &&
+    !(fetchOptions.body instanceof FormData)
+  ) {
     ;(headers as Record<string, string>)['Content-Type'] = 'application/json'
   }
 
@@ -80,6 +85,10 @@ export function useApi() {
         method: 'PATCH',
         body: body !== undefined ? JSON.stringify(body) : undefined,
       })
+    },
+
+    postForm<T>(path: string, body: FormData) {
+      return request<T>(path, { method: 'POST', body })
     },
 
     delete<T>(path: string) {

--- a/resources/js/composables/useFocusTrap.ts
+++ b/resources/js/composables/useFocusTrap.ts
@@ -1,7 +1,7 @@
 import { type Ref, onMounted, onUnmounted, nextTick } from 'vue'
 
 const FOCUSABLE_SELECTOR =
-  'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), summary:not([hidden]), a[href], [tabindex]:not([tabindex="-1"])'
 
 /**
  * Only one focus trap should be active at a time in this application.

--- a/resources/js/stores/data.test.ts
+++ b/resources/js/stores/data.test.ts
@@ -49,6 +49,7 @@ describe('useDataStore', () => {
     expect(store.syncJobs).toEqual([])
     expect(store.isSourceIdSyncing('steam')).toBe(false)
     expect(store.enrichmentStats).toBeNull()
+    expect(store.importSources).toEqual([])
   })
 
   it('loadSyncSources fetches sources and auth status', async () => {

--- a/resources/js/stores/data.test.ts
+++ b/resources/js/stores/data.test.ts
@@ -5,6 +5,7 @@ import { ApiError } from '@/composables/useApi'
 
 const mockGet = vi.fn()
 const mockPost = vi.fn()
+const mockPostForm = vi.fn()
 const mockPut = vi.fn()
 const mockDelete = vi.fn()
 
@@ -18,6 +19,7 @@ vi.mock('@/composables/useApi', () => ({
   useApi: () => ({
     get: (...args: unknown[]) => mockGet(...args),
     post: (...args: unknown[]) => mockPost(...args),
+    postForm: (...args: unknown[]) => mockPostForm(...args),
     put: (...args: unknown[]) => mockPut(...args),
     patch: vi.fn(),
     delete: (...args: unknown[]) => mockDelete(...args),
@@ -31,6 +33,7 @@ describe('useDataStore', () => {
     vi.useFakeTimers()
     mockGet.mockReset()
     mockPost.mockReset()
+    mockPostForm.mockReset()
     mockPut.mockReset()
     mockDelete.mockReset()
   })
@@ -1088,6 +1091,76 @@ describe('useDataStore', () => {
       await expect(store.deleteSource('still_here')).rejects.toBe(error)
       // The listing is untouched so the UI keeps showing the source.
       expect(store.syncSources.map((s) => s.id)).toEqual(['still_here'])
+    })
+  })
+
+  describe('file import flows', () => {
+    it('loadImportSources fetches and caches the importable plugins', async () => {
+      const sources = [
+        {
+          name: 'csv_import',
+          display_name: 'CSV Import',
+          description: 'Import a generic CSV file.',
+          content_types: ['book', 'movie'],
+          fields: [],
+        },
+      ]
+      mockGet.mockResolvedValueOnce(sources)
+
+      const store = useDataStore()
+      const result = await store.loadImportSources()
+
+      expect(mockGet).toHaveBeenCalledWith('/import/sources')
+      expect(result).toEqual(sources)
+      expect(store.importSources).toEqual(sources)
+    })
+
+    it('runImport posts a multipart body and starts sync polling', async () => {
+      const importResult = {
+        message: 'Imported 3 item(s) from CSV Import.',
+        source: 'Import: CSV Import',
+        items_synced: 3,
+        total_items: 3,
+        errors: [],
+      }
+      mockPostForm.mockResolvedValueOnce(importResult)
+
+      const store = useDataStore()
+      const file = new File(['title\nDune'], 'books.csv', { type: 'text/csv' })
+      const result = await store.runImport('csv_import', file, {
+        content_type: 'book',
+      })
+
+      expect(result).toEqual(importResult)
+      expect(mockPostForm).toHaveBeenCalledTimes(1)
+      const [path, body] = mockPostForm.mock.calls[0]
+      expect(path).toBe('/import')
+      expect(body).toBeInstanceOf(FormData)
+      const form = body as FormData
+      expect(form.get('source')).toBe('csv_import')
+      expect(form.get('file')).toBe(file)
+      expect(form.get('content_type')).toBe('book')
+
+      // Polling is live after dispatch — a tick fetches /sync/status.
+      mockGet.mockResolvedValueOnce({ status: 'idle', jobs: [] })
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(mockGet).toHaveBeenCalledWith('/sync/status')
+
+      store.cleanup()
+    })
+
+    it('runImport propagates the ApiError to the caller', async () => {
+      const error = new ApiError(400, 'Bad Request')
+      mockPostForm.mockRejectedValueOnce(error)
+
+      const store = useDataStore()
+      const file = new File(['oops'], 'bad.csv', { type: 'text/csv' })
+
+      await expect(
+        store.runImport('csv_import', file, {}),
+      ).rejects.toBe(error)
+
+      store.cleanup()
     })
   })
 })

--- a/resources/js/stores/data.ts
+++ b/resources/js/stores/data.ts
@@ -15,6 +15,8 @@ import type {
   SourceMigrationResponse,
   PluginInfoResponse,
   SourceCreateRequest,
+  ImportSourceResponse,
+  ImportResultResponse,
 } from '@/types/api'
 
 const ALL_SOURCES_LABEL = 'All Sources'
@@ -397,6 +399,34 @@ export const useDataStore = defineStore('data', () => {
   const sourceSchemas = ref<Record<string, SourceSchemaResponse>>({})
   const sourceConfigs = ref<Record<string, SourceConfigResponse>>({})
   const availablePlugins = ref<PluginInfoResponse[]>([])
+  const importSources = ref<ImportSourceResponse[]>([])
+
+  async function loadImportSources(): Promise<ImportSourceResponse[]> {
+    const sources = await api.get<ImportSourceResponse[]>('/import/sources')
+    importSources.value = sources
+    return sources
+  }
+
+  // One-shot file import. Builds the multipart body the /import endpoint
+  // expects (source + file + one form field per option), dispatches the
+  // POST, then starts sync polling so the in-flight progress feed updates
+  // while the request is awaited. The response body carries the final
+  // counts; ApiError propagates to the caller for status-specific messaging.
+  async function runImport(
+    source: string,
+    file: File,
+    options: Record<string, string>,
+  ): Promise<ImportResultResponse> {
+    const formData = new FormData()
+    formData.append('source', source)
+    formData.append('file', file)
+    for (const [name, value] of Object.entries(options)) {
+      formData.append(name, value)
+    }
+    const pending = api.postForm<ImportResultResponse>('/import', formData)
+    startSyncPolling()
+    return pending
+  }
 
   async function loadSourceSchema(sourceId: string): Promise<SourceSchemaResponse> {
     const schema = await api.get<SourceSchemaResponse>(
@@ -511,6 +541,7 @@ export const useDataStore = defineStore('data', () => {
     // Helpers
     isSourceIdSyncing,
     jobForSourceId,
+    jobForLabel,
     gogStatus,
     epicStatus,
     gogConnectMessage,
@@ -521,6 +552,7 @@ export const useDataStore = defineStore('data', () => {
     sourceSchemas,
     sourceConfigs,
     availablePlugins,
+    importSources,
     // Actions
     loadSyncSources,
     triggerSync,
@@ -544,6 +576,8 @@ export const useDataStore = defineStore('data', () => {
     loadAvailablePlugins,
     createSource,
     deleteSource,
+    loadImportSources,
+    runImport,
     cleanup,
   }
 })

--- a/resources/js/types/api.ts
+++ b/resources/js/types/api.ts
@@ -145,6 +145,24 @@ export interface SourceCreateRequest {
   enabled: boolean
 }
 
+// --- File import ---
+
+export interface ImportSourceResponse {
+  name: string
+  display_name: string
+  description: string
+  content_types: string[]
+  fields: SourceFieldSchema[]
+}
+
+export interface ImportResultResponse {
+  message: string
+  source: string
+  items_synced: number
+  total_items: number
+  errors: string[]
+}
+
 export interface SyncSourceProgressResponse {
   source: string
   items_processed: number

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -21,6 +21,7 @@ from src.conversation.engine import ConversationEngine
 from src.conversation.profile import ProfileGenerator
 from src.enrichment.manager import EnrichmentManager
 from src.ingestion.import_service import FileImportError, import_file
+from src.ingestion.registry import get_registry
 from src.ingestion.sync import (
     MAX_WORKERS_CEILING,
     execute_multi_source_sync,
@@ -533,7 +534,7 @@ def _list_importable_sources(output_format: str) -> None:
     "output_format",
     type=click.Choice(["table", "json"], case_sensitive=False),
     default="table",
-    help="Output format for --source list",
+    help="Output format for the source listing and the import result",
 )
 @click.pass_context
 def import_data(
@@ -604,6 +605,27 @@ def import_data(
     except FileImportError as error:
         click.echo(f"Error: {error}", err=True)
         raise click.Abort() from error
+
+    if output_format == "json":
+        # Mirror the fields POST /api/import returns so JSON consumers get the
+        # same shape (including per-item errors) from either interface.
+        imported_plugin = get_registry().get_plugin(source)
+        display_name = imported_plugin.display_name if imported_plugin else source
+        click.echo(
+            json.dumps(
+                {
+                    "message": (
+                        f"Imported {result.items_synced} item(s) from {display_name}."
+                    ),
+                    "source": source,
+                    "items_synced": result.items_synced,
+                    "total_items": result.total_items,
+                    "errors": result.errors,
+                },
+                indent=2,
+            )
+        )
+        return
 
     click.echo(
         f"Imported {result.items_synced}/{result.total_items} items from {source}."

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -20,6 +20,7 @@ from src.cli.config import get_feature_flags
 from src.conversation.engine import ConversationEngine
 from src.conversation.profile import ProfileGenerator
 from src.enrichment.manager import EnrichmentManager
+from src.ingestion.import_service import FileImportError, import_file
 from src.ingestion.sync import (
     MAX_WORKERS_CEILING,
     execute_multi_source_sync,
@@ -70,6 +71,7 @@ from src.web.sync_sources import (
     delete_source,
     get_available_sync_sources,
     list_available_plugins,
+    list_importable_plugins,
     migrate_source,
     resolve_inputs,
     resolve_source_plugin,
@@ -468,6 +470,146 @@ def update(ctx: click.Context, source: str, workers: int | None) -> None:
     except Exception as error:
         click.echo(f"Error updating data: {error}", err=True)
         raise click.Abort() from error
+
+
+def _list_importable_sources(output_format: str) -> None:
+    """Print the file-import plugins (mirrors GET /api/import/sources)."""
+    plugins = list_importable_plugins()
+    if output_format == "json":
+        click.echo(json.dumps(plugins, indent=2))
+        return
+
+    if not plugins:
+        click.echo("No importable sources available.")
+        return
+
+    rows = [
+        [
+            p["name"],
+            p["display_name"],
+            ",".join(p["content_types"]),
+            ", ".join(field["name"] for field in p["fields"]) or "—",
+        ]
+        for p in plugins
+    ]
+    click.echo(
+        tabulate(
+            rows,
+            headers=["Name", "Display Name", "Content Types", "Options"],
+            tablefmt="grid",
+        )
+    )
+
+
+@click.command(name="import")
+@click.option(
+    "--source",
+    required=True,
+    help="File-import source (use 'list' to see importable sources)",
+)
+@click.option(
+    "--file",
+    "file_path",
+    type=click.Path(path_type=Path),  # type: ignore[type-var]
+    default=None,
+    help="Path to the file to import",
+)
+@click.option(
+    "--content-type",
+    "content_type",
+    type=click.Choice(["book", "movie", "tv_show", "video_game"], case_sensitive=False),
+    default=None,
+    help="Content type for the imported items",
+)
+@click.option(
+    "--option",
+    "options",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="Additional import option as KEY=VALUE (repeatable)",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    default="table",
+    help="Output format for --source list",
+)
+@click.pass_context
+def import_data(
+    ctx: click.Context,
+    source: str,
+    file_path: Path | None,
+    content_type: str | None,
+    options: tuple[str, ...],
+    output_format: str,
+) -> None:
+    """Import content from a file (mirrors POST /api/import).
+
+    Use ``--source list`` to see importable sources and their options.
+    """
+    if source == "list":
+        _list_importable_sources(output_format)
+        return
+
+    if file_path is None:
+        _abort_with("--file is required (or use --source list).")
+
+    import_options: dict[str, Any] = {}
+    if content_type is not None:
+        import_options["content_type"] = content_type
+    for raw in options:
+        if "=" not in raw:
+            _abort_with(f"Invalid --option '{raw}'. Expected KEY=VALUE.")
+        key, value = raw.split("=", 1)
+        import_options[key.strip()] = value
+
+    storage = ctx.obj["storage"]
+    embedding_gen = ctx.obj["embedding_gen"]
+    config = ctx.obj["config"]
+
+    use_embeddings = get_feature_flags(config)["use_embeddings"]
+    enrichment_config = config.get("enrichment", {})
+    auto_enrich = enrichment_config.get("enabled", False) and enrichment_config.get(
+        "auto_enrich_on_sync", False
+    )
+
+    last_reported = -1
+
+    def cli_progress(
+        items_processed: int,
+        total_items: int | None,
+        current_item: str | None,
+        current_source: str | None = None,
+    ) -> None:
+        nonlocal last_reported
+        if not (total_items and items_processed > 0 and items_processed % 10 == 0):
+            return
+        if last_reported == items_processed:
+            return
+        last_reported = items_processed
+        click.echo(f"    Processed {items_processed}/{total_items}...")
+
+    try:
+        result = import_file(
+            plugin_name=source,
+            file_path=file_path,
+            options=import_options,
+            storage_manager=storage,
+            embedding_generator=embedding_gen,
+            use_embeddings=use_embeddings,
+            progress_callback=cli_progress,
+            mark_for_enrichment=auto_enrich,
+        )
+    except FileImportError as error:
+        click.echo(f"Error: {error}", err=True)
+        raise click.Abort() from error
+
+    click.echo(
+        f"Imported {result.items_synced}/{result.total_items} items from {source}."
+    )
+    for item_error in result.errors:
+        click.echo(f"  Warning: {item_error}", err=True)
 
 
 @click.command()

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -10,6 +10,7 @@ from src.cli.commands import (
     chat,
     complete,
     enrichment,
+    import_data,
     library,
     memory,
     preferences,
@@ -69,6 +70,7 @@ cli.add_command(chat)
 cli.add_command(status)
 cli.add_command(recommend)
 cli.add_command(update)
+cli.add_command(import_data)
 cli.add_command(complete)
 cli.add_command(preferences)
 cli.add_command(enrichment)

--- a/src/ingestion/import_service.py
+++ b/src/ingestion/import_service.py
@@ -1,0 +1,113 @@
+"""One-shot file-import service.
+
+Imports a single user-supplied file (a temp file written from a web upload, or
+a real path passed to the CLI ``import --file`` flag) through the existing
+ingestion pipeline and returns the same :class:`~src.ingestion.sync.SyncResult`
+that :func:`~src.ingestion.sync.execute_sync` produces.
+
+Unlike the syncable API sources, file-import plugins have no persistent
+configuration: the file is supplied at invocation time, validated, run through
+the pipeline once, and forgotten.
+
+File lifecycle is the caller's responsibility. This service never creates or
+deletes the file. A web handler that wrote an upload to a temp path must remove
+that path after the call (on success or failure); the CLI passes a real user
+path that must be left in place.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from src.ingestion.plugin_base import SourceError
+from src.ingestion.registry import get_registry
+from src.ingestion.sync import SyncProgressCallback, SyncResult, execute_sync
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from src.llm.embeddings import EmbeddingGenerator
+    from src.storage.manager import StorageManager
+
+logger = logging.getLogger(__name__)
+
+
+class FileImportError(Exception):
+    """Raised when a one-shot file import cannot be completed.
+
+    Covers an unknown or non-file-import plugin, a missing or unreadable file,
+    invalid import options, and a corrupt or unparseable file (wrapping the
+    plugin's :class:`~src.ingestion.plugin_base.SourceError`).
+    """
+
+
+def import_file(
+    plugin_name: str,
+    file_path: Path,
+    options: dict[str, Any],
+    storage_manager: StorageManager,
+    embedding_generator: EmbeddingGenerator | None = None,
+    use_embeddings: bool = False,
+    progress_callback: SyncProgressCallback | None = None,
+    mark_for_enrichment: bool = False,
+    user_id: int = 1,
+) -> SyncResult:
+    """Run a single file through a file-import plugin and the ingestion pipeline.
+
+    Args:
+        plugin_name: Registered name of a file-import plugin (e.g. ``goodreads``,
+            ``csv_import``, ``json_import``, ``markdown_import``).
+        file_path: Path to the file to import. The caller owns its lifecycle —
+            this function neither creates nor deletes it.
+        options: The non-path import options the user supplied, keyed by the
+            plugin's ``get_config_schema()`` field names (e.g. ``content_type``).
+            The file path is injected by this service, so callers must not set
+            ``path`` here.
+        storage_manager: Storage manager used to persist imported items.
+        embedding_generator: Optional embedding generator.
+        use_embeddings: Whether to generate embeddings for each item.
+        progress_callback: Optional progress callback forwarded to the pipeline.
+        mark_for_enrichment: Whether to mark imported items for enrichment.
+        user_id: User ID for credential storage (default 1).
+
+    Returns:
+        The :class:`~src.ingestion.sync.SyncResult` from the ingestion pipeline.
+
+    Raises:
+        FileImportError: If the plugin is unknown or not a file-import plugin,
+            the file is missing/unreadable, the options fail validation, or the
+            file is corrupt/unparseable.
+    """
+    plugin = get_registry().get_plugin(plugin_name)
+    if plugin is None:
+        raise FileImportError(f"Unknown plugin: {plugin_name}")
+    if not plugin.is_file_import:
+        raise FileImportError(f"Plugin '{plugin_name}' does not support file import")
+
+    if not file_path.is_file():
+        raise FileImportError(f"File not found or not readable: {file_path}")
+
+    plugin_config: dict[str, Any] = {**options, "path": str(file_path)}
+
+    validation_errors = plugin.validate_config(
+        plugin_config, storage=storage_manager, user_id=user_id
+    )
+    if validation_errors:
+        raise FileImportError("; ".join(validation_errors))
+
+    try:
+        return execute_sync(
+            plugin=plugin,
+            plugin_config=plugin_config,
+            storage_manager=storage_manager,
+            embedding_generator=embedding_generator,
+            use_embeddings=use_embeddings,
+            progress_callback=progress_callback,
+            mark_for_enrichment=mark_for_enrichment,
+            user_id=user_id,
+        )
+    except SourceError as error:
+        raise FileImportError(
+            f"Failed to import file with '{plugin_name}': {error.message}"
+        ) from error

--- a/src/ingestion/import_service.py
+++ b/src/ingestion/import_service.py
@@ -32,6 +32,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Prefix of the FileImportError message raised when the file is missing or
+# unreadable. The web handler matches on this to mask the (temp) path from the
+# HTTP client while the CLI keeps the full message (a real user path it can fix).
+FILE_NOT_READABLE_MESSAGE = "File not found or not readable"
+
 
 class FileImportError(Exception):
     """Raised when a one-shot file import cannot be completed.
@@ -86,7 +91,7 @@ def import_file(
         raise FileImportError(f"Plugin '{plugin_name}' does not support file import")
 
     if not file_path.is_file():
-        raise FileImportError(f"File not found or not readable: {file_path}")
+        raise FileImportError(f"{FILE_NOT_READABLE_MESSAGE}: {file_path}")
 
     plugin_config: dict[str, Any] = {**options, "path": str(file_path)}
 

--- a/src/ingestion/plugin_base.py
+++ b/src/ingestion/plugin_base.py
@@ -39,6 +39,7 @@ class PluginInfo:
     requires_api_key: bool
     requires_network: bool
     config_schema: list[ConfigField] = field(default_factory=list)
+    is_file_import: bool = False
 
 
 class SourceError(Exception):
@@ -186,6 +187,22 @@ class SourcePlugin(ABC):
             True if network access is required, False otherwise
         """
         return self.requires_api_key
+
+    @property
+    def is_file_import(self) -> bool:
+        """Whether this plugin imports a single user-supplied file.
+
+        File-import plugins (Goodreads, CSV, JSON, Markdown) are not
+        persistent syncable sources: a file is supplied at invocation
+        time (a web upload or the CLI ``import --file`` flag), run
+        through the ingestion pipeline once, and discarded. ``True`` here
+        keeps the plugin out of the syncable-source list and routes it
+        through the one-shot import service instead.
+
+        Returns:
+            True for one-shot file-import plugins, False otherwise.
+        """
+        return False
 
     @abstractmethod
     def get_config_schema(self) -> list[ConfigField]:
@@ -337,4 +354,5 @@ class SourcePlugin(ABC):
             requires_api_key=self.requires_api_key,
             requires_network=self.requires_network,
             config_schema=self.get_config_schema(),
+            is_file_import=self.is_file_import,
         )

--- a/src/ingestion/sources/generic_csv/README.md
+++ b/src/ingestion/sources/generic_csv/README.md
@@ -8,19 +8,18 @@ Imports content items from a generic CSV file. Each input maps to a single conte
 ## Requirements
 - A CSV file with at minimum a `title` column for the configured content type.
 
-## Configuration
+## Importing
 
-```yaml
-inputs:
-  csv_import:
-    path: "/path/to/library.csv"
-    content_type: "book"   # or movie, tv_show, video_game
+This is a one-shot file import, not a syncable `inputs:` source. Upload the CSV
+from the web **Data** tab (**Import from file**) or run:
+
+```bash
+python3.11 -m src.cli import --source csv_import --file /path/to/library.csv --content-type book
 ```
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `path` | str | yes | Path to the CSV file. |
-| `content_type` | str | yes | One of: `book`, `movie`, `tv_show`, `video_game`. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `content_type` | yes | One of: `book`, `movie`, `tv_show`, `video_game`. |
 
 ## Recognized columns
 - Universal: `title`, `status`, `rating`, `date_completed`, `review`, `notes`, `ignored`

--- a/src/ingestion/sources/generic_csv/generic_csv.py
+++ b/src/ingestion/sources/generic_csv/generic_csv.py
@@ -222,14 +222,12 @@ class CsvImportPlugin(SourcePlugin):
     def requires_network(self) -> bool:
         return False
 
+    @property
+    def is_file_import(self) -> bool:
+        return True
+
     def get_config_schema(self) -> list[ConfigField]:
         return [
-            ConfigField(
-                name="path",
-                field_type=str,
-                required=True,
-                description="Path to CSV file matching the template for the content type",
-            ),
             ConfigField(
                 name="content_type",
                 field_type=str,
@@ -245,12 +243,6 @@ class CsvImportPlugin(SourcePlugin):
         user_id: int = 1,
     ) -> list[str]:
         errors = []
-
-        path = config.get("path")
-        if not path:
-            errors.append("'path' is required")
-        elif not Path(path).resolve().exists():
-            errors.append(f"CSV file not found: {path}")
 
         content_type = config.get("content_type", "")
         valid_types = [content_type_enum.value for content_type_enum in ContentType]

--- a/src/ingestion/sources/generic_csv/test_generic_csv.py
+++ b/src/ingestion/sources/generic_csv/test_generic_csv.py
@@ -73,7 +73,6 @@ class TestCsvImportPluginValidation:
 
     def test_validate_does_not_require_path(self, plugin: CsvImportPlugin) -> None:
         """validate_config no longer requires a path — the service injects it."""
-        assert plugin.validate_config({"content_type": "book"}) == []
         assert (
             plugin.validate_config(
                 {"path": "/nonexistent/path.csv", "content_type": "book"}

--- a/src/ingestion/sources/generic_csv/test_generic_csv.py
+++ b/src/ingestion/sources/generic_csv/test_generic_csv.py
@@ -45,12 +45,13 @@ class TestCsvImportPluginProperties:
     def test_requires_network(self, plugin: CsvImportPlugin) -> None:
         assert plugin.requires_network is False
 
-    def test_config_schema(self, plugin: CsvImportPlugin) -> None:
-        schema = plugin.get_config_schema()
-        assert len(schema) == 2
-        names = [field.name for field in schema]
-        assert "path" in names
-        assert "content_type" in names
+    def test_is_file_import(self, plugin: CsvImportPlugin) -> None:
+        assert plugin.is_file_import is True
+
+    def test_config_schema_has_no_path(self, plugin: CsvImportPlugin) -> None:
+        """Path is injected by the import service; only content_type remains."""
+        names = [field.name for field in plugin.get_config_schema()]
+        assert names == ["content_type"]
 
     def test_get_source_identifier(self, plugin: CsvImportPlugin) -> None:
         assert plugin.get_source_identifier() == "csv_import"
@@ -61,60 +62,36 @@ class TestCsvImportPluginProperties:
         assert info.display_name == "CSV Import"
         assert info.requires_api_key is False
         assert info.requires_network is False
+        assert info.is_file_import is True
 
 
 class TestCsvImportPluginValidation:
     """Tests for CsvImportPlugin config validation."""
 
-    def test_validate_valid_config(
-        self, plugin: CsvImportPlugin, tmp_path: Path
-    ) -> None:
-        csv_file = tmp_path / "books.csv"
-        csv_file.write_text("title\n")
-        errors = plugin.validate_config({"path": str(csv_file), "content_type": "book"})
-        assert errors == []
+    def test_validate_valid_config(self, plugin: CsvImportPlugin) -> None:
+        assert plugin.validate_config({"content_type": "book"}) == []
 
-    def test_validate_missing_csv_path(self, plugin: CsvImportPlugin) -> None:
-        errors = plugin.validate_config({"content_type": "book"})
-        assert any("path" in error for error in errors)
-
-    def test_validate_empty_csv_path(self, plugin: CsvImportPlugin) -> None:
-        errors = plugin.validate_config({"path": "", "content_type": "book"})
-        assert any("path" in error for error in errors)
-
-    def test_validate_nonexistent_file(self, plugin: CsvImportPlugin) -> None:
-        errors = plugin.validate_config(
-            {"path": "/nonexistent/path.csv", "content_type": "book"}
+    def test_validate_does_not_require_path(self, plugin: CsvImportPlugin) -> None:
+        """validate_config no longer requires a path — the service injects it."""
+        assert plugin.validate_config({"content_type": "book"}) == []
+        assert (
+            plugin.validate_config(
+                {"path": "/nonexistent/path.csv", "content_type": "book"}
+            )
+            == []
         )
-        assert any("not found" in error for error in errors)
 
-    def test_validate_missing_content_type(
-        self, plugin: CsvImportPlugin, tmp_path: Path
-    ) -> None:
-        csv_file = tmp_path / "books.csv"
-        csv_file.write_text("title\n")
-        errors = plugin.validate_config({"path": str(csv_file)})
+    def test_validate_missing_content_type(self, plugin: CsvImportPlugin) -> None:
+        errors = plugin.validate_config({})
         assert any("content_type" in error for error in errors)
 
-    def test_validate_invalid_content_type(
-        self, plugin: CsvImportPlugin, tmp_path: Path
-    ) -> None:
-        csv_file = tmp_path / "books.csv"
-        csv_file.write_text("title\n")
-        errors = plugin.validate_config(
-            {"path": str(csv_file), "content_type": "podcast"}
-        )
+    def test_validate_invalid_content_type(self, plugin: CsvImportPlugin) -> None:
+        errors = plugin.validate_config({"content_type": "podcast"})
         assert any("Invalid content_type" in error for error in errors)
 
-    def test_validate_all_content_types(
-        self, plugin: CsvImportPlugin, tmp_path: Path
-    ) -> None:
-        csv_file = tmp_path / "data.csv"
-        csv_file.write_text("title\n")
+    def test_validate_all_content_types(self, plugin: CsvImportPlugin) -> None:
         for content_type in ContentType:
-            errors = plugin.validate_config(
-                {"path": str(csv_file), "content_type": content_type.value}
-            )
+            errors = plugin.validate_config({"content_type": content_type.value})
             assert errors == [], f"Failed for content_type={content_type.value}"
 
 

--- a/src/ingestion/sources/generic_json/README.md
+++ b/src/ingestion/sources/generic_json/README.md
@@ -8,19 +8,18 @@ Imports content items from a JSON array or newline-delimited JSON file. Mirrors 
 ## Requirements
 - A `.json` (array of objects) or `.jsonl` (one object per line) file.
 
-## Configuration
+## Importing
 
-```yaml
-inputs:
-  json_import:
-    path: "/path/to/library.json"
-    content_type: "book"   # or movie, tv_show, video_game
+This is a one-shot file import, not a syncable `inputs:` source. Upload the file
+from the web **Data** tab (**Import from file**) or run:
+
+```bash
+python3.11 -m src.cli import --source json_import --file /path/to/library.json --content-type book
 ```
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `path` | str | yes | Path to the JSON or JSONL file. |
-| `content_type` | str | yes | One of: `book`, `movie`, `tv_show`, `video_game`. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `content_type` | yes | One of: `book`, `movie`, `tv_show`, `video_game`. |
 
 ## Notes
 - Field names match the [generic CSV](../generic_csv/README.md) plugin.

--- a/src/ingestion/sources/generic_json/generic_json.py
+++ b/src/ingestion/sources/generic_json/generic_json.py
@@ -67,14 +67,12 @@ class JsonImportPlugin(SourcePlugin):
     def requires_network(self) -> bool:
         return False
 
+    @property
+    def is_file_import(self) -> bool:
+        return True
+
     def get_config_schema(self) -> list[ConfigField]:
         return [
-            ConfigField(
-                name="path",
-                field_type=str,
-                required=True,
-                description="Path to JSON or JSONL file matching the template",
-            ),
             ConfigField(
                 name="content_type",
                 field_type=str,
@@ -90,12 +88,6 @@ class JsonImportPlugin(SourcePlugin):
         user_id: int = 1,
     ) -> list[str]:
         errors = []
-
-        path = config.get("path")
-        if not path:
-            errors.append("'path' is required")
-        elif not Path(path).resolve().exists():
-            errors.append(f"JSON file not found: {path}")
 
         content_type = config.get("content_type", "")
         valid_types = [content_type_enum.value for content_type_enum in ContentType]

--- a/src/ingestion/sources/generic_json/test_generic_json.py
+++ b/src/ingestion/sources/generic_json/test_generic_json.py
@@ -41,56 +41,43 @@ class TestJsonImportPluginProperties:
     def test_requires_network(self, plugin: JsonImportPlugin) -> None:
         assert plugin.requires_network is False
 
-    def test_config_schema(self, plugin: JsonImportPlugin) -> None:
-        schema = plugin.get_config_schema()
-        assert len(schema) == 2
-        names = [field.name for field in schema]
-        assert "path" in names
-        assert "content_type" in names
+    def test_is_file_import(self, plugin: JsonImportPlugin) -> None:
+        assert plugin.is_file_import is True
+
+    def test_config_schema_has_no_path(self, plugin: JsonImportPlugin) -> None:
+        """Path is injected by the import service; only content_type remains."""
+        names = [field.name for field in plugin.get_config_schema()]
+        assert names == ["content_type"]
 
     def test_get_source_identifier(self, plugin: JsonImportPlugin) -> None:
         assert plugin.get_source_identifier() == "json_import"
+
+    def test_get_info_is_file_import(self, plugin: JsonImportPlugin) -> None:
+        assert plugin.get_info().is_file_import is True
 
 
 class TestJsonImportPluginValidation:
     """Tests for JsonImportPlugin config validation."""
 
-    def test_validate_valid_config(
-        self, plugin: JsonImportPlugin, tmp_path: Path
-    ) -> None:
-        json_file = tmp_path / "books.json"
-        json_file.write_text("[]")
-        errors = plugin.validate_config(
-            {"path": str(json_file), "content_type": "book"}
+    def test_validate_valid_config(self, plugin: JsonImportPlugin) -> None:
+        assert plugin.validate_config({"content_type": "book"}) == []
+
+    def test_validate_does_not_require_path(self, plugin: JsonImportPlugin) -> None:
+        """validate_config no longer requires a path — the service injects it."""
+        assert plugin.validate_config({"content_type": "book"}) == []
+        assert (
+            plugin.validate_config(
+                {"path": "/nonexistent/path.json", "content_type": "book"}
+            )
+            == []
         )
-        assert errors == []
 
-    def test_validate_missing_json_path(self, plugin: JsonImportPlugin) -> None:
-        errors = plugin.validate_config({"content_type": "book"})
-        assert any("path" in error for error in errors)
-
-    def test_validate_nonexistent_file(self, plugin: JsonImportPlugin) -> None:
-        errors = plugin.validate_config(
-            {"path": "/nonexistent/path.json", "content_type": "book"}
-        )
-        assert any("not found" in error for error in errors)
-
-    def test_validate_missing_content_type(
-        self, plugin: JsonImportPlugin, tmp_path: Path
-    ) -> None:
-        json_file = tmp_path / "data.json"
-        json_file.write_text("[]")
-        errors = plugin.validate_config({"path": str(json_file)})
+    def test_validate_missing_content_type(self, plugin: JsonImportPlugin) -> None:
+        errors = plugin.validate_config({})
         assert any("content_type" in error for error in errors)
 
-    def test_validate_invalid_content_type(
-        self, plugin: JsonImportPlugin, tmp_path: Path
-    ) -> None:
-        json_file = tmp_path / "data.json"
-        json_file.write_text("[]")
-        errors = plugin.validate_config(
-            {"path": str(json_file), "content_type": "podcast"}
-        )
+    def test_validate_invalid_content_type(self, plugin: JsonImportPlugin) -> None:
+        errors = plugin.validate_config({"content_type": "podcast"})
         assert any("Invalid content_type" in error for error in errors)
 
 

--- a/src/ingestion/sources/generic_json/test_generic_json.py
+++ b/src/ingestion/sources/generic_json/test_generic_json.py
@@ -64,7 +64,6 @@ class TestJsonImportPluginValidation:
 
     def test_validate_does_not_require_path(self, plugin: JsonImportPlugin) -> None:
         """validate_config no longer requires a path — the service injects it."""
-        assert plugin.validate_config({"content_type": "book"}) == []
         assert (
             plugin.validate_config(
                 {"path": "/nonexistent/path.json", "content_type": "book"}

--- a/src/ingestion/sources/goodreads/README.md
+++ b/src/ingestion/sources/goodreads/README.md
@@ -8,17 +8,16 @@ Imports books from a Goodreads CSV export.
 ## Requirements
 - A Goodreads CSV export. Generate one at https://www.goodreads.com/review/import.
 
-## Configuration
+## Importing
 
-```yaml
-inputs:
-  goodreads:
-    path: "/path/to/goodreads_export.csv"
+This is a one-shot file import, not a syncable `inputs:` source. Upload the CSV
+from the web **Data** tab (**Import from file**) or run:
+
+```bash
+python3.11 -m src.cli import --source goodreads --file /path/to/goodreads_export.csv
 ```
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `path` | str | yes | Path to the Goodreads CSV export file. |
+Goodreads takes no import options (it is always books).
 
 ## Notes
 - No API key or network access required — pure file import.

--- a/src/ingestion/sources/goodreads/goodreads.py
+++ b/src/ingestion/sources/goodreads/goodreads.py
@@ -56,15 +56,12 @@ class GoodreadsPlugin(SourcePlugin):
     def requires_network(self) -> bool:
         return False
 
+    @property
+    def is_file_import(self) -> bool:
+        return True
+
     def get_config_schema(self) -> list[ConfigField]:
-        return [
-            ConfigField(
-                name="path",
-                field_type=str,
-                required=True,
-                description="Path to Goodreads CSV export file",
-            ),
-        ]
+        return []
 
     def validate_config(
         self,
@@ -72,13 +69,7 @@ class GoodreadsPlugin(SourcePlugin):
         storage: StorageManager | None = None,
         user_id: int = 1,
     ) -> list[str]:
-        errors = []
-        path = config.get("path")
-        if not path:
-            errors.append("'path' is required")
-        elif not Path(path).exists():
-            errors.append(f"CSV file not found: {path}")
-        return errors
+        return []
 
     def fetch(
         self,

--- a/src/ingestion/sources/goodreads/test_goodreads.py
+++ b/src/ingestion/sources/goodreads/test_goodreads.py
@@ -43,14 +43,15 @@ class TestGoodreadsPluginProperties:
         """Test that plugin does not require network access."""
         assert plugin.requires_network is False
 
-    def test_config_schema(self, plugin: GoodreadsPlugin) -> None:
-        """Test configuration schema defines csv_path."""
+    def test_is_file_import(self, plugin: GoodreadsPlugin) -> None:
+        """Test that Goodreads is a one-shot file-import plugin."""
+        assert plugin.is_file_import is True
+
+    def test_config_schema_has_no_path(self, plugin: GoodreadsPlugin) -> None:
+        """Path is injected by the import service, not configured on the plugin."""
         schema = plugin.get_config_schema()
 
-        assert len(schema) == 1
-        assert schema[0].name == "path"
-        assert schema[0].field_type is str
-        assert schema[0].required is True
+        assert [field.name for field in schema] == []
 
     def test_get_source_identifier(self, plugin: GoodreadsPlugin) -> None:
         """Test source identifier matches plugin name."""
@@ -65,42 +66,16 @@ class TestGoodreadsPluginProperties:
         assert info.content_types == [ContentType.BOOK]
         assert info.requires_api_key is False
         assert info.requires_network is False
+        assert info.is_file_import is True
 
 
 class TestGoodreadsPluginValidation:
     """Tests for GoodreadsPlugin config validation."""
 
-    def test_validate_valid_config(
-        self, plugin: GoodreadsPlugin, tmp_path: Path
-    ) -> None:
-        """Test validation passes with valid CSV path."""
-        csv_file = tmp_path / "books.csv"
-        csv_file.write_text("header\n")
-
-        errors = plugin.validate_config({"path": str(csv_file)})
-
-        assert errors == []
-
-    def test_validate_missing_path(self, plugin: GoodreadsPlugin) -> None:
-        """Test validation fails when path is missing."""
-        errors = plugin.validate_config({})
-
-        assert len(errors) == 1
-        assert "'path' is required" in errors[0]
-
-    def test_validate_empty_path(self, plugin: GoodreadsPlugin) -> None:
-        """Test validation fails when path is empty."""
-        errors = plugin.validate_config({"path": ""})
-
-        assert len(errors) == 1
-        assert "'path' is required" in errors[0]
-
-    def test_validate_nonexistent_file(self, plugin: GoodreadsPlugin) -> None:
-        """Test validation fails when CSV file does not exist."""
-        errors = plugin.validate_config({"path": "/nonexistent/books.csv"})
-
-        assert len(errors) == 1
-        assert "CSV file not found" in errors[0]
+    def test_validate_does_not_require_path(self, plugin: GoodreadsPlugin) -> None:
+        """validate_config no longer requires a path — the service injects it."""
+        assert plugin.validate_config({}) == []
+        assert plugin.validate_config({"path": "/nonexistent/books.csv"}) == []
 
 
 class TestGoodreadsPluginFetch:

--- a/src/ingestion/sources/markdown/README.md
+++ b/src/ingestion/sources/markdown/README.md
@@ -8,19 +8,18 @@ Imports content items from a single Markdown file using a prescriptive list-per-
 ## Requirements
 - A `.md` file with `## Status` section headings and `- **Title** by Creator | metadata` list items.
 
-## Configuration
+## Importing
 
-```yaml
-inputs:
-  markdown_import:
-    path: "/path/to/library.md"
-    content_type: "book"   # or movie, tv_show, video_game
+This is a one-shot file import, not a syncable `inputs:` source. Upload the file
+from the web **Data** tab (**Import from file**) or run:
+
+```bash
+python3.11 -m src.cli import --source markdown_import --file /path/to/library.md --content-type book
 ```
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `path` | str | yes | Path to the Markdown file. |
-| `content_type` | str | yes | One of: `book`, `movie`, `tv_show`, `video_game`. |
+| Option | Required | Description |
+|--------|----------|-------------|
+| `content_type` | yes | One of: `book`, `movie`, `tv_show`, `video_game`. |
 
 ## File format
 

--- a/src/ingestion/sources/markdown/markdown.py
+++ b/src/ingestion/sources/markdown/markdown.py
@@ -97,14 +97,12 @@ class MarkdownImportPlugin(SourcePlugin):
     def requires_network(self) -> bool:
         return False
 
+    @property
+    def is_file_import(self) -> bool:
+        return True
+
     def get_config_schema(self) -> list[ConfigField]:
         return [
-            ConfigField(
-                name="path",
-                field_type=str,
-                required=True,
-                description="Path to Markdown file in the prescribed format",
-            ),
             ConfigField(
                 name="content_type",
                 field_type=str,
@@ -120,12 +118,6 @@ class MarkdownImportPlugin(SourcePlugin):
         user_id: int = 1,
     ) -> list[str]:
         errors = []
-
-        path = config.get("path")
-        if not path:
-            errors.append("'path' is required")
-        elif not Path(path).resolve().exists():
-            errors.append(f"Markdown file not found: {path}")
 
         content_type = config.get("content_type", "")
         valid_types = [content_type_enum.value for content_type_enum in ContentType]

--- a/src/ingestion/sources/markdown/test_markdown.py
+++ b/src/ingestion/sources/markdown/test_markdown.py
@@ -40,54 +40,43 @@ class TestMarkdownImportPluginProperties:
     def test_requires_network(self, plugin: MarkdownImportPlugin) -> None:
         assert plugin.requires_network is False
 
-    def test_config_schema(self, plugin: MarkdownImportPlugin) -> None:
-        schema = plugin.get_config_schema()
-        assert len(schema) == 2
-        names = [field.name for field in schema]
-        assert "path" in names
-        assert "content_type" in names
+    def test_is_file_import(self, plugin: MarkdownImportPlugin) -> None:
+        assert plugin.is_file_import is True
+
+    def test_config_schema_has_no_path(self, plugin: MarkdownImportPlugin) -> None:
+        """Path is injected by the import service; only content_type remains."""
+        names = [field.name for field in plugin.get_config_schema()]
+        assert names == ["content_type"]
 
     def test_get_source_identifier(self, plugin: MarkdownImportPlugin) -> None:
         assert plugin.get_source_identifier() == "markdown_import"
+
+    def test_get_info_is_file_import(self, plugin: MarkdownImportPlugin) -> None:
+        assert plugin.get_info().is_file_import is True
 
 
 class TestMarkdownImportPluginValidation:
     """Tests for config validation."""
 
-    def test_validate_valid_config(
-        self, plugin: MarkdownImportPlugin, tmp_path: Path
-    ) -> None:
-        md_file = tmp_path / "books.md"
-        md_file.write_text("# Books\n")
-        errors = plugin.validate_config({"path": str(md_file), "content_type": "book"})
-        assert errors == []
+    def test_validate_valid_config(self, plugin: MarkdownImportPlugin) -> None:
+        assert plugin.validate_config({"content_type": "book"}) == []
 
-    def test_validate_missing_markdown_path(self, plugin: MarkdownImportPlugin) -> None:
-        errors = plugin.validate_config({"content_type": "book"})
-        assert any("path" in error for error in errors)
-
-    def test_validate_nonexistent_file(self, plugin: MarkdownImportPlugin) -> None:
-        errors = plugin.validate_config(
-            {"path": "/nonexistent/path.md", "content_type": "book"}
+    def test_validate_does_not_require_path(self, plugin: MarkdownImportPlugin) -> None:
+        """validate_config no longer requires a path — the service injects it."""
+        assert plugin.validate_config({"content_type": "book"}) == []
+        assert (
+            plugin.validate_config(
+                {"path": "/nonexistent/path.md", "content_type": "book"}
+            )
+            == []
         )
-        assert any("not found" in error for error in errors)
 
-    def test_validate_missing_content_type(
-        self, plugin: MarkdownImportPlugin, tmp_path: Path
-    ) -> None:
-        md_file = tmp_path / "books.md"
-        md_file.write_text("# Books\n")
-        errors = plugin.validate_config({"path": str(md_file)})
+    def test_validate_missing_content_type(self, plugin: MarkdownImportPlugin) -> None:
+        errors = plugin.validate_config({})
         assert any("content_type" in error for error in errors)
 
-    def test_validate_invalid_content_type(
-        self, plugin: MarkdownImportPlugin, tmp_path: Path
-    ) -> None:
-        md_file = tmp_path / "books.md"
-        md_file.write_text("# Books\n")
-        errors = plugin.validate_config(
-            {"path": str(md_file), "content_type": "podcast"}
-        )
+    def test_validate_invalid_content_type(self, plugin: MarkdownImportPlugin) -> None:
+        errors = plugin.validate_config({"content_type": "podcast"})
         assert any("Invalid content_type" in error for error in errors)
 
 

--- a/src/ingestion/sources/markdown/test_markdown.py
+++ b/src/ingestion/sources/markdown/test_markdown.py
@@ -63,7 +63,6 @@ class TestMarkdownImportPluginValidation:
 
     def test_validate_does_not_require_path(self, plugin: MarkdownImportPlugin) -> None:
         """validate_config no longer requires a path — the service injects it."""
-        assert plugin.validate_config({"content_type": "book"}) == []
         assert (
             plugin.validate_config(
                 {"path": "/nonexistent/path.md", "content_type": "book"}

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -1402,7 +1402,13 @@ async def import_data(
         file: The uploaded file.
 
     Returns:
-        The import result with item counts and any per-item errors.
+        The import result, with fields:
+
+        - ``message``: human-readable summary of the import.
+        - ``source``: the file-import plugin name the caller supplied.
+        - ``items_synced``: count of items successfully imported.
+        - ``total_items``: count of items parsed from the file.
+        - ``errors``: per-item error messages for rows that failed to import.
     """
     storage = get_storage()
     embedding_gen = get_embedding_gen()

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -2,20 +2,27 @@
 
 import json
 import logging
+import os
+import shutil
+import tempfile
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Annotated, Any, cast
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field
 
 from src import __version__ as APP_VERSION
 from src.cli.config import get_feature_flags
+from src.ingestion.import_service import FileImportError, import_file
 from src.ingestion.plugin_base import SourcePlugin
+from src.ingestion.registry import get_registry
 from src.ingestion.sync import (
     MAX_WORKERS_CEILING,
+    SyncResult,
     execute_multi_source_sync,
     resolve_max_workers,
 )
@@ -58,7 +65,7 @@ from src.web.state import (
     get_storage,
     reload_config,
 )
-from src.web.sync_manager import SyncJob, get_sync_manager
+from src.web.sync_manager import SyncInProgressError, SyncJob, get_sync_manager
 from src.web.sync_sources import (
     SourceConfigError,
     build_config_view,
@@ -68,6 +75,7 @@ from src.web.sync_sources import (
     delete_source,
     get_available_sync_sources,
     list_available_plugins,
+    list_importable_plugins,
     migrate_source,
     resolve_inputs,
     resolve_source_plugin,
@@ -471,6 +479,26 @@ class PluginInfoResponse(BaseModel):
     requires_api_key: bool
     requires_network: bool
     fields: list[SourceFieldSchema]
+
+
+class ImportSourceResponse(BaseModel):
+    """One file-import plugin's metadata and option schema for the upload form."""
+
+    name: str
+    display_name: str
+    description: str
+    content_types: list[str]
+    fields: list[SourceFieldSchema]
+
+
+class ImportResultResponse(BaseModel):
+    """Result of a one-shot file import."""
+
+    message: str
+    source: str
+    items_synced: int
+    total_items: int
+    errors: list[str] = Field(default_factory=list)
 
 
 class SourceCreateRequest(BaseModel):
@@ -1332,6 +1360,145 @@ async def update_data(request: UpdateRequest) -> dict[str, Any]:
         "message": f"Sync started for {source_label}. Use GET /api/sync/status to monitor progress.",
         "sources": sources_to_sync,
     }
+
+
+@router.get("/import/sources", response_model=list[ImportSourceResponse])
+async def get_import_sources() -> list[ImportSourceResponse]:
+    """List file-import plugins and their option schema for the upload form.
+
+    The frontend renders the upload form fields from each plugin's
+    ``fields`` schema. Only file-import plugins (Goodreads, CSV, JSON,
+    Markdown) are returned; syncable sources are excluded.
+    """
+    return [ImportSourceResponse(**info) for info in list_importable_plugins()]
+
+
+@router.post("/import", response_model=ImportResultResponse)
+async def import_data(
+    request: Request,
+    source: str = Form(..., description="File-import plugin name"),
+    file: UploadFile = File(..., description="The file to import"),
+) -> ImportResultResponse:
+    """Import a single uploaded file through a file-import plugin.
+
+    The upload is streamed to a temp file, run through the import pipeline
+    (tracked as a job so ``GET /sync/status`` reports progress), and the
+    temp file is always removed afterwards. Per-import options are read from
+    the multipart form by the plugin's config-schema field names (e.g.
+    ``content_type``).
+
+    Args:
+        request: The multipart request, used to read per-import option fields.
+        source: The file-import plugin name (e.g. ``goodreads``, ``csv_import``).
+        file: The uploaded file.
+
+    Returns:
+        The import result with item counts and any per-item errors.
+    """
+    storage = get_storage()
+    embedding_gen = get_embedding_gen()
+    config = get_config()
+
+    if not storage or not config:
+        raise HTTPException(status_code=500, detail="Components not initialized")
+
+    plugin = get_registry().get_plugin(source)
+    if plugin is None or not plugin.is_file_import:
+        raise HTTPException(
+            status_code=422, detail="Unknown or unsupported import source"
+        )
+
+    form = await request.form()
+    options: dict[str, Any] = {
+        field.name: form[field.name]
+        for field in plugin.get_config_schema()
+        if field.name in form
+    }
+
+    use_embeddings = get_feature_flags(config)["use_embeddings"]
+    enrichment_config = config.get("enrichment", {})
+    auto_enrich = enrichment_config.get("enabled", False) and enrichment_config.get(
+        "auto_enrich_on_sync", False
+    )
+
+    import_content_type: ContentType | None = None
+    content_type_value = options.get("content_type")
+    if content_type_value:
+        try:
+            import_content_type = ContentType(content_type_value)
+        except ValueError:
+            import_content_type = None
+
+    sync_manager = get_sync_manager()
+    job_label = f"Import: {plugin.display_name}"
+
+    suffix = Path(file.filename or "").suffix
+    fd, tmp_name = tempfile.mkstemp(suffix=suffix)
+    temp_path = Path(tmp_name)
+
+    captured: dict[str, SyncResult] = {}
+
+    def run_import(job: SyncJob) -> int:
+        def progress_callback(
+            items_processed: int,
+            total_items: int | None,
+            current_item: str | None,
+            current_source: str | None,
+        ) -> None:
+            sync_manager.update_progress(
+                source=job_label,
+                items_processed=items_processed,
+                total_items=total_items,
+                current_item=current_item,
+            )
+
+        result = import_file(
+            plugin_name=source,
+            file_path=temp_path,
+            options=options,
+            storage_manager=storage,
+            embedding_generator=embedding_gen,
+            use_embeddings=use_embeddings,
+            progress_callback=progress_callback,
+            mark_for_enrichment=auto_enrich,
+        )
+        for error in result.errors:
+            sync_manager.add_error(job_label, error)
+        captured["result"] = result
+        return result.items_synced
+
+    def on_complete() -> None:
+        if auto_enrich:
+            enrichment_manager = get_enrichment_manager()
+            enrichment_manager.start_enrichment(
+                storage_manager=storage,
+                config=config,
+                content_type=import_content_type,
+            )
+
+    try:
+        with os.fdopen(fd, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        await run_in_threadpool(
+            sync_manager.run_import, job_label, run_import, on_complete
+        )
+    except FileImportError as error:
+        # FileImportError messages are constructed strings (no stack traces);
+        # safe to surface so the user can fix the file or options.
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    except SyncInProgressError as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+    result = captured["result"]
+    return ImportResultResponse(
+        message=f"Imported {result.items_synced} item(s) from {plugin.display_name}.",
+        source=job_label,
+        items_synced=result.items_synced,
+        total_items=result.total_items,
+        errors=result.errors,
+    )
 
 
 @router.get("/status", response_model=StatusResponse)

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import os
-import shutil
 import tempfile
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -17,7 +16,11 @@ from pydantic import BaseModel, Field
 
 from src import __version__ as APP_VERSION
 from src.cli.config import get_feature_flags
-from src.ingestion.import_service import FileImportError, import_file
+from src.ingestion.import_service import (
+    FILE_NOT_READABLE_MESSAGE,
+    FileImportError,
+    import_file,
+)
 from src.ingestion.plugin_base import SourcePlugin
 from src.ingestion.registry import get_registry
 from src.ingestion.sync import (
@@ -86,6 +89,12 @@ from src.web.sync_sources import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Upload cap for POST /api/import. Streaming the upload in chunks keeps the
+# event loop responsive and bounds disk use so an oversized upload cannot
+# exhaust the host (it is rejected with 413 once the cap is crossed).
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+_UPLOAD_CHUNK_BYTES = 1024 * 1024
 
 router = APIRouter(prefix="/api", tags=["api"])
 
@@ -1409,10 +1418,13 @@ async def import_data(
         )
 
     form = await request.form()
-    options: dict[str, Any] = {
-        field.name: form[field.name]
+    # Only accept string form values for options: a client could send a file
+    # part named like a config field, and an UploadFile must never enter the
+    # options dict passed to the plugin.
+    options: dict[str, str] = {
+        field.name: value
         for field in plugin.get_config_schema()
-        if field.name in form
+        if field.name in form and isinstance(value := form[field.name], str)
     }
 
     use_embeddings = get_feature_flags(config)["use_embeddings"]
@@ -1421,13 +1433,16 @@ async def import_data(
         "auto_enrich_on_sync", False
     )
 
+    # content_type only scopes the enrichment run, so derive it solely on the
+    # auto-enrich path where it is consumed.
     import_content_type: ContentType | None = None
-    content_type_value = options.get("content_type")
-    if content_type_value:
-        try:
-            import_content_type = ContentType(content_type_value)
-        except ValueError:
-            import_content_type = None
+    if auto_enrich:
+        content_type_value = options.get("content_type", "")
+        if content_type_value != "":
+            try:
+                import_content_type = ContentType(content_type_value)
+            except ValueError:
+                import_content_type = None
 
     sync_manager = get_sync_manager()
     job_label = f"Import: {plugin.display_name}"
@@ -1477,14 +1492,33 @@ async def import_data(
             )
 
     try:
+        # Stream the upload in chunks (await keeps the event loop free) and
+        # abort once the byte cap is crossed; the finally block removes the
+        # partial temp file on every exit path, including the 413.
+        total = 0
         with os.fdopen(fd, "wb") as buffer:
-            shutil.copyfileobj(file.file, buffer)
+            while chunk := await file.read(_UPLOAD_CHUNK_BYTES):
+                total += len(chunk)
+                if total > MAX_UPLOAD_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            f"Upload exceeds the "
+                            f"{MAX_UPLOAD_BYTES // (1024 * 1024)} MB limit."
+                        ),
+                    )
+                buffer.write(chunk)
         await run_in_threadpool(
             sync_manager.run_import, job_label, run_import, on_complete
         )
     except FileImportError as error:
         # FileImportError messages are constructed strings (no stack traces);
-        # safe to surface so the user can fix the file or options.
+        # safe to surface so the user can fix the file or options — except the
+        # not-readable case, whose message embeds the internal temp path.
+        if str(error).startswith(FILE_NOT_READABLE_MESSAGE):
+            raise HTTPException(
+                status_code=400, detail="The uploaded file could not be read"
+            ) from error
         raise HTTPException(status_code=400, detail=str(error)) from error
     except SyncInProgressError as error:
         raise HTTPException(status_code=409, detail=str(error)) from error
@@ -1494,7 +1528,9 @@ async def import_data(
     result = captured["result"]
     return ImportResultResponse(
         message=f"Imported {result.items_synced} item(s) from {plugin.display_name}.",
-        source=job_label,
+        # The plugin name the user supplied — what a `source` field should mean.
+        # The internal "Import: <display_name>" job label stays in sync status.
+        source=source,
         items_synced=result.items_synced,
         total_items=result.total_items,
         errors=result.errors,

--- a/src/web/sync_manager.py
+++ b/src/web/sync_manager.py
@@ -322,12 +322,15 @@ class SyncManager:
 
         try:
             count = import_function(job)
-        except Exception:
+        except Exception as error:
             with self._lock:
                 job.status = SyncStatus.FAILED
                 job.completed_at = datetime.now()
-                if job.error_message is None and job.errors:
-                    job.error_message = job.errors[0]
+                if job.error_message is None:
+                    # Prefer a per-item error; otherwise fall back to the raised
+                    # exception so a failure before any add_error still reports a
+                    # message instead of leaving error_message None.
+                    job.error_message = job.errors[0] if job.errors else str(error)
             raise
 
         with self._lock:

--- a/src/web/sync_manager.py
+++ b/src/web/sync_manager.py
@@ -17,6 +17,19 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+class SyncInProgressError(Exception):
+    """Raised when an inline tracked job starts while one for the same key runs.
+
+    ``run_import`` runs in the calling thread (so the caller can surface an
+    error), unlike the fire-and-forget ``start_sync``; it signals a duplicate
+    via this exception rather than a ``(success, message)`` tuple.
+    """
+
+    def __init__(self, source: str) -> None:
+        super().__init__(f"A job for {source} is already running")
+        self.source = source
+
+
 class SyncStatus(str, Enum):
     """Status of a sync job."""
 
@@ -228,18 +241,7 @@ class SyncManager:
         try:
             count = sync_function(job)
             with self._lock:
-                job.completed_at = datetime.now()
-                job.items_processed = count
-                # A sync that produced zero items but logged errors is a
-                # failure, not a success — plugins like Epic Games catch
-                # their own exceptions and report them via add_error, and
-                # the UI banner branches on the status field.
-                if count == 0 and job.errors:
-                    job.status = SyncStatus.FAILED
-                    job.error_message = job.errors[0]
-                else:
-                    job.status = SyncStatus.COMPLETED
-                final_status = job.status
+                final_status = self._finalize_job_locked(job, count)
                 error_count = len(job.errors)
 
             if final_status == SyncStatus.COMPLETED:
@@ -263,6 +265,81 @@ class SyncManager:
                 job.completed_at = datetime.now()
                 job.error_message = "Sync failed due to an internal error"
             logger.error("Sync failed for %s", source, exc_info=True)
+
+    def _finalize_job_locked(self, job: SyncJob, count: int) -> SyncStatus:
+        """Transition a finished job to COMPLETED/FAILED. Caller holds the lock.
+
+        A job that produced zero items but logged errors is a failure, not a
+        success — plugins like Epic Games catch their own exceptions and
+        report them via ``add_error``, and the UI banner branches on status.
+        """
+        job.completed_at = datetime.now()
+        job.items_processed = count
+        if count == 0 and job.errors:
+            job.status = SyncStatus.FAILED
+            job.error_message = job.errors[0]
+        else:
+            job.status = SyncStatus.COMPLETED
+        return job.status
+
+    def run_import(
+        self,
+        source: str,
+        import_function: Callable[[SyncJob], int],
+        on_complete: Callable[[], None] | None = None,
+    ) -> int:
+        """Run a one-shot import inline, tracked as a job for status polling.
+
+        Unlike :meth:`start_sync` (background, fire-and-forget), this runs in
+        the calling thread and re-raises any exception so the web handler can
+        map a ``FileImportError`` onto an HTTP response. The job is registered
+        and finalised exactly like a background sync, so :meth:`get_status`
+        reports its progress and final state to a polling frontend.
+
+        Args:
+            source: Label that identifies the job (used as the dict key).
+            import_function: Callable that performs the import, accepting the
+                ``SyncJob`` for progress updates and returning the item count.
+            on_complete: Optional callback run after a successful import.
+
+        Returns:
+            The number of items imported.
+
+        Raises:
+            SyncInProgressError: If a job for ``source`` is already running.
+        """
+        with self._lock:
+            existing = self._jobs.get(source)
+            if existing is not None and existing.status == SyncStatus.RUNNING:
+                raise SyncInProgressError(source)
+            job = SyncJob(
+                source=source,
+                status=SyncStatus.RUNNING,
+                started_at=datetime.now(),
+            )
+            self._jobs[source] = job
+            self._evict_history_locked()
+
+        try:
+            count = import_function(job)
+        except Exception:
+            with self._lock:
+                job.status = SyncStatus.FAILED
+                job.completed_at = datetime.now()
+                if job.error_message is None and job.errors:
+                    job.error_message = job.errors[0]
+            raise
+
+        with self._lock:
+            final_status = self._finalize_job_locked(job, count)
+
+        if final_status == SyncStatus.COMPLETED and on_complete is not None:
+            try:
+                on_complete()
+            except Exception as callback_error:
+                logger.error("Import on_complete callback failed: %s", callback_error)
+
+        return count
 
     def update_progress(
         self,

--- a/src/web/sync_sources.py
+++ b/src/web/sync_sources.py
@@ -153,6 +153,14 @@ def resolve_inputs(
             )
             continue
 
+        if plugin.is_file_import:
+            logger.warning(
+                "path-based import for '%s' has been removed; "
+                "use the web upload or `import --file`",
+                source_id,
+            )
+            continue
+
         plugin_config = dict(raw_fields)
         plugin_config["_source_id"] = source_id
 
@@ -231,6 +239,10 @@ def get_available_sync_sources(
 
         plugin = registry.get_plugin(plugin_name)
         if plugin is None:
+            continue
+
+        # File-import plugins are one-shot uploads, not syncable sources.
+        if plugin.is_file_import:
             continue
 
         sources.append(

--- a/src/web/sync_sources.py
+++ b/src/web/sync_sources.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 
 from src.ingestion.plugin_base import SourcePlugin
 from src.ingestion.registry import get_registry
+from src.models.config_field import ConfigField
 from src.utils.text import humanize_source_id
 
 if TYPE_CHECKING:
@@ -362,6 +363,22 @@ def field_type_name(field_type: type) -> str:
     return "str"
 
 
+def _field_view(field: ConfigField) -> dict[str, Any]:
+    """Serialise one ``ConfigField`` to the wire shape used by every schema view.
+
+    ``default`` is masked to ``None`` for sensitive fields so a plugin that
+    hard-codes a placeholder credential as the default never leaks it.
+    """
+    return {
+        "name": field.name,
+        "field_type": field_type_name(field.field_type),
+        "required": field.required,
+        "default": None if field.sensitive else field.default,
+        "description": field.description,
+        "sensitive": field.sensitive,
+    }
+
+
 def resolve_source_plugin(
     source_id: str,
     config: dict[str, Any] | None,
@@ -411,17 +428,7 @@ def build_schema_view(source_id: str, plugin: SourcePlugin) -> dict[str, Any]:
         "source_id": source_id,
         "plugin": plugin.name,
         "plugin_display_name": plugin.display_name,
-        "fields": [
-            {
-                "name": field.name,
-                "field_type": field_type_name(field.field_type),
-                "required": field.required,
-                "default": None if field.sensitive else field.default,
-                "description": field.description,
-                "sensitive": field.sensitive,
-            }
-            for field in plugin.get_config_schema()
-        ],
+        "fields": [_field_view(field) for field in plugin.get_config_schema()],
     }
 
 
@@ -687,19 +694,33 @@ def list_available_plugins() -> list[dict[str, Any]]:
                 "content_types": [str(ct.value) for ct in plugin.content_types],
                 "requires_api_key": plugin.requires_api_key,
                 "requires_network": plugin.requires_network,
-                # Sensitive defaults are masked — a stray placeholder credential
-                # in a plugin schema would otherwise leak via this endpoint.
-                "fields": [
-                    {
-                        "name": field.name,
-                        "field_type": field_type_name(field.field_type),
-                        "required": field.required,
-                        "default": None if field.sensitive else field.default,
-                        "description": field.description,
-                        "sensitive": field.sensitive,
-                    }
-                    for field in plugin.get_config_schema()
-                ],
+                "fields": [_field_view(field) for field in plugin.get_config_schema()],
+            }
+        )
+    return plugins
+
+
+def list_importable_plugins() -> list[dict[str, Any]]:
+    """Return metadata for every file-import plugin, sorted by name.
+
+    Drives the web upload form (``GET /api/import/sources``) and the CLI
+    ``import --source list`` listing: only plugins whose ``is_file_import``
+    is True are included, each with the option schema the user fills in
+    alongside the uploaded file. Non-file-import (syncable) plugins are
+    excluded.
+    """
+    registry = get_registry()
+    plugins = []
+    for name, plugin in sorted(registry.get_all_plugins().items()):
+        if not plugin.is_file_import:
+            continue
+        plugins.append(
+            {
+                "name": name,
+                "display_name": plugin.display_name,
+                "description": plugin.description,
+                "content_types": [str(ct.value) for ct in plugin.content_types],
+                "fields": [_field_view(field) for field in plugin.get_config_schema()],
             }
         )
     return plugins

--- a/tests/cli/test_cli_import.py
+++ b/tests/cli/test_cli_import.py
@@ -1,0 +1,167 @@
+"""Tests for the CLI import command."""
+
+import json
+from unittest.mock import MagicMock
+
+from src.storage.manager import StorageManager
+from tests.cli.conftest import _invoke_with_mocks
+
+# Goodreads CSV export header recognised by the goodreads plugin.
+_GOODREADS_CSV = (
+    "Title,Author,My Rating,Exclusive Shelf,Date Read\n"
+    "Dune,Frank Herbert,5,read,2020/01/01\n"
+    "Neuromancer,William Gibson,4,read,2020/02/01\n"
+)
+
+
+class TestImportCommand:
+    """Tests for ``recommendinator import``."""
+
+    def test_list_sources_json_matches_importable_plugins(self, cli_runner):
+        """--source list --format json mirrors GET /api/import/sources."""
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["import", "--source", "list", "--format", "json"],
+            MagicMock(spec=StorageManager),
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        names = [plugin["name"] for plugin in data]
+        assert names == ["csv_import", "goodreads", "json_import", "markdown_import"]
+        csv_plugin = next(p for p in data if p["name"] == "csv_import")
+        assert [f["name"] for f in csv_plugin["fields"]] == ["content_type"]
+
+    def test_goodreads_import_success(self, cli_runner, tmp_path):
+        """A Goodreads CSV file imports every parsed book."""
+        storage = MagicMock(spec=StorageManager)
+        storage.save_content_item.return_value = 1
+        data_file = tmp_path / "books.csv"
+        data_file.write_text(_GOODREADS_CSV)
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["import", "--source", "goodreads", "--file", str(data_file)],
+            storage,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Imported 2/2 items from goodreads." in result.output
+
+    def test_csv_import_passes_content_type_option(self, cli_runner, tmp_path):
+        """--content-type is forwarded as the import option and drives parsing."""
+        storage = MagicMock(spec=StorageManager)
+        storage.save_content_item.return_value = 1
+        data_file = tmp_path / "books.csv"
+        data_file.write_text("title,author,status,rating\nDune,Frank Herbert,read,5\n")
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            [
+                "import",
+                "--source",
+                "csv_import",
+                "--file",
+                str(data_file),
+                "--content-type",
+                "book",
+            ],
+            storage,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Imported 1/1 items from csv_import." in result.output
+        saved_item = storage.save_content_item.call_args.args[0]
+        assert saved_item.title == "Dune"
+
+    def test_option_flag_passes_through_to_service(self, cli_runner, tmp_path):
+        """A repeatable --option KEY=VALUE pair reaches the import service."""
+        storage = MagicMock(spec=StorageManager)
+        storage.save_content_item.return_value = 1
+        data_file = tmp_path / "books.csv"
+        data_file.write_text("title,author,status,rating\nDune,Frank Herbert,read,5\n")
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            [
+                "import",
+                "--source",
+                "csv_import",
+                "--file",
+                str(data_file),
+                "--option",
+                "content_type=book",
+            ],
+            storage,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Imported 1/1 items from csv_import." in result.output
+
+    def test_invalid_option_format_errors(self, cli_runner, tmp_path):
+        """An --option without '=' is rejected before importing."""
+        storage = MagicMock(spec=StorageManager)
+        data_file = tmp_path / "books.csv"
+        data_file.write_text("title\nDune\n")
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            [
+                "import",
+                "--source",
+                "csv_import",
+                "--file",
+                str(data_file),
+                "--option",
+                "bogus",
+            ],
+            storage,
+        )
+        assert result.exit_code != 0
+        assert "Invalid --option" in result.output
+
+    def test_missing_file_errors(self, cli_runner, tmp_path):
+        """A non-existent --file path exits non-zero with a readable message."""
+        storage = MagicMock(spec=StorageManager)
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["import", "--source", "goodreads", "--file", str(tmp_path / "nope.csv")],
+            storage,
+        )
+        assert result.exit_code != 0
+        assert "File not found" in result.output
+
+    def test_unknown_source_errors(self, cli_runner, tmp_path):
+        """An unregistered source exits non-zero with a clear message."""
+        storage = MagicMock(spec=StorageManager)
+        data_file = tmp_path / "x.csv"
+        data_file.write_text("ignored\n")
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["import", "--source", "does_not_exist", "--file", str(data_file)],
+            storage,
+        )
+        assert result.exit_code != 0
+        assert "Unknown plugin" in result.output
+
+    def test_non_file_import_source_errors(self, cli_runner, tmp_path):
+        """A syncable (non-file-import) source exits non-zero with a clear message."""
+        storage = MagicMock(spec=StorageManager)
+        data_file = tmp_path / "x.csv"
+        data_file.write_text("ignored\n")
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["import", "--source", "sonarr", "--file", str(data_file)],
+            storage,
+        )
+        assert result.exit_code != 0
+        assert "does not support file import" in result.output
+
+    def test_file_required_without_list(self, cli_runner):
+        """Omitting --file (without --source list) is an error."""
+        storage = MagicMock(spec=StorageManager)
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["import", "--source", "goodreads"],
+            storage,
+        )
+        assert result.exit_code != 0
+        assert "--file is required" in result.output

--- a/tests/cli/test_cli_import.py
+++ b/tests/cli/test_cli_import.py
@@ -13,6 +13,21 @@ _GOODREADS_CSV = (
     "Neuromancer,William Gibson,4,read,2020/02/01\n"
 )
 
+# Generic JSON array recognised by the json_import plugin.
+_JSON_BOOKS = json.dumps(
+    [
+        {"title": "Dune", "author": "Frank Herbert", "status": "completed"},
+        {"title": "Neuromancer", "author": "William Gibson", "status": "read"},
+    ]
+)
+
+# Markdown export recognised by the markdown_import plugin.
+_MARKDOWN_BOOKS = (
+    "## Completed\n"
+    "- **Dune** by Frank Herbert | Rating: 5\n"
+    "- **Neuromancer** by William Gibson | Rating: 4\n"
+)
+
 
 class TestImportCommand:
     """Tests for ``recommendinator import``."""
@@ -93,6 +108,70 @@ class TestImportCommand:
         )
         assert result.exit_code == 0, result.output
         assert "Imported 1/1 items from csv_import." in result.output
+
+    def test_json_import_success(self, cli_runner, tmp_path):
+        """A JSON file imports every parsed entry (criterion 2: JSON format)."""
+        storage = MagicMock(spec=StorageManager)
+        storage.save_content_item.return_value = 1
+        data_file = tmp_path / "books.json"
+        data_file.write_text(_JSON_BOOKS)
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            [
+                "import",
+                "--source",
+                "json_import",
+                "--file",
+                str(data_file),
+                "--content-type",
+                "book",
+            ],
+            storage,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Imported 2/2 items from json_import." in result.output
+
+    def test_markdown_import_success(self, cli_runner, tmp_path):
+        """A markdown file imports every parsed entry (criterion 2: markdown)."""
+        storage = MagicMock(spec=StorageManager)
+        storage.save_content_item.return_value = 1
+        data_file = tmp_path / "books.md"
+        data_file.write_text(_MARKDOWN_BOOKS)
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            [
+                "import",
+                "--source",
+                "markdown_import",
+                "--file",
+                str(data_file),
+                "--content-type",
+                "book",
+            ],
+            storage,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Imported 2/2 items from markdown_import." in result.output
+
+    def test_missing_required_option_errors(self, cli_runner, tmp_path):
+        """Omitting content_type for a generic format exits non-zero, no traceback.
+
+        csv_import requires content_type; without it the service raises
+        FileImportError and the CLI must abort with a readable message.
+        """
+        storage = MagicMock(spec=StorageManager)
+        data_file = tmp_path / "books.csv"
+        data_file.write_text("title\nDune\n")
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["import", "--source", "csv_import", "--file", str(data_file)],
+            storage,
+        )
+        assert result.exit_code != 0
+        assert "content_type" in result.output
 
     def test_invalid_option_format_errors(self, cli_runner, tmp_path):
         """An --option without '=' is rejected before importing."""

--- a/tests/cli/test_cli_import.py
+++ b/tests/cli/test_cli_import.py
@@ -98,6 +98,62 @@ class TestImportCommand:
         assert result.exit_code == 0, result.output
         assert "Imported 2/2 items from goodreads." in result.output
 
+    def test_per_item_error_warning_in_table_output(self, cli_runner, tmp_path):
+        """A row that fails to save surfaces a per-item warning in table output.
+
+        The first book's save raises and the second succeeds, so the import
+        completes with one item and prints a per-item warning for the failed
+        row (without leaking the raw exception text).
+        """
+        storage = MagicMock(spec=StorageManager)
+        storage.save_content_item.side_effect = [RuntimeError("db write failed"), 1]
+        data_file = tmp_path / "books.csv"
+        data_file.write_text(GOODREADS_CSV)
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            ["import", "--source", "goodreads", "--file", str(data_file)],
+            storage,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Imported 1/2 items from goodreads." in result.output
+        assert "Warning: Failed to process 'Dune'" in result.output
+        # The raw exception text must never leak to the user.
+        assert "db write failed" not in result.output
+
+    def test_per_item_error_populates_json_errors(self, cli_runner, tmp_path):
+        """--format json surfaces failed rows in the errors array.
+
+        Mirrors the web POST /api/import per-item error contract: a partially
+        failing import still exits 0, reports the surviving count, and lists the
+        safe per-item error string for the failed row.
+        """
+        storage = MagicMock(spec=StorageManager)
+        storage.save_content_item.side_effect = [RuntimeError("db write failed"), 1]
+        data_file = tmp_path / "books.csv"
+        data_file.write_text(GOODREADS_CSV)
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            [
+                "import",
+                "--source",
+                "goodreads",
+                "--file",
+                str(data_file),
+                "--format",
+                "json",
+            ],
+            storage,
+        )
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert body["items_synced"] == 1
+        assert body["total_items"] == 2
+        assert body["errors"] == ["Failed to process 'Dune'"]
+        # The raw exception text must never leak to the user.
+        assert "db write failed" not in result.output
+
     def test_csv_import_passes_content_type_option(self, cli_runner, tmp_path):
         """--content-type is forwarded as the import option and drives parsing."""
         storage = MagicMock(spec=StorageManager)

--- a/tests/cli/test_cli_import.py
+++ b/tests/cli/test_cli_import.py
@@ -5,13 +5,7 @@ from unittest.mock import MagicMock
 
 from src.storage.manager import StorageManager
 from tests.cli.conftest import _invoke_with_mocks
-
-# Goodreads CSV export header recognised by the goodreads plugin.
-_GOODREADS_CSV = (
-    "Title,Author,My Rating,Exclusive Shelf,Date Read\n"
-    "Dune,Frank Herbert,5,read,2020/01/01\n"
-    "Neuromancer,William Gibson,4,read,2020/02/01\n"
-)
+from tests.import_test_data import GOODREADS_CSV
 
 # Generic JSON array recognised by the json_import plugin.
 _JSON_BOOKS = json.dumps(
@@ -41,17 +35,60 @@ class TestImportCommand:
         )
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
-        names = [plugin["name"] for plugin in data]
-        assert names == ["csv_import", "goodreads", "json_import", "markdown_import"]
+        names = {plugin["name"] for plugin in data}
+        # Subset (not equality) so adding a fifth file-import plugin later does
+        # not break this test; the contract is that these four are importable.
+        assert {"csv_import", "goodreads", "json_import", "markdown_import"} <= names
+        # Syncable sources are excluded from the importable listing.
+        assert "roms" not in names
         csv_plugin = next(p for p in data if p["name"] == "csv_import")
         assert [f["name"] for f in csv_plugin["fields"]] == ["content_type"]
+
+    def test_import_result_json_matches_web_fields(self, cli_runner, tmp_path):
+        """--format json on a real import emits the web ImportResultResponse shape.
+
+        The CLI previously honoured --format only for --source list; an actual
+        import always printed prose. This pins the JSON result path so a JSON
+        consumer gets the same fields (including errors) from either interface.
+        """
+        storage = MagicMock(spec=StorageManager)
+        storage.save_content_item.return_value = 1
+        data_file = tmp_path / "books.csv"
+        data_file.write_text(GOODREADS_CSV)
+
+        result = _invoke_with_mocks(
+            cli_runner,
+            [
+                "import",
+                "--source",
+                "goodreads",
+                "--file",
+                str(data_file),
+                "--format",
+                "json",
+            ],
+            storage,
+        )
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert set(body) == {
+            "message",
+            "source",
+            "items_synced",
+            "total_items",
+            "errors",
+        }
+        assert body["source"] == "goodreads"
+        assert body["items_synced"] == 2
+        assert body["total_items"] == 2
+        assert body["errors"] == []
 
     def test_goodreads_import_success(self, cli_runner, tmp_path):
         """A Goodreads CSV file imports every parsed book."""
         storage = MagicMock(spec=StorageManager)
         storage.save_content_item.return_value = 1
         data_file = tmp_path / "books.csv"
-        data_file.write_text(_GOODREADS_CSV)
+        data_file.write_text(GOODREADS_CSV)
 
         result = _invoke_with_mocks(
             cli_runner,

--- a/tests/import_test_data.py
+++ b/tests/import_test_data.py
@@ -1,0 +1,8 @@
+"""Shared sample import files for the web and CLI import tests."""
+
+# Goodreads CSV export header recognised by the goodreads plugin.
+GOODREADS_CSV = (
+    "Title,Author,My Rating,Exclusive Shelf,Date Read\n"
+    "Dune,Frank Herbert,5,read,2020/01/01\n"
+    "Neuromancer,William Gibson,4,read,2020/02/01\n"
+)

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -207,6 +207,33 @@ class TestImportFile:
                 storage_manager=storage,
             )
 
+    def test_progress_callback_is_invoked(
+        self, storage: StorageManager, tmp_path: Path
+    ) -> None:
+        """The progress callback is forwarded to the pipeline and called."""
+        data_file = tmp_path / "books.txt"
+        data_file.write_text("Dune\nNeuromancer\n")
+
+        calls: list[tuple[int, int | None, str | None, str | None]] = []
+
+        def record(
+            items_processed: int,
+            total_items: int | None,
+            current_item: str | None,
+            current_source: str | None,
+        ) -> None:
+            calls.append((items_processed, total_items, current_item, current_source))
+
+        import_file(
+            plugin_name="fake_file",
+            file_path=data_file,
+            options={"content_type": "book"},
+            storage_manager=storage,
+            progress_callback=record,
+        )
+
+        assert calls, "expected at least one progress update during import"
+
     def test_path_option_is_injected_not_taken_from_options(
         self, storage: StorageManager, tmp_path: Path
     ) -> None:

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -1,0 +1,224 @@
+"""Tests for the one-shot file-import service."""
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.ingestion.import_service import FileImportError, import_file
+from src.ingestion.plugin_base import ConfigField, SourceError, SourcePlugin
+from src.ingestion.registry import PluginRegistry
+from src.models.content import ConsumptionStatus, ContentItem, ContentType
+from src.storage.manager import StorageManager
+
+
+class FakeFileImportPlugin(SourcePlugin):
+    """File-import plugin that reads one title per line.
+
+    A line equal to ``CORRUPT`` makes ``fetch`` raise ``SourceError`` so the
+    corrupt-file path can be exercised.
+    """
+
+    @property
+    def name(self) -> str:
+        return "fake_file"
+
+    @property
+    def display_name(self) -> str:
+        return "Fake File"
+
+    @property
+    def content_types(self) -> list[ContentType]:
+        return [ContentType.BOOK]
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    @property
+    def is_file_import(self) -> bool:
+        return True
+
+    def get_config_schema(self) -> list[ConfigField]:
+        return [ConfigField(name="content_type", field_type=str, required=True)]
+
+    def validate_config(self, config: dict[str, Any], **kwargs: Any) -> list[str]:
+        if not config.get("content_type"):
+            return ["'content_type' is required"]
+        return []
+
+    def fetch(self, config: dict[str, Any], **kwargs: Any) -> Iterator[ContentItem]:
+        for line in Path(config["path"]).read_text(encoding="utf-8").splitlines():
+            title = line.strip()
+            if not title:
+                continue
+            if title == "CORRUPT":
+                raise SourceError(self.name, "unparseable file")
+            yield ContentItem(
+                title=title,
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.COMPLETED,
+                source=self.get_source_identifier(config),
+            )
+
+
+class FakeSyncablePlugin(SourcePlugin):
+    """A normal (non-file-import) syncable plugin."""
+
+    @property
+    def name(self) -> str:
+        return "fake_syncable"
+
+    @property
+    def display_name(self) -> str:
+        return "Fake Syncable"
+
+    @property
+    def content_types(self) -> list[ContentType]:
+        return [ContentType.VIDEO_GAME]
+
+    @property
+    def requires_api_key(self) -> bool:
+        return True
+
+    def get_config_schema(self) -> list[ConfigField]:
+        return []
+
+    def validate_config(self, config: dict[str, Any], **kwargs: Any) -> list[str]:
+        return []
+
+    def fetch(self, config: dict[str, Any], **kwargs: Any) -> Iterator[ContentItem]:
+        yield ContentItem(
+            title="Game",
+            content_type=ContentType.VIDEO_GAME,
+            status=ConsumptionStatus.UNREAD,
+            source=self.get_source_identifier(config),
+        )
+
+
+@pytest.fixture()
+def _registry_with_fakes() -> Iterator[None]:
+    registry = PluginRegistry.get_instance()
+    registry._discovered = True
+    registry._plugins.clear()
+    registry.register(FakeFileImportPlugin())
+    registry.register(FakeSyncablePlugin())
+    yield
+    PluginRegistry.reset_instance()
+
+
+@pytest.fixture()
+def storage(tmp_path: Path) -> StorageManager:
+    return StorageManager(sqlite_path=tmp_path / "test.db")
+
+
+@pytest.mark.usefixtures("_registry_with_fakes")
+class TestImportFile:
+    """Tests for import_file."""
+
+    def test_valid_file_returns_expected_counts(
+        self, storage: StorageManager, tmp_path: Path
+    ) -> None:
+        """A valid file is parsed, persisted, and counted."""
+        data_file = tmp_path / "books.txt"
+        data_file.write_text("Dune\nNeuromancer\n")
+
+        result = import_file(
+            plugin_name="fake_file",
+            file_path=data_file,
+            options={"content_type": "book"},
+            storage_manager=storage,
+        )
+
+        assert result.items_synced == 2
+        assert result.total_items == 2
+        assert result.errors == []
+
+    def test_non_file_import_plugin_rejected(
+        self, storage: StorageManager, tmp_path: Path
+    ) -> None:
+        """A syncable (non-file-import) plugin cannot be imported via a file."""
+        data_file = tmp_path / "x.txt"
+        data_file.write_text("ignored\n")
+
+        with pytest.raises(FileImportError, match="does not support file import"):
+            import_file(
+                plugin_name="fake_syncable",
+                file_path=data_file,
+                options={},
+                storage_manager=storage,
+            )
+
+    def test_unknown_plugin_rejected(
+        self, storage: StorageManager, tmp_path: Path
+    ) -> None:
+        """An unregistered plugin name raises a clear error."""
+        data_file = tmp_path / "x.txt"
+        data_file.write_text("ignored\n")
+
+        with pytest.raises(FileImportError, match="Unknown plugin"):
+            import_file(
+                plugin_name="does_not_exist",
+                file_path=data_file,
+                options={"content_type": "book"},
+                storage_manager=storage,
+            )
+
+    def test_missing_file_rejected(
+        self, storage: StorageManager, tmp_path: Path
+    ) -> None:
+        """A path that is not a readable file raises a clear error."""
+        with pytest.raises(FileImportError, match="File not found or not readable"):
+            import_file(
+                plugin_name="fake_file",
+                file_path=tmp_path / "nope.txt",
+                options={"content_type": "book"},
+                storage_manager=storage,
+            )
+
+    def test_invalid_options_rejected(
+        self, storage: StorageManager, tmp_path: Path
+    ) -> None:
+        """Options that fail plugin validation raise FileImportError."""
+        data_file = tmp_path / "books.txt"
+        data_file.write_text("Dune\n")
+
+        with pytest.raises(FileImportError, match="content_type"):
+            import_file(
+                plugin_name="fake_file",
+                file_path=data_file,
+                options={},
+                storage_manager=storage,
+            )
+
+    def test_corrupt_file_surfaces_typed_error(
+        self, storage: StorageManager, tmp_path: Path
+    ) -> None:
+        """A SourceError from fetch is wrapped in a typed FileImportError."""
+        data_file = tmp_path / "books.txt"
+        data_file.write_text("CORRUPT\n")
+
+        with pytest.raises(FileImportError, match="unparseable file"):
+            import_file(
+                plugin_name="fake_file",
+                file_path=data_file,
+                options={"content_type": "book"},
+                storage_manager=storage,
+            )
+
+    def test_path_option_is_injected_not_taken_from_options(
+        self, storage: StorageManager, tmp_path: Path
+    ) -> None:
+        """The service injects the file path; the file argument wins."""
+        real_file = tmp_path / "real.txt"
+        real_file.write_text("Dune\n")
+
+        result = import_file(
+            plugin_name="fake_file",
+            file_path=real_file,
+            options={"content_type": "book", "path": "/bogus/ignored.txt"},
+            storage_manager=storage,
+        )
+
+        assert result.items_synced == 1

--- a/tests/test_plugin_base.py
+++ b/tests/test_plugin_base.py
@@ -12,6 +12,12 @@ from src.ingestion.plugin_base import (
     SourceError,
     SourcePlugin,
 )
+from src.ingestion.sources.generic_csv.generic_csv import CsvImportPlugin
+from src.ingestion.sources.generic_json.generic_json import JsonImportPlugin
+from src.ingestion.sources.goodreads.goodreads import GoodreadsPlugin
+from src.ingestion.sources.markdown.markdown import MarkdownImportPlugin
+from src.ingestion.sources.roms.roms import RomScannerPlugin
+from src.ingestion.sources.steam.steam import SteamPlugin
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
 
 
@@ -204,6 +210,10 @@ class TestSourcePlugin:
         assert file_plugin.requires_network is False
         assert api_plugin.requires_network is True
 
+    def test_is_file_import_defaults_false(self) -> None:
+        """Plugins are syncable sources unless they opt into file import."""
+        assert MockPlugin().is_file_import is False
+
     def test_get_config_schema(self) -> None:
         """Test getting configuration schema."""
         plugin = MockPlugin()
@@ -257,6 +267,7 @@ class TestSourcePlugin:
         assert info.content_types == [ContentType.BOOK]
         assert info.requires_api_key is False
         assert info.requires_network is False
+        assert info.is_file_import is False
         assert len(info.config_schema) == 2
 
 
@@ -331,6 +342,7 @@ class TestPluginInfo:
         assert ContentType.MOVIE in info.content_types
         assert info.requires_api_key is True
         assert info.config_schema == []
+        assert info.is_file_import is False
 
     def test_plugin_info_with_schema(self) -> None:
         """Test PluginInfo with config schema."""
@@ -348,3 +360,22 @@ class TestPluginInfo:
 
         assert len(info.config_schema) == 1
         assert info.config_schema[0].name == "url"
+
+
+class TestFileImportPluginFlags:
+    """The four single-file import plugins opt into ``is_file_import``;
+    directory-scan and API sources stay syncable (``is_file_import`` False).
+    """
+
+    def test_file_import_plugins_marked(self) -> None:
+        for plugin in (
+            GoodreadsPlugin(),
+            CsvImportPlugin(),
+            JsonImportPlugin(),
+            MarkdownImportPlugin(),
+        ):
+            assert plugin.is_file_import is True, plugin.name
+
+    def test_directory_scan_and_api_sources_not_marked(self) -> None:
+        assert RomScannerPlugin().is_file_import is False
+        assert SteamPlugin().is_file_import is False

--- a/tests/test_sync_sources.py
+++ b/tests/test_sync_sources.py
@@ -164,6 +164,45 @@ class FakeCredentialPlugin(SourcePlugin):
         )
 
 
+class FakeFileImportPlugin(SourcePlugin):
+    """Fake one-shot file-import plugin (not a syncable source)."""
+
+    @property
+    def name(self) -> str:
+        return "fake_file"
+
+    @property
+    def display_name(self) -> str:
+        return "Fake File"
+
+    @property
+    def content_types(self) -> list[ContentType]:
+        return [ContentType.BOOK]
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    @property
+    def is_file_import(self) -> bool:
+        return True
+
+    def get_config_schema(self) -> list[ConfigField]:
+        return []
+
+    def validate_config(self, config: dict[str, Any], **kwargs: Any) -> list[str]:
+        return []
+
+    def fetch(self, config: dict[str, Any]) -> Iterator[ContentItem]:
+        yield ContentItem(
+            id="file_1",
+            title="Fake File Item",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            source=self.get_source_identifier(config),
+        )
+
+
 @pytest.fixture()
 def _registry_with_fakes() -> Iterator[None]:
     """Set up a registry with fake plugins for testing."""
@@ -173,6 +212,7 @@ def _registry_with_fakes() -> Iterator[None]:
     registry.register(FakeBookPlugin())
     registry.register(FakeGamePlugin())
     registry.register(FakeCredentialPlugin())
+    registry.register(FakeFileImportPlugin())
     yield
     PluginRegistry.reset_instance()
 
@@ -344,6 +384,94 @@ class TestResolveInputs:
         assert len(resolved) == 2
         source_ids = {entry.source_id for entry in resolved}
         assert source_ids == {"my_books", "more_books"}
+
+
+@pytest.mark.usefixtures("_registry_with_fakes")
+class TestFileImportExcludedFromSync:
+    """File-import plugins are one-shot uploads, never syncable sources.
+
+    Regression: legacy ``config.yaml`` files may still carry path-based
+    ``inputs:`` blocks for the file-import plugins (goodreads, csv_import,
+    json_import, markdown_import). ``resolve_inputs`` and
+    ``get_available_sync_sources`` must skip them — with a clear, non-fatal
+    warning on the resolve path — rather than treat them as syncable or crash.
+    """
+
+    def test_resolve_inputs_skips_file_import_plugin(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        config = {
+            "inputs": {
+                "legacy_books": {
+                    "plugin": "fake_file",
+                    "enabled": True,
+                    "path": "inputs/old_export.csv",
+                },
+            }
+        }
+
+        with caplog.at_level("WARNING", logger="src.web.sync_sources"):
+            resolved = resolve_inputs(config)
+
+        assert resolved == []
+        assert any(
+            "legacy_books" in message and "import --file" in message
+            for message in caplog.messages
+        )
+
+    def test_resolve_inputs_skips_file_import_without_path(self) -> None:
+        """A legacy block with no path at all is still skipped, not crashed."""
+        config = {
+            "inputs": {
+                "legacy_books": {
+                    "plugin": "fake_file",
+                    "enabled": True,
+                },
+            }
+        }
+
+        assert resolve_inputs(config) == []
+
+    def test_resolve_inputs_keeps_syncable_alongside_file_import(self) -> None:
+        """A file-import block is dropped while a real source still resolves."""
+        config = {
+            "inputs": {
+                "legacy_books": {
+                    "plugin": "fake_file",
+                    "enabled": True,
+                    "path": "inputs/old.csv",
+                },
+                "my_books": {
+                    "plugin": "fake_books",
+                    "enabled": True,
+                    "path": "/data/books.csv",
+                },
+            }
+        }
+
+        resolved = resolve_inputs(config)
+
+        assert [entry.source_id for entry in resolved] == ["my_books"]
+
+    def test_get_available_sync_sources_excludes_file_import(self) -> None:
+        config = {
+            "inputs": {
+                "legacy_books": {
+                    "plugin": "fake_file",
+                    "enabled": True,
+                    "path": "inputs/old.csv",
+                },
+                "my_books": {
+                    "plugin": "fake_books",
+                    "enabled": True,
+                    "path": "/data/books.csv",
+                },
+            }
+        }
+
+        ids = {source.id for source in get_available_sync_sources(config)}
+
+        assert ids == {"my_books"}
 
 
 @pytest.mark.usefixtures("_registry_with_fakes")

--- a/tests/test_sync_sources.py
+++ b/tests/test_sync_sources.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from src.ingestion.plugin_base import ConfigField, SourcePlugin
+from src.ingestion.plugin_base import ConfigField, ProgressCallback, SourcePlugin
 from src.ingestion.registry import PluginRegistry
 from src.models.content import ConsumptionStatus, ContentItem, ContentType
 from src.storage.manager import StorageManager
@@ -193,7 +193,11 @@ class FakeFileImportPlugin(SourcePlugin):
     def validate_config(self, config: dict[str, Any], **kwargs: Any) -> list[str]:
         return []
 
-    def fetch(self, config: dict[str, Any]) -> Iterator[ContentItem]:
+    def fetch(
+        self,
+        config: dict[str, Any],
+        progress_callback: ProgressCallback | None = None,
+    ) -> Iterator[ContentItem]:
         yield ContentItem(
             id="file_1",
             title="Fake File Item",

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from src.ingestion.import_service import FileImportError
 from src.ingestion.sync import SyncResult
 from src.llm.client import OllamaClient
 from src.llm.embeddings import EmbeddingGenerator
@@ -3100,3 +3101,133 @@ class TestAuthDisconnectEndpoints:
         response = client.delete("/api/epic/token")
 
         assert response.status_code == 404
+
+
+# Goodreads CSV export header recognised by the goodreads plugin.
+_GOODREADS_CSV = (
+    "Title,Author,My Rating,Exclusive Shelf,Date Read\n"
+    "Dune,Frank Herbert,5,read,2020/01/01\n"
+    "Neuromancer,William Gibson,4,read,2020/02/01\n"
+)
+
+
+class TestImportSourcesEndpoint:
+    """Tests for GET /api/import/sources."""
+
+    def test_lists_only_file_import_plugins_with_schema(self, client):
+        """The listing returns the four file-import plugins, excluding syncables."""
+        response = client.get("/api/import/sources")
+        assert response.status_code == 200
+        data = response.json()
+        names = [plugin["name"] for plugin in data]
+        assert names == ["csv_import", "goodreads", "json_import", "markdown_import"]
+        # Syncable sources (sonarr is configured in mock_config) are excluded.
+        assert "sonarr" not in names
+
+        csv_plugin = next(p for p in data if p["name"] == "csv_import")
+        assert [f["name"] for f in csv_plugin["fields"]] == ["content_type"]
+
+        goodreads_plugin = next(p for p in data if p["name"] == "goodreads")
+        assert goodreads_plugin["fields"] == []
+
+
+class TestImportEndpoint:
+    """Tests for POST /api/import."""
+
+    def test_goodreads_happy_path(self, client, mock_components):
+        """A Goodreads CSV upload imports every parsed book."""
+        mock_components["storage"].save_content_item.return_value = 1
+        response = client.post(
+            "/api/import",
+            data={"source": "goodreads"},
+            files={"file": ("books.csv", _GOODREADS_CSV, "text/csv")},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["items_synced"] == 2
+        assert body["total_items"] == 2
+        assert body["source"] == "Import: Goodreads"
+        assert body["errors"] == []
+
+    def test_csv_import_happy_path_with_content_type_option(
+        self, client, mock_components
+    ):
+        """A generic CSV upload uses the content_type form field as an option."""
+        mock_components["storage"].save_content_item.return_value = 1
+        csv_content = "title,author,status,rating\nDune,Frank Herbert,read,5\n"
+        response = client.post(
+            "/api/import",
+            data={"source": "csv_import", "content_type": "book"},
+            files={"file": ("books.csv", csv_content, "text/csv")},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["items_synced"] == 1
+        assert body["total_items"] == 1
+        assert body["source"] == "Import: CSV Import"
+
+    def test_unknown_plugin_rejected(self, client):
+        """An unregistered source name is a 422 client error."""
+        response = client.post(
+            "/api/import",
+            data={"source": "does_not_exist"},
+            files={"file": ("x.csv", "ignored", "text/csv")},
+        )
+        assert response.status_code == 422
+
+    def test_non_file_import_source_rejected(self, client):
+        """A syncable (non-file-import) source is a 422 client error."""
+        response = client.post(
+            "/api/import",
+            data={"source": "sonarr"},
+            files={"file": ("x.csv", "ignored", "text/csv")},
+        )
+        assert response.status_code == 422
+
+    def test_corrupt_file_returns_client_error(self, client):
+        """A FileImportError from the service maps to a 400 with its message."""
+        with patch(
+            "src.web.api.import_file",
+            side_effect=FileImportError("Failed to import file with 'csv_import': bad"),
+        ):
+            response = client.post(
+                "/api/import",
+                data={"source": "csv_import", "content_type": "book"},
+                files={"file": ("x.csv", "garbage", "text/csv")},
+            )
+        assert response.status_code == 400
+        assert "Failed to import file" in response.json()["detail"]
+
+    def test_temp_file_cleaned_up_on_failure(self, client):
+        """The streamed temp file is removed even when the import fails."""
+        captured: dict[str, Path] = {}
+
+        def fail(**kwargs: Path) -> None:
+            captured["file_path"] = kwargs["file_path"]
+            raise FileImportError("boom")
+
+        with patch("src.web.api.import_file", side_effect=fail):
+            response = client.post(
+                "/api/import",
+                data={"source": "csv_import", "content_type": "book"},
+                files={"file": ("x.csv", "garbage", "text/csv")},
+            )
+        assert response.status_code == 400
+        assert "file_path" in captured
+        assert not captured["file_path"].exists()
+
+    def test_progress_observable_via_status_endpoint(self, client, mock_components):
+        """A completed import is reported as a job via GET /api/sync/status."""
+        mock_components["storage"].save_content_item.return_value = 1
+        response = client.post(
+            "/api/import",
+            data={"source": "goodreads"},
+            files={"file": ("books.csv", _GOODREADS_CSV, "text/csv")},
+        )
+        assert response.status_code == 200
+
+        status = client.get("/api/sync/status").json()
+        jobs = {job["source"]: job for job in status["jobs"]}
+        assert "Import: Goodreads" in jobs
+        assert jobs["Import: Goodreads"]["status"] == "completed"
+        assert jobs["Import: Goodreads"]["items_processed"] == 2

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -3231,3 +3231,187 @@ class TestImportEndpoint:
         assert "Import: Goodreads" in jobs
         assert jobs["Import: Goodreads"]["status"] == "completed"
         assert jobs["Import: Goodreads"]["items_processed"] == 2
+
+    def test_json_import_happy_path(self, client, mock_components):
+        """A generic JSON upload imports every entry (criterion 1: JSON format)."""
+        mock_components["storage"].save_content_item.return_value = 1
+        json_content = json.dumps(
+            [
+                {"title": "Dune", "author": "Frank Herbert", "status": "completed"},
+                {"title": "Neuromancer", "author": "William Gibson", "status": "read"},
+            ]
+        )
+        response = client.post(
+            "/api/import",
+            data={"source": "json_import", "content_type": "book"},
+            files={"file": ("books.json", json_content, "application/json")},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["items_synced"] == 2
+        assert body["total_items"] == 2
+        assert body["source"] == "Import: JSON Import"
+        assert body["errors"] == []
+
+    def test_markdown_import_happy_path(self, client, mock_components):
+        """A markdown upload imports every entry (criterion 1: markdown format)."""
+        mock_components["storage"].save_content_item.return_value = 1
+        md_content = (
+            "## Completed\n"
+            "- **Dune** by Frank Herbert | Rating: 5\n"
+            "- **Neuromancer** by William Gibson | Rating: 4\n"
+        )
+        response = client.post(
+            "/api/import",
+            data={"source": "markdown_import", "content_type": "book"},
+            files={"file": ("books.md", md_content, "text/markdown")},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["items_synced"] == 2
+        assert body["total_items"] == 2
+        assert body["source"] == "Import: Markdown Import"
+        assert body["errors"] == []
+
+    def test_temp_file_cleaned_up_on_success(self, client):
+        """The streamed temp file is removed on the success path (criterion 7).
+
+        The existing suite only proves cleanup on failure; this locks in that
+        the ``finally`` block also runs after a successful import so uploads
+        never accumulate on disk.
+        """
+        captured: dict[str, Path] = {}
+
+        def succeed(**kwargs: Path) -> SyncResult:
+            file_path = kwargs["file_path"]
+            captured["file_path"] = file_path
+            # The temp file must still exist while the import runs.
+            assert file_path.exists()
+            return SyncResult(source_name="csv_import", items_synced=1, total_items=1)
+
+        with patch("src.web.api.import_file", side_effect=succeed):
+            response = client.post(
+                "/api/import",
+                data={"source": "csv_import", "content_type": "book"},
+                files={"file": ("x.csv", "title\nDune\n", "text/csv")},
+            )
+        assert response.status_code == 200, response.text
+        assert "file_path" in captured
+        assert not captured["file_path"].exists()
+
+    def test_missing_required_option_returns_400(self, client, mock_components):
+        """Omitting content_type for a generic format is a 400, not a 500.
+
+        csv_import requires a content_type option; without it the plugin's
+        validate_config fails, the service raises FileImportError, and the
+        endpoint must surface a clean 400.
+        """
+        mock_components["storage"].save_content_item.return_value = 1
+        response = client.post(
+            "/api/import",
+            data={"source": "csv_import"},
+            files={"file": ("x.csv", "title\nDune\n", "text/csv")},
+        )
+        assert response.status_code == 400
+        assert "content_type" in response.json()["detail"]
+
+    def test_empty_file_imports_zero_items(self, client, mock_components):
+        """An empty upload is a clean 200 with zero items, not an error.
+
+        An empty file yields no rows; the import completes successfully with
+        zero counts rather than failing or raising.
+        """
+        mock_components["storage"].save_content_item.return_value = 1
+        response = client.post(
+            "/api/import",
+            data={"source": "csv_import", "content_type": "book"},
+            files={"file": ("empty.csv", "", "text/csv")},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["items_synced"] == 0
+        assert body["total_items"] == 0
+        assert body["errors"] == []
+
+    def test_wrong_format_file_returns_400(self, client, mock_components):
+        """A JSON file sent to csv_import surfaces a clean 400, not a 500.
+
+        The CSV parser sees no ``title`` column in the JSON content and raises
+        a SourceError, which the service wraps into a FileImportError -> 400.
+        """
+        mock_components["storage"].save_content_item.return_value = 1
+        json_content = json.dumps([{"name": "Dune"}, {"name": "Neuromancer"}], indent=2)
+        response = client.post(
+            "/api/import",
+            data={"source": "csv_import", "content_type": "book"},
+            files={"file": ("books.json", json_content, "application/json")},
+        )
+        assert response.status_code == 400
+        assert "Failed to import file" in response.json()["detail"]
+
+    def test_per_item_errors_surfaced_when_some_rows_fail(
+        self, client, mock_components
+    ):
+        """A file that parses but whose rows partially fail to save reports them.
+
+        The first item's save raises; the second succeeds. The endpoint must
+        return 200 with the surviving count and a safe per-item error string
+        (no raw exception text) for the failed row.
+        """
+        mock_components["storage"].save_content_item.side_effect = [
+            RuntimeError("db write failed"),
+            1,
+        ]
+        response = client.post(
+            "/api/import",
+            data={"source": "goodreads"},
+            files={"file": ("books.csv", _GOODREADS_CSV, "text/csv")},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["items_synced"] == 1
+        assert body["total_items"] == 2
+        assert body["errors"] == ["Failed to process 'Dune'"]
+        # The raw exception text must never leak to the client.
+        assert "db write failed" not in json.dumps(body)
+
+    def test_concurrent_import_returns_409(self, client, mock_components):
+        """A second import for the same label while one runs is a 409.
+
+        Plants a RUNNING job under the import's label in the global
+        SyncManager, then posts an import that maps to the same label. The
+        endpoint must reject it with 409 rather than starting a duplicate.
+        """
+        mock_components["storage"].save_content_item.return_value = 1
+        manager = get_sync_manager()
+        with patch("src.web.sync_manager.threading.Thread"):
+            manager.start_sync(source="Import: Goodreads", sync_function=lambda _job: 0)
+        assert manager.is_running("Import: Goodreads") is True
+
+        response = client.post(
+            "/api/import",
+            data={"source": "goodreads"},
+            files={"file": ("books.csv", _GOODREADS_CSV, "text/csv")},
+        )
+        assert response.status_code == 409
+
+
+class TestRomsRemainsSyncable:
+    """The roms plugin is untouched by the file-import migration."""
+
+    def test_roms_not_importable_and_not_file_import(self, client):
+        """roms is excluded from file-import sources and is not a file import.
+
+        Criterion: roms keeps its directory-scan config and stays a syncable
+        source rather than being routed through the one-shot import flow.
+        """
+        from src.ingestion.registry import get_registry
+
+        roms = get_registry().get_plugin("roms")
+        assert roms is not None
+        assert roms.is_file_import is False
+        # Directory config (paths) is still part of its schema.
+        assert "paths" in {field.name for field in roms.get_config_schema()}
+
+        importable = client.get("/api/import/sources").json()
+        assert "roms" not in {plugin["name"] for plugin in importable}

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1,16 +1,18 @@
 """Tests for web API endpoints."""
 
 import json
+import tempfile
 import threading
 from collections.abc import Callable
 from dataclasses import fields
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from src.ingestion.import_service import FileImportError
+from src.ingestion.import_service import FILE_NOT_READABLE_MESSAGE, FileImportError
 from src.ingestion.sync import SyncResult
 from src.llm.client import OllamaClient
 from src.llm.embeddings import EmbeddingGenerator
@@ -31,6 +33,7 @@ from src.web.sync_manager import (
     get_sync_manager,
     reset_sync_manager,
 )
+from tests.import_test_data import GOODREADS_CSV
 
 
 @pytest.fixture
@@ -3103,12 +3106,22 @@ class TestAuthDisconnectEndpoints:
         assert response.status_code == 404
 
 
-# Goodreads CSV export header recognised by the goodreads plugin.
-_GOODREADS_CSV = (
-    "Title,Author,My Rating,Exclusive Shelf,Date Read\n"
-    "Dune,Frank Herbert,5,read,2020/01/01\n"
-    "Neuromancer,William Gibson,4,read,2020/02/01\n"
-)
+def _recording_mkstemp(
+    captured: dict[str, Path],
+) -> Callable[..., tuple[int, str]]:
+    """Wrap tempfile.mkstemp so a test can capture and later assert on the path.
+
+    The real temp file is still created (the handler writes the upload into it);
+    its path is recorded under ``captured["path"]`` so cleanup can be verified.
+    """
+    real_mkstemp = tempfile.mkstemp
+
+    def recording(*args: Any, **kwargs: Any) -> tuple[int, str]:
+        fd, name = real_mkstemp(*args, **kwargs)
+        captured["path"] = Path(name)
+        return fd, name
+
+    return recording
 
 
 class TestImportSourcesEndpoint:
@@ -3119,8 +3132,10 @@ class TestImportSourcesEndpoint:
         response = client.get("/api/import/sources")
         assert response.status_code == 200
         data = response.json()
-        names = [plugin["name"] for plugin in data]
-        assert names == ["csv_import", "goodreads", "json_import", "markdown_import"]
+        names = {plugin["name"] for plugin in data}
+        # Subset (not equality) so adding a fifth file-import plugin later does
+        # not break this test; the contract is that these four are importable.
+        assert {"csv_import", "goodreads", "json_import", "markdown_import"} <= names
         # Syncable sources (sonarr is configured in mock_config) are excluded.
         assert "sonarr" not in names
 
@@ -3140,13 +3155,14 @@ class TestImportEndpoint:
         response = client.post(
             "/api/import",
             data={"source": "goodreads"},
-            files={"file": ("books.csv", _GOODREADS_CSV, "text/csv")},
+            files={"file": ("books.csv", GOODREADS_CSV, "text/csv")},
         )
         assert response.status_code == 200, response.text
         body = response.json()
         assert body["items_synced"] == 2
         assert body["total_items"] == 2
-        assert body["source"] == "Import: Goodreads"
+        # source is the plugin name the user passed, not the internal job label.
+        assert body["source"] == "goodreads"
         assert body["errors"] == []
 
     def test_csv_import_happy_path_with_content_type_option(
@@ -3164,7 +3180,7 @@ class TestImportEndpoint:
         body = response.json()
         assert body["items_synced"] == 1
         assert body["total_items"] == 1
-        assert body["source"] == "Import: CSV Import"
+        assert body["source"] == "csv_import"
 
     def test_unknown_plugin_rejected(self, client):
         """An unregistered source name is a 422 client error."""
@@ -3202,7 +3218,7 @@ class TestImportEndpoint:
         """The streamed temp file is removed even when the import fails."""
         captured: dict[str, Path] = {}
 
-        def fail(**kwargs: Path) -> None:
+        def fail(**kwargs: Any) -> None:
             captured["file_path"] = kwargs["file_path"]
             raise FileImportError("boom")
 
@@ -3222,7 +3238,7 @@ class TestImportEndpoint:
         response = client.post(
             "/api/import",
             data={"source": "goodreads"},
-            files={"file": ("books.csv", _GOODREADS_CSV, "text/csv")},
+            files={"file": ("books.csv", GOODREADS_CSV, "text/csv")},
         )
         assert response.status_code == 200
 
@@ -3250,7 +3266,7 @@ class TestImportEndpoint:
         body = response.json()
         assert body["items_synced"] == 2
         assert body["total_items"] == 2
-        assert body["source"] == "Import: JSON Import"
+        assert body["source"] == "json_import"
         assert body["errors"] == []
 
     def test_markdown_import_happy_path(self, client, mock_components):
@@ -3270,7 +3286,7 @@ class TestImportEndpoint:
         body = response.json()
         assert body["items_synced"] == 2
         assert body["total_items"] == 2
-        assert body["source"] == "Import: Markdown Import"
+        assert body["source"] == "markdown_import"
         assert body["errors"] == []
 
     def test_temp_file_cleaned_up_on_success(self, client):
@@ -3282,7 +3298,7 @@ class TestImportEndpoint:
         """
         captured: dict[str, Path] = {}
 
-        def succeed(**kwargs: Path) -> SyncResult:
+        def succeed(**kwargs: Any) -> SyncResult:
             file_path = kwargs["file_path"]
             captured["file_path"] = file_path
             # The temp file must still exist while the import runs.
@@ -3347,7 +3363,9 @@ class TestImportEndpoint:
             files={"file": ("books.json", json_content, "application/json")},
         )
         assert response.status_code == 400
-        assert "Failed to import file" in response.json()["detail"]
+        # Plugin-specific detail: the wrapper names the failing plugin so the
+        # user knows which importer rejected the file, not just that it failed.
+        assert "Failed to import file with 'csv_import'" in response.json()["detail"]
 
     def test_per_item_errors_surfaced_when_some_rows_fail(
         self, client, mock_components
@@ -3365,12 +3383,14 @@ class TestImportEndpoint:
         response = client.post(
             "/api/import",
             data={"source": "goodreads"},
-            files={"file": ("books.csv", _GOODREADS_CSV, "text/csv")},
+            files={"file": ("books.csv", GOODREADS_CSV, "text/csv")},
         )
         assert response.status_code == 200, response.text
         body = response.json()
         assert body["items_synced"] == 1
         assert body["total_items"] == 2
+        # Pins the pipeline's per-item error format ("Failed to process '<title>'"):
+        # a safe, title-only string with no raw exception text.
         assert body["errors"] == ["Failed to process 'Dune'"]
         # The raw exception text must never leak to the client.
         assert "db write failed" not in json.dumps(body)
@@ -3388,12 +3408,95 @@ class TestImportEndpoint:
             manager.start_sync(source="Import: Goodreads", sync_function=lambda _job: 0)
         assert manager.is_running("Import: Goodreads") is True
 
+        captured: dict[str, Path] = {}
+        with patch(
+            "src.web.api.tempfile.mkstemp",
+            side_effect=_recording_mkstemp(captured),
+        ):
+            response = client.post(
+                "/api/import",
+                data={"source": "goodreads"},
+                files={"file": ("books.csv", GOODREADS_CSV, "text/csv")},
+            )
+        assert response.status_code == 409
+        # The streamed temp file must be removed on the 409 path too.
+        assert "path" in captured
+        assert not captured["path"].exists()
+
+    def test_oversized_upload_returns_413_and_cleans_up(self, client, mock_components):
+        """An upload past the byte cap is rejected with 413; the temp file goes.
+
+        The cap is patched low so the test does not have to stream tens of
+        megabytes. The chunked write must abort and the finally block must
+        still remove the partial temp file.
+        """
+        mock_components["storage"].save_content_item.return_value = 1
+        captured: dict[str, Path] = {}
+        with (
+            patch("src.web.api.MAX_UPLOAD_BYTES", 16),
+            patch(
+                "src.web.api.tempfile.mkstemp",
+                side_effect=_recording_mkstemp(captured),
+            ),
+        ):
+            response = client.post(
+                "/api/import",
+                data={"source": "goodreads"},
+                files={"file": ("books.csv", "x" * 1024, "text/csv")},
+            )
+        assert response.status_code == 413
+        assert "exceeds" in response.json()["detail"]
+        assert "path" in captured
+        assert not captured["path"].exists()
+
+    def test_returns_500_when_components_uninitialized(self, client, mock_components):
+        """With storage uninitialized the endpoint is a clean 500, not a crash."""
+        app_state.storage = None
         response = client.post(
             "/api/import",
             data={"source": "goodreads"},
-            files={"file": ("books.csv", _GOODREADS_CSV, "text/csv")},
+            files={"file": ("books.csv", GOODREADS_CSV, "text/csv")},
         )
-        assert response.status_code == 409
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Components not initialized"
+
+    def test_unreadable_file_error_is_masked(self, client):
+        """The not-readable FileImportError never leaks the internal temp path.
+
+        The service embeds the (temp) path in its message for the CLI; the web
+        handler must replace it with a generic detail so the client cannot see
+        server-side filesystem paths.
+        """
+        secret_path = "/tmp/server-secret-upload-xyz.csv"
+        with patch(
+            "src.web.api.import_file",
+            side_effect=FileImportError(f"{FILE_NOT_READABLE_MESSAGE}: {secret_path}"),
+        ):
+            response = client.post(
+                "/api/import",
+                data={"source": "goodreads"},
+                files={"file": ("books.csv", GOODREADS_CSV, "text/csv")},
+            )
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert detail == "The uploaded file could not be read"
+        assert secret_path not in detail
+
+    def test_auto_enrich_triggers_enrichment_on_success(self, client, mock_components):
+        """With auto-enrich configured, a successful import starts enrichment."""
+        mock_components["storage"].save_content_item.return_value = 1
+        app_state.config["enrichment"] = {
+            "enabled": True,
+            "auto_enrich_on_sync": True,
+        }
+        with patch("src.web.api.get_enrichment_manager") as mock_get:
+            response = client.post(
+                "/api/import",
+                data={"source": "goodreads"},
+                files={"file": ("books.csv", GOODREADS_CSV, "text/csv")},
+            )
+        assert response.status_code == 200, response.text
+        mock_get.return_value.start_enrichment.assert_called_once()
 
 
 class TestRomsRemainsSyncable:

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -3483,7 +3483,12 @@ class TestImportEndpoint:
         assert secret_path not in detail
 
     def test_auto_enrich_triggers_enrichment_on_success(self, client, mock_components):
-        """With auto-enrich configured, a successful import starts enrichment."""
+        """With auto-enrich configured, a successful import starts enrichment.
+
+        The completion callback must forward the live storage_manager and
+        config. A Goodreads upload carries no content_type form field, so the
+        enrichment run is unscoped (content_type is None) and covers all types.
+        """
         mock_components["storage"].save_content_item.return_value = 1
         app_state.config["enrichment"] = {
             "enabled": True,
@@ -3496,7 +3501,11 @@ class TestImportEndpoint:
                 files={"file": ("books.csv", GOODREADS_CSV, "text/csv")},
             )
         assert response.status_code == 200, response.text
-        mock_get.return_value.start_enrichment.assert_called_once()
+        mock_get.return_value.start_enrichment.assert_called_once_with(
+            storage_manager=mock_components["storage"],
+            config=app_state.config,
+            content_type=None,
+        )
 
 
 class TestRomsRemainsSyncable:

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -50,9 +50,10 @@ def mock_config():
             "port": 8000,
         },
         "inputs": {
-            "goodreads": {
-                "plugin": "goodreads",
-                "path": "inputs/goodreads_library_export.csv",
+            "sonarr": {
+                "plugin": "sonarr",
+                "url": "http://localhost:8989",
+                "api_key": "x",
                 "enabled": True,
             }
         },
@@ -337,12 +338,12 @@ def test_sync_sources_endpoint(client, mock_config):
     assert response.status_code == 200
     sources = response.json()
     assert isinstance(sources, list)
-    # mock_config has exactly goodreads enabled
+    # mock_config has exactly sonarr enabled
     assert len(sources) == 1
-    goodreads = next((s for s in sources if s["id"] == "goodreads"), None)
-    assert goodreads is not None
-    assert goodreads["display_name"] == "Goodreads"
-    assert goodreads["plugin_display_name"] == "Goodreads"
+    sonarr = next((s for s in sources if s["id"] == "sonarr"), None)
+    assert sonarr is not None
+    assert sonarr["display_name"] == "Sonarr"
+    assert sonarr["plugin_display_name"] == "Sonarr"
 
 
 def test_sync_sources_lists_all_with_enabled_flag(client):
@@ -351,6 +352,9 @@ def test_sync_sources_lists_all_with_enabled_flag(client):
     The UI renders disabled sources in a muted state instead of hiding them
     entirely, so the listing endpoint must surface them. ``resolve_inputs``
     is the gate that filters to enabled-only for sync execution.
+
+    File-import plugins (here ``goodreads``) are never syncable sources, so
+    they must be omitted from this listing even when present in YAML.
     """
     app_state.config = {
         "inputs": {
@@ -385,7 +389,7 @@ def test_sync_sources_lists_all_with_enabled_flag(client):
     sources = response.json()
     by_id = {s["id"]: s for s in sources}
 
-    assert by_id["goodreads"]["enabled"] is True
+    assert "goodreads" not in by_id
     assert by_id["sonarr"]["enabled"] is True
     assert by_id["steam"]["enabled"] is False
     assert by_id["radarr"]["enabled"] is False
@@ -482,11 +486,11 @@ def test_update_endpoint(client, mock_components):
 
     with (
         patch(
-            "src.ingestion.sources.goodreads.GoodreadsPlugin.fetch",
+            "src.ingestion.sources.sonarr.sonarr.SonarrPlugin.fetch",
             return_value=iter([mock_item]),
         ),
         patch(
-            "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+            "src.ingestion.sources.sonarr.sonarr.SonarrPlugin.validate_config",
             return_value=[],
         ),
     ):
@@ -495,7 +499,7 @@ def test_update_endpoint(client, mock_components):
         ] * 768
         mock_components["storage"].save_content_item.return_value = 1
 
-        response = client.post("/api/update", json={"source": "goodreads"})
+        response = client.post("/api/update", json={"source": "sonarr"})
 
         assert response.status_code == 200
         data = response.json()
@@ -626,11 +630,11 @@ def test_update_endpoint_all_sources(client, mock_components):
 
     with (
         patch(
-            "src.ingestion.sources.goodreads.GoodreadsPlugin.fetch",
+            "src.ingestion.sources.sonarr.sonarr.SonarrPlugin.fetch",
             return_value=iter([mock_book]),
         ),
         patch(
-            "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+            "src.ingestion.sources.sonarr.sonarr.SonarrPlugin.validate_config",
             return_value=[],
         ),
         patch(
@@ -654,7 +658,7 @@ def test_update_endpoint_all_sources(client, mock_components):
         # New async behavior: returns sync started message with sources list
         assert "message" in data
         assert "sources" in data
-        assert "goodreads" in data["sources"]
+        assert "sonarr" in data["sources"]
         assert "steam" in data["sources"]
 
 
@@ -2192,21 +2196,21 @@ class TestUpdateEndpoint409Conflict:
             mock_manager = Mock(spec=SyncManager)
             mock_manager.start_sync.return_value = (
                 False,
-                "Sync already in progress for Goodreads",
+                "Sync already in progress for Sonarr",
             )
             mock_get_sync_manager.return_value = mock_manager
 
             with patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.sonarr.sonarr.SonarrPlugin.validate_config",
                 return_value=[],
             ):
-                response = client.post("/api/update", json={"source": "goodreads"})
+                response = client.post("/api/update", json={"source": "sonarr"})
 
             assert response.status_code == 409
             detail = response.json()["detail"]
             assert "Sync already in progress" in detail
-            assert "Goodreads" in detail
-            assert mock_manager.start_sync.call_args.args[0] == "Goodreads"
+            assert "Sonarr" in detail
+            assert mock_manager.start_sync.call_args.args[0] == "Sonarr"
 
     def test_update_allows_different_sources_concurrently(
         self, client: TestClient, mock_components: dict
@@ -2214,7 +2218,7 @@ class TestUpdateEndpoint409Conflict:
         """A second source is accepted while a different source is running.
 
         Plants a real RUNNING job for Steam in the global SyncManager
-        before triggering a Goodreads sync. The endpoint must reject
+        before triggering a Sonarr sync. The endpoint must reject
         only when the SAME label is running — different labels return
         200 even with another sync still in flight.
         """
@@ -2230,23 +2234,23 @@ class TestUpdateEndpoint409Conflict:
         assert manager.is_running("Steam") is True
 
         with patch(
-            "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+            "src.ingestion.sources.sonarr.sonarr.SonarrPlugin.validate_config",
             return_value=[],
         ):
             # Drop the captured execute_multi_source_sync into a no-op so
             # the second sync's daemon doesn't try to actually run.
             with patch(
                 "src.web.api.execute_multi_source_sync",
-                return_value=[SyncJob(source="Goodreads", status=SyncStatus.RUNNING)],
+                return_value=[SyncJob(source="Sonarr", status=SyncStatus.RUNNING)],
             ):
-                response = client.post("/api/update", json={"source": "goodreads"})
+                response = client.post("/api/update", json={"source": "sonarr"})
 
         assert response.status_code == 200, response.text
         assert "Sync started" in response.json()["message"]
         # Manager now tracks both jobs; the Steam one is still running
-        # and the Goodreads one was added on top.
+        # and the Sonarr one was added on top.
         assert manager.is_running("Steam") is True
-        assert "Goodreads" in {job["source"] for job in manager.get_status()["jobs"]}
+        assert "Sonarr" in {job["source"] for job in manager.get_status()["jobs"]}
 
 
 class TestUpdateEndpointParallelSync:
@@ -2297,7 +2301,7 @@ class TestUpdateEndpointParallelSync:
                 side_effect=self._make_capture(captured_kwargs, completion),
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.sonarr.sonarr.SonarrPlugin.validate_config",
                 return_value=[],
             ),
         ):
@@ -2321,7 +2325,7 @@ class TestUpdateEndpointParallelSync:
                 side_effect=self._make_capture(captured_kwargs, completion),
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.sonarr.sonarr.SonarrPlugin.validate_config",
                 return_value=[],
             ),
         ):
@@ -2345,7 +2349,7 @@ class TestUpdateEndpointParallelSync:
                 side_effect=self._make_capture(captured_kwargs, completion),
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.sonarr.sonarr.SonarrPlugin.validate_config",
                 return_value=[],
             ),
         ):

--- a/tests/web/test_sync_manager.py
+++ b/tests/web/test_sync_manager.py
@@ -5,7 +5,10 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from src.web.sync_manager import (
+    SyncInProgressError,
     SyncJob,
     SyncManager,
     SyncStatus,
@@ -699,6 +702,56 @@ class TestSyncManagerRunSync:
         manager._run_sync("steam", sync_function)
 
         assert manager.get_status()["jobs"][0]["items_processed"] == 99
+
+
+class TestSyncManagerRunImport:
+    """run_import inline execution and failure reporting."""
+
+    def test_failure_without_per_item_errors_sets_error_message(self) -> None:
+        """A raise before any add_error still reports a non-null error_message.
+
+        run_import re-raises so the web handler can map the failure, but the
+        tracked job must still expose a message via get_status — otherwise a
+        polling client sees status=failed with error_message=None.
+        """
+        manager = SyncManager()
+
+        def boom(_job: SyncJob) -> int:
+            raise RuntimeError("import blew up")
+
+        with pytest.raises(RuntimeError, match="import blew up"):
+            manager.run_import("Import: Goodreads", boom)
+
+        job = manager.get_status()["jobs"][0]
+        assert job["status"] == "failed"
+        assert job["error_message"] == "import blew up"
+
+    def test_per_item_error_preferred_over_exception_message(self) -> None:
+        """When the job recorded a per-item error, it wins over the exception."""
+        manager = SyncManager()
+
+        def boom(job: SyncJob) -> int:
+            manager.add_error(job.source, "row 3 failed validation")
+            raise RuntimeError("downstream blew up")
+
+        with pytest.raises(RuntimeError):
+            manager.run_import("Import: Goodreads", boom)
+
+        job = manager.get_status()["jobs"][0]
+        assert job["status"] == "failed"
+        assert job["error_message"] == "row 3 failed validation"
+
+    def test_duplicate_running_label_raises(self) -> None:
+        """A second run_import for a label already running raises."""
+        manager = SyncManager()
+        manager._jobs["Import: Goodreads"] = SyncJob(
+            source="Import: Goodreads",
+            status=SyncStatus.RUNNING,
+            started_at=datetime.now(),
+        )
+
+        with pytest.raises(SyncInProgressError):
+            manager.run_import("Import: Goodreads", lambda _job: 0)
 
 
 class TestSyncManagerThreadCreation:

--- a/uv.lock
+++ b/uv.lock
@@ -2058,6 +2058,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "python-semantic-release"
 version = "10.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2157,6 +2166,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "tabulate" },
@@ -2199,6 +2209,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0,<6.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0,<4.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.9,<1.0.0" },
     { name = "python-semantic-release", marker = "extra == 'dev'", specifier = ">=9.0.0,<11.0.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "requests", specifier = ">=2.31.0,<3.0.0" },


### PR DESCRIPTION
## What

This moves the four single file sources off the old "drop a file on disk and put its path in config.yaml" flow and onto a real import flow: upload the file in the web UI, or point the CLI at it with `import --file`. It's the next step in getting away from file based config for everything past the bare minimum needed to boot.

In scope: **goodreads, csv_import, json_import, markdown_import**. `roms` is untouched since it scans a directory rather than taking a single file, so it stays a normal syncable source.

## How it works

The import is one shot. You hand it a file, it validates, runs the file through the existing ingestion pipeline, and forgets it. There's no lingering "source" to manage and nothing re-syncs. To refresh you just export again and re-import.

- **Web:** an "Import from file" button on the Data page opens a modal that pulls the importable formats from `GET /api/import/sources`, renders whatever options each one needs (just a content type today) straight from the schema, and posts the file to `POST /api/import`. Progress rides the same sync status polling the rest of the page already uses, and the final counts come back in the response.
- **CLI:** `import --source <name> --file <path> [--content-type ...] [--option K=V ...] [--format table|json]`, plus `--source list`. Same capability as the web, at parity (same sources, same options, same outcomes, matching JSON shapes).

## Breaking change

The YAML `inputs.<name>.path` config for those four sources is gone. If you still have a leftover block for one of them the app logs a warning and skips it rather than failing to boot, but the path based import itself no longer runs. Use the upload button or `import --file` instead. Docs across the board (DATA_SOURCES, CLI, README, QUICKSTART, ARCHITECTURE, the plugin guide, Docker, the plugin READMEs) are updated to match.

## Calls I made along the way

- **Legacy YAML is a warning, not a crash.** A stale `path:` block for one of these sources warns at startup and gets skipped. Breaking, but it won't brick a running install.
- **One shot, no stored file.** Uploads are processed and discarded. A Goodreads export is a point in time snapshot anyway, so there was nothing worth persisting and re-syncing.
- **Uploads are capped at 50 MB** (413 over the limit) so a giant or runaway upload can't fill the temp disk. The CLI reads local files with no cap since it's a local tool reading files you already trust.

## Testing

Both interfaces are covered end to end for all four formats, plus the edges: empty and zero item files, wrong format for the chosen source, missing required options, unknown or non file import sources, the already running case, per item row failures (without leaking the raw exception), the upload size cap, and temp file cleanup on every exit path. Full gate green: 3148 Python tests, 508 frontend tests, black / mypy (strict) / ruff / vue-tsc all clean.

One known behavior worth flagging for review: an upload that parses but yields zero items comes back as a clean success with zero counts rather than a "nothing imported" warning. That's a defensible default, but happy to add a signal there if you'd rather.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)