### PR TITLE
feat: add StoryGraph CSV book ingestion source

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,6 +14,7 @@ Responsible for parsing and normalizing data from various sources.
 
 **Current Sources:**
 - Goodreads CSV exports (books)
+- The StoryGraph CSV exports (books)
 - Steam Web API (video games)
 - GOG OAuth API (video games)
 - Epic Games via Legendary (video games)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -110,7 +110,7 @@ With `auto_enrich_on_sync: true`, enrichment runs automatically every time you s
 
 The system supports multiple data sources through a plugin architecture. See `config/example.yaml` for the full list of available plugins and their configuration options.
 
-**Available plugins:** Goodreads (books), Steam (games), GOG (games), Epic Games (games), Sonarr (TV shows), Radarr (movies), Trakt (TV shows/movies), ROM Library (games), and generic CSV/JSON/Markdown importers for any content type.
+**Available plugins:** Goodreads (books), The StoryGraph (books), Steam (games), GOG (games), Epic Games (games), Sonarr (TV shows), Radarr (movies), Trakt (TV shows/movies), ROM Library (games), and generic CSV/JSON/Markdown importers for any content type.
 
 ### Configure a source
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ rest.
 | Source | Type | Setup |
 |--------|------|-------|
 | **Goodreads** | Books | [goodreads](src/ingestion/sources/goodreads/README.md) |
+| **The StoryGraph** | Books | [storygraph_csv](src/ingestion/sources/storygraph_csv/README.md) |
 | **Steam** | Games | [steam](src/ingestion/sources/steam/README.md) |
 | **GOG** | Games | [gog](src/ingestion/sources/gog/README.md) |
 | **Epic Games** | Games | [epic_games](src/ingestion/sources/epic_games/README.md) |

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -73,6 +73,15 @@ inputs:
     content_type: "book"  # Content type for enrichment (book, movie, tv_show, video_game)
     enabled: true
 
+  # The StoryGraph — CSV export from your library (no API; pure file import).
+  # Generate the file at Manage Account -> Manage Your Data ->
+  # Export StoryGraph Library.
+  storygraph_csv:
+    plugin: storygraph_csv
+    path: "inputs/storygraph_export.csv"
+    content_type: "book"
+    enabled: false
+
   steam:
     plugin: steam
     # Steam Web API configuration

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -10,6 +10,7 @@ sources in the UI/CLI, parallel sync, and library export.
 | Source | Type | Setup guide |
 |--------|------|-------------|
 | **Goodreads** | Books | [goodreads](../src/ingestion/sources/goodreads/README.md) — CSV export from your Goodreads library |
+| **The StoryGraph** | Books | [storygraph_csv](../src/ingestion/sources/storygraph_csv/README.md) — CSV export from your StoryGraph library |
 | **Steam** | Games | [steam](../src/ingestion/sources/steam/README.md) — automatic import via Steam Web API |
 | **GOG** | Games | [gog](../src/ingestion/sources/gog/README.md) — OAuth; imports library and wishlist |
 | **Epic Games** | Games | [epic_games](../src/ingestion/sources/epic_games/README.md) — OAuth via Legendary |

--- a/src/ingestion/sources/storygraph_csv/README.md
+++ b/src/ingestion/sources/storygraph_csv/README.md
@@ -1,0 +1,48 @@
+# The StoryGraph (CSV Export)
+
+Imports books from a The StoryGraph library CSV export.
+
+## Content type
+- `book`
+
+## Requirements
+- A The StoryGraph library CSV export. The StoryGraph has no public API, so
+  generate the file from your account: **Manage Account → Manage Your Data →
+  Export StoryGraph Library**. StoryGraph emails you the CSV.
+
+## Configuration
+
+```yaml
+inputs:
+  storygraph_csv:
+    plugin: storygraph_csv
+    path: "/path/to/storygraph_export.csv"
+    content_type: "book"
+    enabled: true
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | str | yes | Path to The StoryGraph library CSV export file. |
+
+## Notes
+- No API key or network access required — pure file import.
+- Reads `Title`, `Authors`, `Contributors`, `ISBN/UID`, `Format`, `Read Status`,
+  `Date Added`, `Last Date Read`, `Dates Read`, `Read Count`, `Moods`, `Pace`,
+  the character-attribute columns (`Character- or Plot-Driven?`, `Strong
+  Character Development?`, `Loveable Characters?`, `Diverse Characters?`,
+  `Flawed Characters?`), `Star Rating`, `Review`, `Content Warnings`, `Content
+  Warning Description`, `Tags`, and `Owned?`. Missing or extra columns are
+  tolerated — StoryGraph tweaks the export shape over time.
+- Status mapping: `read` → completed, `currently-reading` → currently consuming,
+  `to-read` → unread, `did-not-finish` → completed (a rated-then-abandoned book
+  is a real signal). Anything else → unread. The raw status is kept in
+  `metadata["read_status"]`.
+- Rating mapping: StoryGraph rates in quarter-star steps on a 0–5 scale. Ratings
+  are rounded half up and clamped to 1–5 (e.g. `4.5` → 5, `3.25` → 3, `3.75` →
+  4). A `0`, blank, or unparseable rating is treated as unrated.
+
+## Development
+- Implementation: [`storygraph_csv.py`](storygraph_csv.py)
+- Tests: [`test_storygraph_csv.py`](test_storygraph_csv.py)
+- Plugin class: `StorygraphCsvPlugin`

--- a/src/ingestion/sources/storygraph_csv/__init__.py
+++ b/src/ingestion/sources/storygraph_csv/__init__.py
@@ -1,0 +1,3 @@
+"""storygraph_csv plugin package."""
+
+from src.ingestion.sources.storygraph_csv.storygraph_csv import *  # noqa: F401, F403

--- a/src/ingestion/sources/storygraph_csv/storygraph_csv.py
+++ b/src/ingestion/sources/storygraph_csv/storygraph_csv.py
@@ -1,0 +1,250 @@
+"""The StoryGraph CSV export plugin."""
+
+from __future__ import annotations
+
+import csv
+import logging
+import math
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from src.ingestion.plugin_base import (
+    ConfigField,
+    ProgressCallback,
+    SourceError,
+    SourcePlugin,
+)
+from src.models.content import ConsumptionStatus, ContentItem, ContentType
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
+
+logger = logging.getLogger(__name__)
+
+# StoryGraph "Read Status" value -> consumption status. did-not-finish maps to
+# completed because a rated-then-abandoned book is a real preference signal; the
+# raw status is preserved in metadata so no fidelity is lost.
+STATUS_MAP: dict[str, ConsumptionStatus] = {
+    "read": ConsumptionStatus.COMPLETED,
+    "currently-reading": ConsumptionStatus.CURRENTLY_CONSUMING,
+    "to-read": ConsumptionStatus.UNREAD,
+    "did-not-finish": ConsumptionStatus.COMPLETED,
+}
+
+
+def _field(row: dict[str, str], column: str) -> str:
+    """Read a column defensively, tolerating missing or None values.
+
+    StoryGraph tweaks its export columns over time, and short rows leave later
+    columns as ``None`` under ``csv.DictReader``. Both cases collapse to "".
+    """
+    return (row.get(column) or "").strip()
+
+
+class StorygraphCsvPlugin(SourcePlugin):
+    """Plugin for importing books from The StoryGraph CSV exports.
+
+    The StoryGraph has no public API, so users export their library as a CSV
+    from Manage Account -> Manage Your Data -> Export StoryGraph Library and
+    point this plugin at the downloaded file.
+    """
+
+    @property
+    def name(self) -> str:
+        return "storygraph_csv"
+
+    @property
+    def display_name(self) -> str:
+        return "The StoryGraph (CSV Export)"
+
+    @property
+    def description(self) -> str:
+        return "Import books from a The StoryGraph library CSV export"
+
+    @property
+    def content_types(self) -> list[ContentType]:
+        return [ContentType.BOOK]
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    @property
+    def requires_network(self) -> bool:
+        return False
+
+    def get_config_schema(self) -> list[ConfigField]:
+        return [
+            ConfigField(
+                name="path",
+                field_type=str,
+                required=True,
+                description="Path to The StoryGraph library CSV export file",
+            ),
+        ]
+
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: StorageManager | None = None,
+        user_id: int = 1,
+    ) -> list[str]:
+        errors = []
+        path = config.get("path")
+        if not path:
+            errors.append("'path' is required")
+        elif not Path(path).exists():
+            errors.append(f"CSV file not found: {path}")
+        return errors
+
+    def fetch(
+        self,
+        config: dict[str, Any],
+        progress_callback: ProgressCallback | None = None,
+    ) -> Iterator[ContentItem]:
+        """Fetch content items from a StoryGraph CSV export.
+
+        Args:
+            config: Must contain 'path' pointing to the CSV file
+            progress_callback: Optional callback for progress updates
+
+        Yields:
+            ContentItem for each book in the export
+
+        Raises:
+            SourceError: If the file cannot be read or parsed
+        """
+        path = config.get("path", "")
+        file_path = Path(path)
+
+        try:
+            yield from self._parse_csv(file_path, config, progress_callback)
+        except FileNotFoundError as error:
+            raise SourceError(self.name, f"CSV file not found: {file_path}") from error
+        except csv.Error as error:
+            raise SourceError(self.name, f"Failed to parse CSV: {error}") from error
+
+    def _parse_csv(
+        self,
+        file_path: Path,
+        config: dict[str, Any],
+        progress_callback: ProgressCallback | None = None,
+    ) -> Iterator[ContentItem]:
+        """Parse a StoryGraph CSV export file.
+
+        Args:
+            file_path: Path to the StoryGraph CSV export file
+            config: Plugin config dict (used for source identifier resolution)
+            progress_callback: Optional callback for progress updates
+
+        Yields:
+            ContentItem objects for each book in the export
+        """
+        source = self.get_source_identifier(config)
+        logger.info("Parsing StoryGraph CSV file: %s", file_path)
+
+        with open(file_path, encoding="utf-8") as csv_file:
+            reader = csv.DictReader(csv_file)
+            rows = list(reader)
+
+        total = len(rows)
+        logger.info("Found %d entries in StoryGraph CSV file", total)
+        processed_count = 0
+        for row in rows:
+            title = _field(row, "Title")
+            if not title:
+                continue
+
+            if progress_callback:
+                progress_callback(processed_count, total, title)
+
+            author = _field(row, "Authors") or None
+            rating = self._parse_rating(_field(row, "Star Rating"))
+
+            read_status = _field(row, "Read Status").lower()
+            status = STATUS_MAP.get(read_status, ConsumptionStatus.UNREAD)
+
+            date_completed = None
+            last_date_read = _field(row, "Last Date Read")
+            if last_date_read:
+                try:
+                    date_completed = datetime.strptime(
+                        last_date_read, "%Y/%m/%d"
+                    ).date()
+                except ValueError:
+                    pass
+
+            review = _field(row, "Review") or None
+            isbn_uid = _field(row, "ISBN/UID") or None
+
+            metadata = {
+                "isbn_uid": isbn_uid,
+                "contributors": _field(row, "Contributors") or None,
+                "format": _field(row, "Format") or None,
+                "read_status": read_status or None,
+                "read_count": _field(row, "Read Count") or None,
+                "date_added": _field(row, "Date Added") or None,
+                "last_date_read": last_date_read or None,
+                "dates_read": _field(row, "Dates Read") or None,
+                "moods": _field(row, "Moods") or None,
+                "pace": _field(row, "Pace") or None,
+                "character_or_plot_driven": (
+                    _field(row, "Character- or Plot-Driven?") or None
+                ),
+                "strong_character_development": (
+                    _field(row, "Strong Character Development?") or None
+                ),
+                "loveable_characters": _field(row, "Loveable Characters?") or None,
+                "diverse_characters": _field(row, "Diverse Characters?") or None,
+                "flawed_characters": _field(row, "Flawed Characters?") or None,
+                "content_warnings": _field(row, "Content Warnings") or None,
+                "content_warning_description": (
+                    _field(row, "Content Warning Description") or None
+                ),
+                "tags": _field(row, "Tags") or None,
+                "owned": _field(row, "Owned?") or None,
+            }
+
+            yield ContentItem(
+                id=isbn_uid,
+                title=title,
+                author=author,
+                content_type=ContentType.BOOK,
+                rating=rating,
+                review=review,
+                status=status,
+                date_completed=date_completed,
+                metadata=metadata,
+                source=source,
+            )
+            processed_count += 1
+
+        logger.info("Imported %d items from StoryGraph CSV file", processed_count)
+
+    @staticmethod
+    def _parse_rating(raw_rating: str) -> int | None:
+        """Convert a StoryGraph 0-5 fractional star rating to an int 1-5.
+
+        StoryGraph rates in quarter-star steps (e.g. ``4.5``, ``3.25``). The
+        value is rounded half up and clamped to 1-5. A ``0``, blank, or
+        unparseable rating means unrated and returns ``None``.
+
+        This deliberately does not delegate to the base ``normalize_rating``:
+        that helper does not round half up (it ``int()``-truncates, dropping
+        the fractional star) and clamps negative values up to 1 instead of
+        treating them as unrated. Do not "simplify" it back to the base helper.
+        """
+        if not raw_rating:
+            return None
+        try:
+            value = float(raw_rating)
+        except ValueError:
+            return None
+        if not math.isfinite(value):
+            return None
+        rounded = math.floor(value + 0.5)
+        if rounded <= 0:
+            return None
+        return min(5, rounded)

--- a/src/ingestion/sources/storygraph_csv/test_storygraph_csv.py
+++ b/src/ingestion/sources/storygraph_csv/test_storygraph_csv.py
@@ -1,0 +1,666 @@
+"""Tests for The StoryGraph CSV plugin."""
+
+import csv
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from src.ingestion.plugin_base import SourceError, SourcePlugin
+from src.ingestion.registry import PluginRegistry
+from src.ingestion.sources.storygraph_csv.storygraph_csv import StorygraphCsvPlugin
+from src.models.content import ConsumptionStatus, ContentType
+
+# A full StoryGraph export header row, matching the columns the site emits.
+HEADER = (
+    "Title,Authors,Contributors,ISBN/UID,Format,Read Status,Date Added,"
+    "Last Date Read,Dates Read,Read Count,Moods,Pace,"
+    "Character- or Plot-Driven?,Strong Character Development?,"
+    "Loveable Characters?,Diverse Characters?,Flawed Characters?,"
+    "Star Rating,Review,Content Warnings,Content Warning Description,Tags,Owned?"
+)
+
+
+@pytest.fixture()
+def plugin() -> StorygraphCsvPlugin:
+    """Create a StorygraphCsvPlugin instance."""
+    return StorygraphCsvPlugin()
+
+
+class TestStorygraphCsvPluginProperties:
+    """Tests for StorygraphCsvPlugin metadata properties."""
+
+    def test_is_source_plugin(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test that StorygraphCsvPlugin is a SourcePlugin subclass."""
+        assert isinstance(plugin, SourcePlugin)
+
+    def test_name(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test plugin name identifier."""
+        assert plugin.name == "storygraph_csv"
+
+    def test_display_name(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test human-readable display name."""
+        assert plugin.display_name == "The StoryGraph (CSV Export)"
+
+    def test_description(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test the custom description overrides the base class default."""
+        assert (
+            plugin.description
+            == "Import books from a The StoryGraph library CSV export"
+        )
+
+    def test_content_types(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test that plugin provides books."""
+        assert plugin.content_types == [ContentType.BOOK]
+
+    def test_requires_api_key(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test that plugin does not require an API key."""
+        assert plugin.requires_api_key is False
+
+    def test_requires_network(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test that plugin does not require network access."""
+        assert plugin.requires_network is False
+
+    def test_config_schema(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test configuration schema defines a single required path."""
+        schema = plugin.get_config_schema()
+
+        assert len(schema) == 1
+        assert schema[0].name == "path"
+        assert schema[0].field_type is str
+        assert schema[0].required is True
+
+    def test_get_source_identifier(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test source identifier matches plugin name by default."""
+        assert plugin.get_source_identifier() == "storygraph_csv"
+
+    def test_get_info(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test plugin info includes all metadata."""
+        info = plugin.get_info()
+
+        assert info.name == "storygraph_csv"
+        assert info.display_name == "The StoryGraph (CSV Export)"
+        assert info.content_types == [ContentType.BOOK]
+        assert info.requires_api_key is False
+        assert info.requires_network is False
+
+
+class TestStorygraphCsvPluginValidation:
+    """Tests for StorygraphCsvPlugin config validation."""
+
+    def test_validate_valid_config(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test validation passes with valid CSV path."""
+        csv_file = tmp_path / "library.csv"
+        csv_file.write_text("header\n")
+
+        errors = plugin.validate_config({"path": str(csv_file)})
+
+        assert errors == []
+
+    def test_validate_missing_path(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test validation fails when path is missing."""
+        errors = plugin.validate_config({})
+
+        assert len(errors) == 1
+        assert "'path' is required" in errors[0]
+
+    def test_validate_empty_path(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test validation fails when path is empty."""
+        errors = plugin.validate_config({"path": ""})
+
+        assert len(errors) == 1
+        assert "'path' is required" in errors[0]
+
+    def test_validate_nonexistent_file(self, plugin: StorygraphCsvPlugin) -> None:
+        """Test validation fails when CSV file does not exist."""
+        errors = plugin.validate_config({"path": "/nonexistent/library.csv"})
+
+        assert len(errors) == 1
+        assert "CSV file not found" in errors[0]
+
+
+class TestStorygraphCsvPluginFetch:
+    """Tests for StorygraphCsvPlugin.fetch()."""
+
+    def _write(self, tmp_path: Path, rows: str) -> Path:
+        csv_file = tmp_path / "library.csv"
+        csv_file.write_text(f"{HEADER}\n{rows}")
+        return csv_file
+
+    def test_fetch_basic(self, plugin: StorygraphCsvPlugin, tmp_path: Path) -> None:
+        """Test basic multi-row parsing into ContentItem fields."""
+        rows = (
+            "The Fifth Season,N. K. Jemisin,,9780316229296,Paperback,read,"
+            "2024/01/01,2024/03/15,2024/01/01-2024/03/15,1,adventurous,medium,"
+            "plot,Yes,Yes,Yes,Yes,4.5,A stunning read.,,,fantasy,Yes\n"
+            "The Way of Kings,Brandon Sanderson,,,Hardcover,to-read,"
+            "2024/02/01,,,0,,,,,,,,,,,,,No\n"
+        )
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert len(items) == 2
+
+        first = items[0]
+        assert first.title == "The Fifth Season"
+        assert first.author == "N. K. Jemisin"
+        assert first.content_type == ContentType.BOOK
+        assert first.rating == 5  # 4.5 rounds up
+        assert first.status == ConsumptionStatus.COMPLETED
+        assert first.date_completed == date(2024, 3, 15)
+        assert first.review == "A stunning read."
+        assert first.id == "9780316229296"
+        assert first.source == "storygraph_csv"
+
+        second = items[1]
+        assert second.title == "The Way of Kings"
+        assert second.author == "Brandon Sanderson"
+        assert second.rating is None
+        assert second.status == ConsumptionStatus.UNREAD
+        assert second.date_completed is None
+        assert second.review is None
+        assert second.id is None
+
+    def test_fetch_status_currently_reading(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test currently-reading maps to CURRENTLY_CONSUMING."""
+        rows = "Reading Now,Some Author,,,,currently-reading," + "," * 17 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].status == ConsumptionStatus.CURRENTLY_CONSUMING
+
+    def test_fetch_status_to_read(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test to-read maps to UNREAD."""
+        rows = "On The Pile,Some Author,,,,to-read," + "," * 17 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].status == ConsumptionStatus.UNREAD
+
+    def test_fetch_status_read(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test read maps to COMPLETED."""
+        rows = "Finished It,Some Author,,,,read," + "," * 17 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].status == ConsumptionStatus.COMPLETED
+
+    def test_fetch_status_did_not_finish_maps_to_completed(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test did-not-finish maps to COMPLETED but preserves raw status.
+
+        Product decision: a rated-then-abandoned book is a real signal, so it
+        counts as completed for scoring, while the true StoryGraph status is
+        retained in metadata so no fidelity is lost.
+        """
+        rows = "Gave Up,Some Author,,,,did-not-finish," + "," * 17 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].status == ConsumptionStatus.COMPLETED
+        assert items[0].metadata["read_status"] == "did-not-finish"
+
+    def test_fetch_status_unknown_defaults_to_unread(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test an unrecognized read status falls back to UNREAD."""
+        rows = "Mystery Status,Some Author,,,,wishlist," + "," * 17 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].status == ConsumptionStatus.UNREAD
+
+    def test_fetch_status_blank_defaults_to_unread(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a blank read status falls back to UNREAD."""
+        rows = "No Status,Some Author," + "," * 20 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].status == ConsumptionStatus.UNREAD
+
+    def test_fetch_rating_half_rounds_up(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a .5 rating rounds up (3.5 -> 4)."""
+        rows = "Half Star,Some Author,,,,read," + "," * 11 + "3.5\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].rating == 4
+
+    def test_fetch_rating_quarter_rounds_down(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a .25 rating rounds down (3.25 -> 3)."""
+        rows = "Quarter Star,Some Author,,,,read," + "," * 11 + "3.25\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].rating == 3
+
+    def test_fetch_rating_three_quarter_rounds_up(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a .75 rating rounds up (3.75 -> 4)."""
+        rows = "Three Quarter,Some Author,,,,read," + "," * 11 + "3.75\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].rating == 4
+
+    def test_fetch_rating_integer(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test an integer rating passes through unchanged."""
+        rows = "Whole Star,Some Author,,,,read," + "," * 11 + "5\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].rating == 5
+
+    def test_fetch_rating_zero_is_none(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a zero rating becomes None (model requires 1-5 or None)."""
+        rows = "Unrated,Some Author,,,,read," + "," * 11 + "0\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].rating is None
+
+    def test_fetch_rating_blank_is_none(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a blank rating becomes None."""
+        rows = "No Rating,Some Author,,,,read," + "," * 17 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].rating is None
+
+    def test_fetch_rating_out_of_range_clamped(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test an out-of-range rating clamps into 1-5."""
+        rows = "Too High,Some Author,,,,read," + "," * 11 + "9\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].rating == 5
+
+    def test_fetch_rating_garbage_is_none(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test an unparseable rating becomes None."""
+        rows = "Weird,Some Author,,,,read," + "," * 11 + "abc\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].rating is None
+
+    @pytest.mark.parametrize("raw_rating", ["-1", "-0.5"])
+    def test_fetch_rating_negative_is_none(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path, raw_rating: str
+    ) -> None:
+        """Test a negative rating becomes None rather than clamping up to 1."""
+        rows = "Negative,Some Author,,,,read," + "," * 11 + f"{raw_rating}\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].rating is None
+
+    def test_fetch_empty_title_skipped(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test that rows with an empty title are skipped."""
+        rows = (
+            ",Ghost Author,,,,read," + "," * 17 + "\n"
+            "Real Book,Real Author,,,,read," + "," * 17 + "\n"
+        )
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert len(items) == 1
+        assert items[0].title == "Real Book"
+
+    def test_fetch_sets_source_identifier_default(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test that items use the plugin name as source by default."""
+        rows = "A Book,An Author,,,,read," + "," * 17 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].source == "storygraph_csv"
+
+    def test_fetch_sets_source_identifier_override(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test that a user-defined _source_id overrides the plugin name."""
+        rows = "A Book,An Author,,,,read," + "," * 17 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(
+            plugin.fetch({"path": str(csv_file), "_source_id": "my_storygraph"})
+        )
+
+        assert items[0].source == "my_storygraph"
+
+    def test_fetch_file_not_found_raises_source_error(
+        self, plugin: StorygraphCsvPlugin
+    ) -> None:
+        """Test that fetching a nonexistent file raises SourceError."""
+        with pytest.raises(SourceError, match="CSV file not found") as exc_info:
+            list(plugin.fetch({"path": "/nonexistent/library.csv"}))
+
+        assert exc_info.value.plugin_name == "storygraph_csv"
+
+    def test_fetch_oversized_field_raises_source_error(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a field exceeding csv.field_size_limit wraps as SourceError.
+
+        Exercises the ``except csv.Error`` branch in ``fetch()``: the csv
+        module raises ``_csv.Error`` when a field exceeds the process-wide
+        ``field_size_limit``, and ``fetch()`` must translate that into a
+        ``SourceError`` carrying the plugin name rather than letting a raw
+        ``csv.Error`` escape to the caller.
+        """
+        oversized_title = "x" * 200
+        rows = f"{oversized_title},Author,,,,read," + ("," * 17) + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        original_field_size_limit = csv.field_size_limit()
+        csv.field_size_limit(100)
+        try:
+            with pytest.raises(SourceError, match="Failed to parse CSV") as exc_info:
+                list(plugin.fetch({"path": str(csv_file)}))
+        finally:
+            csv.field_size_limit(original_field_size_limit)
+
+        assert exc_info.value.plugin_name == "storygraph_csv"
+
+    def test_fetch_invalid_date_is_none(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test that an unparseable date falls through to None."""
+        rows = "Bad Date,Some Author,,,,read,2024/01/01,not-a-date," + "," * 15 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].date_completed is None
+
+    def test_fetch_metadata_rich_signals(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test the rich StoryGraph signals populate metadata."""
+        rows = (
+            "Rich Signals,Author Name,Narrator Person,9781234567890,Audiobook,read,"
+            "2024/01/01,2024/03/15,2024/01/01-2024/03/15,2,"
+            '"adventurous, dark",fast,character,Yes,Yes,No,Yes,4,Loved it,'
+            '"violence, grief",Some description,"fantasy, favorites",Yes\n'
+        )
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        meta = items[0].metadata
+        assert meta["isbn_uid"] == "9781234567890"
+        assert meta["format"] == "Audiobook"
+        assert meta["read_count"] == "2"
+        assert meta["date_added"] == "2024/01/01"
+        assert meta["last_date_read"] == "2024/03/15"
+        assert meta["dates_read"] == "2024/01/01-2024/03/15"
+        assert meta["read_status"] == "read"
+        assert meta["moods"] == "adventurous, dark"
+        assert meta["pace"] == "fast"
+        assert meta["tags"] == "fantasy, favorites"
+        assert meta["content_warnings"] == "violence, grief"
+        assert meta["content_warning_description"] == "Some description"
+        assert meta["character_or_plot_driven"] == "character"
+        assert meta["strong_character_development"] == "Yes"
+        assert meta["loveable_characters"] == "Yes"
+        assert meta["diverse_characters"] == "No"
+        assert meta["flawed_characters"] == "Yes"
+        assert meta["contributors"] == "Narrator Person"
+        assert meta["owned"] == "Yes"
+
+    def test_fetch_missing_optional_columns_parses(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a trimmed export (missing optional columns) still parses.
+
+        StoryGraph tweaks its export shape over time, so a header with only a
+        subset of columns must not crash the parse.
+        """
+        csv_file = tmp_path / "library.csv"
+        csv_file.write_text(
+            "Title,Authors,Read Status,Star Rating\n"
+            "Slim Export,Terse Author,read,4\n"
+        )
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert len(items) == 1
+        assert items[0].title == "Slim Export"
+        assert items[0].author == "Terse Author"
+        assert items[0].rating == 4
+        assert items[0].status == ConsumptionStatus.COMPLETED
+        assert items[0].id is None
+
+    def test_fetch_unicode_title_and_author(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test unicode characters in title and author survive parsing."""
+        rows = "Café Déjà Vu,Émile Zola,,,,read," + "," * 17 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].title == "Café Déjà Vu"
+        assert items[0].author == "Émile Zola"
+
+    def test_fetch_quoted_field_with_comma(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a quoted field containing a comma is parsed as one value."""
+        rows = '"Goodbye, Columbus",Philip Roth,,,,read,' + "," * 17 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].title == "Goodbye, Columbus"
+        assert items[0].author == "Philip Roth"
+
+    def test_fetch_empty_author_is_none(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test that a blank Authors column yields a None author."""
+        rows = "No Author Book,,,,,read," + "," * 17 + "\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].author is None
+
+    def test_fetch_header_only_file_yields_nothing(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a header-only export (no data rows) yields zero items."""
+        csv_file = tmp_path / "library.csv"
+        csv_file.write_text(f"{HEADER}\n")
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items == []
+
+    def test_fetch_truly_empty_file_yields_nothing(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a completely empty file (no header, no rows) yields no items."""
+        csv_file = tmp_path / "library.csv"
+        csv_file.write_text("")
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items == []
+
+    def test_fetch_short_row_missing_trailing_columns(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a row with fewer fields than the header does not crash.
+
+        Under ``csv.DictReader`` a short row leaves later columns as ``None``.
+        The plugin must tolerate that (the flagged None-handling risk) rather
+        than raising on ``.strip()`` of a missing value.
+        """
+        # Full 23-column header, but a row that stops after Read Status.
+        rows = "Short Row,Terse Author,,,,read\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert len(items) == 1
+        assert items[0].title == "Short Row"
+        assert items[0].author == "Terse Author"
+        assert items[0].status == ConsumptionStatus.COMPLETED
+        assert items[0].rating is None
+        assert items[0].metadata["format"] is None
+        assert items[0].metadata["tags"] is None
+
+    def test_fetch_read_status_is_case_insensitive(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test Read Status matching ignores case (e.g. 'READ', 'To-Read')."""
+        rows = (
+            "Shouty Read,Author,,,,READ," + "," * 17 + "\n"
+            "Mixed Case,Author,,,,Currently-Reading," + "," * 17 + "\n"
+            "Title Case,Author,,,,To-Read," + "," * 17 + "\n"
+        )
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].status == ConsumptionStatus.COMPLETED
+        assert items[1].status == ConsumptionStatus.CURRENTLY_CONSUMING
+        assert items[2].status == ConsumptionStatus.UNREAD
+
+    def test_fetch_rating_nan_is_none(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a Star Rating of 'nan' is treated as unrated, not a crash.
+
+        ``float('nan')`` parses successfully, so a hand-edited or corrupt
+        export carrying 'nan' must round to None rather than propagate an
+        exception out of fetch().
+        """
+        rows = "Not A Number,Author,,,,read," + "," * 11 + "nan\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].rating is None
+
+    def test_fetch_rating_infinity_is_none(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test a Star Rating of 'inf' is treated as unrated, not a crash.
+
+        ``float('inf')`` parses successfully, so an out-of-range 'inf' must
+        clamp/round to None rather than propagate an exception out of fetch().
+        """
+        rows = "Infinite Stars,Author,,,,read," + "," * 11 + "inf\n"
+        csv_file = self._write(tmp_path, rows)
+
+        items = list(plugin.fetch({"path": str(csv_file)}))
+
+        assert items[0].rating is None
+
+    def test_fetch_invokes_progress_callback_per_processed_row(
+        self, plugin: StorygraphCsvPlugin, tmp_path: Path
+    ) -> None:
+        """Test progress_callback fires once per processed row, skipping blanks.
+
+        The callback must report (items_processed_before_this_row, total_rows,
+        title) for each row that clears the blank-title check, and must not
+        fire for the skipped blank-title row in between.
+        """
+        rows = (
+            "First Book,Author One,,,,read," + "," * 17 + "\n"
+            ",Ghost Author,,,,read," + "," * 17 + "\n"
+            "Second Book,Author Two,,,,read," + "," * 17 + "\n"
+        )
+        csv_file = self._write(tmp_path, rows)
+        progress_calls: list[tuple[int, int | None, str | None]] = []
+
+        def record_progress(
+            items_processed: int, total_items: int | None, current_item: str | None
+        ) -> None:
+            progress_calls.append((items_processed, total_items, current_item))
+
+        items = list(
+            plugin.fetch({"path": str(csv_file)}, progress_callback=record_progress)
+        )
+
+        assert len(items) == 2
+        assert progress_calls == [
+            (0, 3, "First Book"),
+            (1, 3, "Second Book"),
+        ]
+
+
+class TestStorygraphCsvPluginDiscovery:
+    """Tests that the plugin is auto-discovered through the real registry."""
+
+    def test_plugin_discovered_by_registry_name(self) -> None:
+        """Test the registry resolves 'storygraph_csv' to the plugin class.
+
+        This proves auto-discovery works end to end, not just that the class
+        is importable — the registry scans src/ingestion/sources/ and must
+        register this plugin under its ``name``.
+        """
+        registry = PluginRegistry()
+
+        plugin = registry.get_plugin("storygraph_csv")
+
+        assert plugin is not None
+        assert isinstance(plugin, StorygraphCsvPlugin)
+        assert plugin.display_name == "The StoryGraph (CSV Export)"
+
+    def test_plugin_listed_among_book_sources(self) -> None:
+        """Test the plugin is discoverable via content-type filtering."""
+        registry = PluginRegistry()
+
+        book_plugins = registry.get_plugins_by_content_type(ContentType.BOOK)
+
+        assert "storygraph_csv" in {plugin.name for plugin in book_plugins}


### PR DESCRIPTION
## What this does

Adds The StoryGraph as a book ingestion source. It works just like the Goodreads plugin: you export your library from StoryGraph (Manage Account → export your data), point the config at the CSV, and it imports your books.

## Why CSV and not something live

I looked into whether StoryGraph offers an RSS feed or an API we could pull from directly, since that would be a nicer experience than a manual export. It doesn't. There's no public API and no RSS feed, and RSS has been an open feature request on their roadmap since early 2023 with no movement from their one-person team. The only "live" options out there are third party scrapers of public profiles, which are brittle and clash with the privacy-first approach here. So CSV export it is.

The plugin is named `storygraph_csv` rather than just `storygraph` on purpose, so there's room for a `storygraph_rss` source later if they ever ship a feed.

## Details worth knowing

- **Ratings**: StoryGraph rates in fractional stars (half and quarter steps). Those get rounded half up to an integer 1-5, and a 0/blank/garbage rating becomes unrated.
- **Statuses**: `read` → completed, `currently-reading` → currently reading, `to-read` → unread. StoryGraph also has a `did-not-finish` status that our model has no slot for, so it folds into completed. The thinking: a book you rated 2 stars and abandoned is a real signal worth keeping. The raw `did-not-finish` is preserved in metadata so nothing is lost.
- **Rich metadata**: StoryGraph carries more than Goodreads does (moods, pace, tags, content warnings, character attributes). Nothing consumes those yet, but they're captured in item metadata so they're there if the engine learns to use them.

The source is auto-discovered by the plugin registry, so it shows up in both the CLI and web UI with no extra wiring.

## Testing

51 colocated tests, 100% coverage on the plugin. Covers rating rounding (including the nan/inf and negative edge cases), every status mapping, the did-not-finish fidelity, rich metadata capture, empty/short/missing-column files, quoted commas, unicode, and registry discovery. Full suite green (3328 backend + 515 frontend), mypy/black/ruff clean.

To try it: drop a StoryGraph export at the path in the `storygraph_csv` block in `config/example.yaml`, enable it, and run a sync.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
