### PR TITLE
fix: exclude ignored and unrated items from recommendation signal

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -122,14 +122,14 @@ RecommendationEngine
 3. Per-user DB settings (`users.settings` JSON → `"preference_config"` key)
 
 **Process:**
-1. Analyze user's consumed content (ratings, reviews) **across ALL content types**
-2. Extract preferences and patterns (genres, themes, authors) from all consumed content
+1. Analyze the user's **taste-signal set across ALL content types** — completed items that are **rated** and **not ignored**. Ignored items and completed-but-unrated items carry no reliable taste signal and never shape recommendations (preferences, scoring, similarity, or explanations)
+2. Extract preferences and patterns (genres, themes, authors) from that signal set
 3. Load per-user preference config (if available), apply scorer weight overrides
 4. Score all unconsumed candidates through the scoring pipeline
 5. Optionally blend vector-similarity scores when AI is enabled
 6. Apply series filtering with substitution (when `series_in_order` is enabled): candidates that fail series ordering rules are replaced with the earliest recommendable entry from the same series, using the substitute's own pipeline score. Duplicate substitutions per series are prevented. Also apply diversity bonus (genre-hopping) and ranking adjustments
 7. Apply the variety penalty (when `variety_penalty` > 0): build a stepped genre-fatigue ladder from the user's recently completed items **of the recommended content type**, deriving the ladder's top rung from the user's `variety_penalty` (0.0-5.0) divided by its `5.0` maximum (so `4.0` reproduces the legacy `0.8` top fraction and `5.0` fully zeroes a just-finished genre), then multiply each candidate's final score by `1 - penalty` where the penalty is the strongest among the candidate's recently finished genre clusters (`variety.py`). A finished season of an otherwise in-progress TV show also counts as a completion event for the ladder, dated by that season's watch timestamp rather than the show's (absent) `date_completed` — see [SCORING.md](docs/SCORING.md#variety-after-completion). The penalty is softened (halved) for an item that continues a series the user is actively progressing through (`is_active_series_continuation`), so the next book in an unfinished series is not buried by genre fatigue. The applied penalty is surfaced per recommendation
-8. Filter out items marked as `ignored`
+8. Exclude candidates that are already consumed or marked as `ignored` (ignored items are filtered from the candidate pool at fetch time, the same way they are excluded from the signal set)
 9. Generate ranked recommendations with score breakdowns
 
 **Cross-Content-Type Recommendations:**

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -124,4 +124,18 @@ Items can be marked as `ignored` to permanently exclude them from
 recommendations. Set `ignored: true` when importing via CSV or JSON templates, or
 use the **Ignore** button in the web UI's Library page (CLI:
 `library ignore --id <id>`). Ignored items remain in your library but are
-filtered out before recommendations are generated.
+excluded from **all** recommendation processing — they never feed preference
+analysis, scoring, similarity search, or the "since you enjoyed X" explanation
+references, and they are never surfaced as candidates. The same exclusion
+applies to completed-but-unrated items in the *signal* set: an item you finished
+but never rated carries no taste signal, so it does not shape recommendations
+(though unrated items still appear as candidates — the backlog you might consume
+next is unrated by nature). This filtering is centralized in the storage
+layer's signal-set accessor, so every surface that shapes recommendations —
+the ranking engine, the conversational assistant, and the web's streaming
+blurbs — respects it uniformly.
+
+Series *ordering* is the one deliberate exception: whether you have already
+consumed an earlier entry in a series is a consumption fact independent of
+rating or ignore state, so an ignored or unrated earlier entry still counts for
+"recommend book #1 before book #3" purposes.

--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -241,11 +241,14 @@ class ContextAssembler:
         Returns:
             List of high-rated ContentItem objects
         """
+        # High-rated (4+) items are used as taste references, so ignored items
+        # must be excluded; min_rating already drops unrated items (issue #99).
         return self.storage.get_completed_items(
             user_id=user_id,
             content_type=content_type,
             min_rating=4,
             limit=limit,
+            include_ignored=False,
         )
 
     def _get_recommendation_briefs_from_pipeline(
@@ -330,16 +333,18 @@ class ContextAssembler:
         Returns:
             List of unconsumed ContentItem objects
         """
-        # Fetch all unconsumed items for accurate series filtering
+        # Fetch all unconsumed, non-ignored items for accurate series
+        # filtering. Ignored items are excluded at the fetch (issue #99).
         items = self.storage.get_unconsumed_items(
             user_id=user_id,
             content_type=content_type,
+            include_ignored=False,
         )
 
-        # Filter out ignored items
-        non_ignored = [item for item in items if not item.ignored]
-
-        # Build series tracking from completed items to enforce series order
+        # Build series tracking from the full completed set. Series ordering
+        # asks whether the user has *consumed* an earlier entry — a fact
+        # independent of rating or ignore state — so this must not use the
+        # signal set (issue #99).
         completed_items = self.storage.get_completed_items(
             user_id=user_id,
             content_type=content_type,
@@ -349,10 +354,8 @@ class ContextAssembler:
         # Filter by series ordering rules
         recommendable = [
             item
-            for item in non_ignored
-            if should_recommend_item(
-                item, series_tracking, unconsumed_items=non_ignored
-            )
+            for item in items
+            if should_recommend_item(item, series_tracking, unconsumed_items=items)
         ]
 
         return recommendable[:limit]

--- a/src/conversation/profile.py
+++ b/src/conversation/profile.py
@@ -223,7 +223,9 @@ class ProfileGenerator:
         Returns:
             PreferenceProfile with computed preferences
         """
-        completed_items = self.storage.get_completed_items(user_id=user_id, limit=1000)
+        # Only rated, non-ignored items carry a taste signal for the profile;
+        # ignored/unrated content must not shape chat preferences (issue #99).
+        completed_items = self.storage.get_signal_items(user_id=user_id, limit=1000)
 
         genre_affinities = self._calculate_genre_affinities(completed_items)
 

--- a/src/recommendations/engine.py
+++ b/src/recommendations/engine.py
@@ -217,15 +217,20 @@ class RecommendationEngine:
         Returns:
             List of recommendation dictionaries.
         """
-        # Get consumed items from ALL content types for preference analysis
-        all_consumed_items = self.storage.get_completed_items(
-            content_type=None, min_rating=None
-        )
+        # Taste-signal items (completed, rated, not ignored) shape every
+        # recommendation: preference analysis, scoring, similarity seeds, and
+        # explanation references (issue #99).
+        all_consumed_items = self.storage.get_signal_items(content_type=None)
 
-        # Get consumed items of the requested type for series tracking
+        # Full completed set of the requested type for series ordering.
+        # Deliberately NOT the signal set: whether the user consumed an earlier
+        # series entry is a consumption fact independent of rating or ignore
+        # state, so an ignored/unrated earlier entry must still block a later
+        # one. The signal subset below drives taste-shaped ranking instead.
         consumed_items_of_type = self.storage.get_completed_items(
             content_type=content_type, min_rating=None
         )
+        signal_items_of_type = self.storage.get_signal_items(content_type=content_type)
 
         if not all_consumed_items:
             logger.warning(
@@ -241,11 +246,8 @@ class RecommendationEngine:
         # (e.g., "The Black Unicorn #2" sorts before "Magic Kingdom... #1" when
         # ignoring articles). The scoring pipeline limits results after scoring.
         unconsumed_items = self.storage.get_unconsumed_items(
-            content_type=content_type, limit=None
+            content_type=content_type, limit=None, include_ignored=False
         )
-
-        # Filter out ignored items - they should not be recommended
-        unconsumed_items = [item for item in unconsumed_items if not item.ignored]
 
         if not unconsumed_items:
             logger.warning("No unconsumed items found for %s", content_type.value)
@@ -402,7 +404,7 @@ class RecommendationEngine:
             preferences=preferences,
             content_type=content_type,
             adaptations_map=adaptations_map,
-            recently_completed=consumed_items_of_type,
+            recently_completed=signal_items_of_type,
         )
 
         # Apply the stepped genre-fatigue variety penalty (issue #74) when the
@@ -421,7 +423,7 @@ class RecommendationEngine:
         ):
             ranked_items = self._apply_variety_penalty(
                 ranked_items,
-                consumed_items_of_type,
+                signal_items_of_type,
                 series_tracking,
                 unconsumed_items,
                 top_penalty=user_preference_config.variety_penalty
@@ -480,7 +482,8 @@ class RecommendationEngine:
         content, then searches for similar unconsumed items via embeddings.
 
         Args:
-            all_consumed_items: All consumed items across content types.
+            all_consumed_items: The taste-signal set across content types
+                (completed, rated, not ignored).
             content_type: Target content type for recommendations.
             candidate_count: Upper bound on similarity search results,
                 set to the number of unconsumed candidates so no candidate
@@ -492,14 +495,19 @@ class RecommendationEngine:
         if self.similarity_matcher is None:
             return {}
 
-        rated_items = [item for item in all_consumed_items if item.rating is not None]
-        rated_items.sort(key=lambda item: item.rating or 0, reverse=True)
-
+        # all_consumed_items is the signal set, so every item is already rated.
+        sorted_by_rating = sorted(
+            all_consumed_items, key=lambda item: item.rating or 0, reverse=True
+        )
         high_rated_refs = [
-            item for item in rated_items if item.rating is not None and item.rating >= 4
+            item
+            for item in sorted_by_rating
+            if item.rating is not None and item.rating >= 4
         ][:5]
         low_rated_refs = [
-            item for item in rated_items if item.rating is not None and item.rating < 3
+            item
+            for item in sorted_by_rating
+            if item.rating is not None and item.rating < 3
         ][:3]
 
         reference_items = high_rated_refs + low_rated_refs
@@ -515,6 +523,7 @@ class RecommendationEngine:
             content_type=content_type,
             exclude_ids=exclude_ids,
             limit=capped_limit,
+            include_ignored=False,
         )
 
         if similar_candidates:
@@ -978,9 +987,12 @@ class RecommendationEngine:
         An adaptation is when the same title/author exists in a different content type.
         For example, "Lord of the Rings" book -> "Lord of the Rings" movie.
 
+        Only adaptations the user rated 4+ are surfaced. Callers pass the
+        taste-signal set, so every item is already rated and not ignored.
+
         Args:
             item: Item to check for adaptations.
-            consumed_items: List of consumed items to check against.
+            consumed_items: Signal-set items to check against (all rated).
 
         Returns:
             List of consumed items that are adaptations of this item.
@@ -1032,9 +1044,10 @@ class RecommendationEngine:
         items that don't genuinely relate to the candidate are omitted
         rather than padded.
 
-        Items rated below 3 are excluded — they represent content the user
-        disliked and should never appear as "you liked".  Unrated items
-        (``rating is None``) are kept (benefit of the doubt).
+        Callers pass the taste-signal set, so every item is already rated and
+        not ignored. Items rated below 3 are still excluded here — they
+        represent content the user disliked and should never appear as
+        "you liked".
 
         For same-type items, raw genre Jaccard is used (works well since
         the same vocabulary is shared).  For cross-type items, thematic
@@ -1043,7 +1056,7 @@ class RecommendationEngine:
 
         Args:
             candidate: The recommended item.
-            all_consumed_items: All consumed items.
+            all_consumed_items: The taste-signal set (all rated, not ignored).
 
         Returns:
             Contributing consumed items grouped by type: up to 3 same-type,
@@ -1071,8 +1084,7 @@ class RecommendationEngine:
                 continue
 
             # Skip items the user actively disliked — they should never
-            # appear as "recommended because you liked".  Unrated items
-            # (rating is None) are kept.
+            # appear as "recommended because you liked".
             if consumed.rating is not None and consumed.rating < 3:
                 continue
 
@@ -1127,7 +1139,7 @@ class RecommendationEngine:
                 overlap += 0.5
 
             # Boost highly-rated items so they surface as references more
-            # often, but don't exclude lower-rated or unrated items.
+            # often, without excluding lower-rated ones.
             if consumed.rating and consumed.rating >= 4:
                 overlap += 0.15
 

--- a/src/recommendations/similarity.py
+++ b/src/recommendations/similarity.py
@@ -35,6 +35,7 @@ class SimilarityMatcher:
         exclude_ids: list[str] | None = None,
         limit: int = 20,
         user_id: int | None = None,
+        include_ignored: bool = True,
     ) -> list[tuple[ContentItem, float]]:
         """Find items similar to reference items.
 
@@ -44,6 +45,9 @@ class SimilarityMatcher:
             exclude_ids: Optional list of IDs to exclude
             limit: Maximum number of results
             user_id: User ID to scope item lookup (defaults to default user)
+            include_ignored: Whether ignored items may appear in the result
+                lookup table (default True). Recommendation callers pass False
+                so ignored items are never surfaced as similar candidates.
 
         Returns:
             List of (ContentItem, similarity_score) tuples, sorted by score
@@ -121,6 +125,7 @@ class SimilarityMatcher:
                 user_id=user_id,
                 content_type=content_type,
                 limit=_MAX_SIMILARITY_CANDIDATES,
+                include_ignored=include_ignored,
             )
             items_by_id = {item.id: item for item in all_items if item.id}
 

--- a/src/storage/manager.py
+++ b/src/storage/manager.py
@@ -308,6 +308,7 @@ class StorageManager:
         user_id: int | None = None,
         content_type: ContentType | None = None,
         limit: int | None = None,
+        include_ignored: bool = True,
     ) -> list[ContentItem]:
         """Get unconsumed items (status = UNREAD or CURRENTLY_CONSUMING).
 
@@ -315,12 +316,16 @@ class StorageManager:
             user_id: Filter by user ID
             content_type: Filter by content type
             limit: Maximum number of results
+            include_ignored: Whether to include ignored items (default True)
 
         Returns:
             List of unconsumed ContentItem objects
         """
         return self.sqlite_db.get_unconsumed_items(
-            user_id=user_id, content_type=content_type, limit=limit
+            user_id=user_id,
+            content_type=content_type,
+            limit=limit,
+            include_ignored=include_ignored,
         )
 
     def get_completed_items(
@@ -329,6 +334,7 @@ class StorageManager:
         content_type: ContentType | None = None,
         min_rating: int | None = None,
         limit: int | None = None,
+        include_ignored: bool = True,
     ) -> list[ContentItem]:
         """Get completed items (status = COMPLETED or CURRENTLY_CONSUMING).
 
@@ -337,6 +343,7 @@ class StorageManager:
             content_type: Filter by content type
             min_rating: Minimum rating (inclusive)
             limit: Maximum number of results
+            include_ignored: Whether to include ignored items (default True)
 
         Returns:
             List of completed ContentItem objects
@@ -346,7 +353,49 @@ class StorageManager:
             content_type=content_type,
             min_rating=min_rating,
             limit=limit,
+            include_ignored=include_ignored,
         )
+
+    def get_signal_items(
+        self,
+        user_id: int | None = None,
+        content_type: ContentType | None = None,
+        limit: int | None = None,
+    ) -> list[ContentItem]:
+        """Get taste-signal items: completed, rated, and not ignored.
+
+        This is the single source of truth for the set of items that may
+        shape recommendations — preference analysis, scoring, similarity
+        seeds, and explanation references. Ignored items are excluded by the
+        user, and completed-but-unrated items carry no taste signal, so
+        neither may shape recommendations (issue #99). The "not ignored"
+        constraint is expressed once, via the SQL ``include_ignored=False``
+        predicate; only the rating floor is applied in Python because it has
+        no dedicated query parameter.
+
+        This is deliberately distinct from series-ordering fetches: whether
+        the user has *consumed* an earlier series entry is a fact independent
+        of rating or ignore state, so series tracking must use the full
+        completed set, not this signal set.
+
+        Args:
+            user_id: Filter by user ID
+            content_type: Filter by content type
+            limit: Maximum number of completed (non-ignored) items to consider.
+                Applied by ``get_completed_items`` before the Python rating
+                filter, so a caller passing ``limit`` may receive fewer than
+                ``limit`` signal items when some are unrated.
+
+        Returns:
+            List of completed, rated, non-ignored ContentItem objects
+        """
+        completed = self.get_completed_items(
+            user_id=user_id,
+            content_type=content_type,
+            limit=limit,
+            include_ignored=False,
+        )
+        return [item for item in completed if item.rating is not None]
 
     def search_similar(
         self,

--- a/src/storage/sqlite_db.py
+++ b/src/storage/sqlite_db.py
@@ -994,6 +994,7 @@ class SQLiteDB:
         user_id: int | None = None,
         content_type: ContentType | None = None,
         limit: int | None = None,
+        include_ignored: bool = True,
     ) -> list[ContentItem]:
         """Get unconsumed items (status = UNREAD or CURRENTLY_CONSUMING).
 
@@ -1001,6 +1002,7 @@ class SQLiteDB:
             user_id: Filter by user ID
             content_type: Filter by content type
             limit: Maximum number of results
+            include_ignored: Whether to include ignored items (default True)
 
         Returns:
             List of unconsumed ContentItem objects
@@ -1010,6 +1012,7 @@ class SQLiteDB:
             content_type=content_type,
             status=[ConsumptionStatus.UNREAD, ConsumptionStatus.CURRENTLY_CONSUMING],
             limit=limit,
+            include_ignored=include_ignored,
         )
 
     def get_completed_items(
@@ -1018,6 +1021,7 @@ class SQLiteDB:
         content_type: ContentType | None = None,
         min_rating: int | None = None,
         limit: int | None = None,
+        include_ignored: bool = True,
     ) -> list[ContentItem]:
         """Get completed items (status = COMPLETED or CURRENTLY_CONSUMING).
 
@@ -1026,6 +1030,7 @@ class SQLiteDB:
             content_type: Filter by content type
             min_rating: Minimum rating (inclusive)
             limit: Maximum number of results
+            include_ignored: Whether to include ignored items (default True)
 
         Returns:
             List of completed ContentItem objects
@@ -1036,6 +1041,7 @@ class SQLiteDB:
             status=[ConsumptionStatus.COMPLETED, ConsumptionStatus.CURRENTLY_CONSUMING],
             min_rating=min_rating,
             limit=limit,
+            include_ignored=include_ignored,
         )
 
     # Configuration for reading detail table columns back into metadata.

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -718,10 +718,11 @@ async def stream_recommendations(
             }
             yield f"data: {json.dumps(event)}\n\n"
 
-            # Phase 2: generate blurbs per item, stream as they complete
-            consumed_items = engine.storage.get_completed_items(
-                content_type=None, min_rating=None
-            )
+            # Phase 2: generate blurbs per item, stream as they complete.
+            # Blurbs cite consumed items as taste context, so they must draw
+            # from the signal set only — never ignored or unrated items
+            # (issue #99).
+            consumed_items = engine.storage.get_signal_items(content_type=None)
 
             items_with_index: list[tuple[int, ContentItem, list[ContentItem]]] = []
             for idx, rec in enumerate(recommendations):

--- a/tests/conversation/test_context.py
+++ b/tests/conversation/test_context.py
@@ -2051,3 +2051,84 @@ class TestContextBlockHallucinationRegression:
         assert "No Recommendations Available" in block
         assert "Do NOT invent" in block
         assert "backlog is empty" not in block
+
+
+class TestContextIgnoredSignalRegression:
+    """Bug reported: ignored items leaked into the conversational RAG context.
+
+    Bug reported: the chat assistant's fallback taste references and backlog
+    both surfaced items the user had marked ``ignored`` — high-rated ignored
+    items appeared as "you enjoyed" references and ignored backlog items were
+    offered as suggestions.
+    Root cause: ``_get_high_rated_items`` fetched with the default
+    ``include_ignored=True`` and ``_get_unconsumed_items_fallback`` filtered
+    ignored items in Python after the fetch rather than at the fetch.
+    Fix: both fetch with ``include_ignored=False``.
+    """
+
+    def test_high_rated_references_exclude_ignored_regression(
+        self,
+        context_assembler: ContextAssembler,
+        storage_manager: StorageManager,
+    ) -> None:
+        """Ignored high-rated items never appear as RAG taste references."""
+        storage_manager.save_content_item(
+            ContentItem(
+                id="kept",
+                title="Loved Book",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.COMPLETED,
+                rating=5,
+            ),
+            user_id=1,
+        )
+        ignored_db_id = storage_manager.save_content_item(
+            ContentItem(
+                id="ignored",
+                title="Ignored Favorite",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.COMPLETED,
+                rating=5,
+            ),
+            user_id=1,
+        )
+        storage_manager.set_item_ignored(ignored_db_id, True, user_id=1)
+
+        titles = {
+            item.title for item in context_assembler._get_high_rated_items(user_id=1)
+        }
+        assert "Loved Book" in titles
+        assert "Ignored Favorite" not in titles
+
+    def test_unconsumed_fallback_excludes_ignored_regression(
+        self,
+        context_assembler: ContextAssembler,
+        storage_manager: StorageManager,
+    ) -> None:
+        """Ignored backlog items are never offered as fallback suggestions."""
+        storage_manager.save_content_item(
+            ContentItem(
+                id="kept",
+                title="Backlog Book",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.UNREAD,
+            ),
+            user_id=1,
+        )
+        ignored_db_id = storage_manager.save_content_item(
+            ContentItem(
+                id="ignored",
+                title="Ignored Backlog",
+                content_type=ContentType.BOOK,
+                status=ConsumptionStatus.UNREAD,
+            ),
+            user_id=1,
+        )
+        storage_manager.set_item_ignored(ignored_db_id, True, user_id=1)
+
+        titles = {
+            item.title
+            for item in context_assembler._get_unconsumed_items_fallback(user_id=1)
+        }
+        assert "Backlog Book" in titles
+        assert "Ignored Backlog" not in titles

--- a/tests/conversation/test_profile.py
+++ b/tests/conversation/test_profile.py
@@ -745,3 +745,55 @@ class TestProfileRegression:
         # because TV shows have no fantasy data at all
         for pattern in profile.cross_media_patterns:
             assert "fantasy" not in pattern.lower() or "but not" not in pattern.lower()
+
+
+class TestProfileIgnoredSignalRegression:
+    """Bug reported: ignored items shaped the conversational preference profile.
+
+    Bug reported: ``generate_profile`` analyzed the user's whole completed
+    library, so items the user marked ``ignored`` still influenced the chat
+    assistant's genre affinities and theme preferences.
+    Root cause: it fetched via ``get_completed_items`` with the default
+    ``include_ignored=True``.
+    Fix: it routes through ``get_signal_items`` (completed, rated, not
+    ignored).
+    """
+
+    def test_ignored_items_excluded_from_profile_regression(
+        self, profile_generator: ProfileGenerator, storage_manager: StorageManager
+    ) -> None:
+        """A distinctive genre only present on ignored items never enters the profile."""
+        # Two normal signal items so their genre clears MIN_ITEMS_PER_GENRE and
+        # the profile is non-empty.
+        for index, title in enumerate(("Dune", "Foundation")):
+            storage_manager.save_content_item(
+                ContentItem(
+                    id=f"signal{index}",
+                    title=title,
+                    content_type=ContentType.BOOK,
+                    status=ConsumptionStatus.COMPLETED,
+                    rating=5,
+                    metadata={"genres": ["sci-fi"]},
+                ),
+                user_id=1,
+            )
+        # Two high-rated westerns, both ignored — enough to clear the
+        # per-genre minimum, so only the ignore filter can keep them out.
+        for index in range(2):
+            db_id = storage_manager.save_content_item(
+                ContentItem(
+                    id=f"western{index}",
+                    title=f"Western {index}",
+                    content_type=ContentType.BOOK,
+                    status=ConsumptionStatus.COMPLETED,
+                    rating=5,
+                    metadata={"genres": ["western"]},
+                ),
+                user_id=1,
+            )
+            storage_manager.set_item_ignored(db_id, True, user_id=1)
+
+        profile = profile_generator.generate_profile(user_id=1)
+
+        assert "western" not in profile.genre_affinities
+        assert "science fiction" in profile.genre_affinities

--- a/tests/test_recommendation_engine.py
+++ b/tests/test_recommendation_engine.py
@@ -30,11 +30,26 @@ from src.storage.vector_db import VectorDB
 
 @pytest.fixture
 def mock_storage():
-    """Create a mock storage manager."""
+    """Create a mock storage manager.
+
+    ``get_signal_items`` mirrors the real accessor (completed, rated, not
+    ignored) by filtering whatever ``get_completed_items`` a test sets up, so
+    existing tests only need to stub ``get_completed_items``. The real
+    accessor's own filtering is covered in ``tests/test_storage_manager.py``.
+    """
     storage = Mock(spec=StorageManager)
     storage.vector_db = Mock(spec=VectorDB)
     storage.vector_db.has_embedding = Mock(return_value=False)
     storage.vector_db.get_embedding = Mock(return_value=None)
+    storage.get_signal_items = Mock(
+        side_effect=lambda user_id=None, content_type=None, limit=None, **kwargs: [
+            item
+            for item in storage.get_completed_items(
+                user_id=user_id, content_type=content_type, limit=limit, **kwargs
+            )
+            if item.rating is not None and not item.ignored
+        ]
+    )
     return storage
 
 
@@ -66,6 +81,49 @@ def non_ai_engine(mock_storage):
         recommendation_generator=None,
         min_rating=4,
     )
+
+
+@pytest.fixture
+def real_storage(tmp_path):
+    """Create a real StorageManager backed by a temporary SQLite database."""
+    return StorageManager(tmp_path / "engine_signal.db", ai_enabled=False)
+
+
+@pytest.fixture
+def real_engine(real_storage):
+    """Create a non-AI RecommendationEngine over real storage."""
+    return RecommendationEngine(
+        storage_manager=real_storage,
+        embedding_generator=None,
+        recommendation_generator=None,
+        min_rating=4,
+    )
+
+
+def _save_book(
+    storage,
+    *,
+    item_id,
+    title,
+    status,
+    rating=None,
+    ignored=False,
+    genre="Science Fiction",
+):
+    """Persist a book, optionally marking it ignored; return its db_id."""
+    db_id = storage.save_content_item(
+        ContentItem(
+            id=item_id,
+            title=title,
+            content_type=ContentType.BOOK,
+            status=status,
+            rating=rating,
+            metadata={"genre": genre},
+        )
+    )
+    if ignored:
+        storage.set_item_ignored(db_id, True)
+    return db_id
 
 
 # ---------------------------------------------------------------------------
@@ -907,47 +965,34 @@ class TestSeriesOrderingRegression:
 
 
 class TestIgnoredItems:
-    """Tests for ignored items filtering in recommendations."""
+    """Tests for ignored items filtering in recommendations (real storage)."""
 
     def test_ignored_items_filtered_from_recommendations(
-        self, non_ai_engine, mock_storage
+        self, real_engine, real_storage
     ):
         """Ignored unconsumed items should not appear in recommendations."""
-        consumed = ContentItem(
-            id="1",
+        _save_book(
+            real_storage,
+            item_id="1",
             title="Consumed Book",
-            content_type=ContentType.BOOK,
             status=ConsumptionStatus.COMPLETED,
             rating=5,
-            metadata={"genre": "Science Fiction"},
         )
-
-        normal_item = ContentItem(
-            id="2",
+        _save_book(
+            real_storage,
+            item_id="2",
             title="Normal Book",
-            content_type=ContentType.BOOK,
             status=ConsumptionStatus.UNREAD,
-            ignored=False,
-            metadata={"genre": "Science Fiction"},
         )
-
-        ignored_item = ContentItem(
-            id="3",
+        _save_book(
+            real_storage,
+            item_id="3",
             title="Ignored Book",
-            content_type=ContentType.BOOK,
             status=ConsumptionStatus.UNREAD,
             ignored=True,
-            metadata={"genre": "Science Fiction"},
         )
 
-        mock_storage.get_completed_items = Mock(
-            side_effect=lambda content_type=None, **kwargs: [consumed]
-        )
-        mock_storage.get_unconsumed_items = Mock(
-            return_value=[normal_item, ignored_item]
-        )
-
-        recommendations = non_ai_engine.generate_recommendations(
+        recommendations = real_engine.generate_recommendations(
             content_type=ContentType.BOOK,
             count=5,
         )
@@ -960,43 +1005,34 @@ class TestIgnoredItems:
         # Ignored item should NOT be recommended
         assert "Ignored Book" not in recommended_titles
 
-    def test_all_ignored_items_returns_empty(self, non_ai_engine, mock_storage):
+    def test_all_ignored_items_returns_empty(self, real_engine, real_storage):
         """If all unconsumed items are ignored, return empty recommendations."""
-        consumed = ContentItem(
-            id="1",
+        _save_book(
+            real_storage,
+            item_id="1",
             title="Consumed Book",
-            content_type=ContentType.BOOK,
             status=ConsumptionStatus.COMPLETED,
             rating=5,
-            metadata={"genre": "Drama"},
+            genre="Drama",
         )
-
-        ignored_item_1 = ContentItem(
-            id="2",
+        _save_book(
+            real_storage,
+            item_id="2",
             title="Ignored Book 1",
-            content_type=ContentType.BOOK,
             status=ConsumptionStatus.UNREAD,
             ignored=True,
-            metadata={"genre": "Drama"},
+            genre="Drama",
         )
-
-        ignored_item_2 = ContentItem(
-            id="3",
+        _save_book(
+            real_storage,
+            item_id="3",
             title="Ignored Book 2",
-            content_type=ContentType.BOOK,
             status=ConsumptionStatus.UNREAD,
             ignored=True,
-            metadata={"genre": "Drama"},
+            genre="Drama",
         )
 
-        mock_storage.get_completed_items = Mock(
-            side_effect=lambda content_type=None, **kwargs: [consumed]
-        )
-        mock_storage.get_unconsumed_items = Mock(
-            return_value=[ignored_item_1, ignored_item_2]
-        )
-
-        recommendations = non_ai_engine.generate_recommendations(
+        recommendations = real_engine.generate_recommendations(
             content_type=ContentType.BOOK,
             count=5,
         )
@@ -3548,3 +3584,589 @@ class TestInProgressItemsExcludedFromBasisRegression:
             "LLM-only fallback must receive only completed items as taste "
             "context — in-progress items must be filtered out"
         )
+
+
+class TestIgnoredAndUnratedSignalRegression:
+    """Bug reported: ignored and completed-but-unrated items shaped recs.
+
+    Bug reported: ignored items were only filtered at the final candidate
+    stage, so they still fed preference analysis, scoring, similarity seeds,
+    and "since you enjoyed X" explanation references; completed-but-unrated
+    items leaked the same way because the signal was fetched with
+    min_rating=None.
+    Root cause: the engine fetched its signal set with the default
+    include_ignored=True and min_rating=None, never narrowing to rated items.
+    Fix: the engine draws its signal set from StorageManager.get_signal_items
+    (completed, rated, not ignored) and its candidate pool with
+    include_ignored=False. Verified end-to-end against real storage so the
+    assertions exercise the actual filtering, not mock wiring.
+    """
+
+    def test_ignored_and_unrated_excluded_from_signal_regression(
+        self, real_engine, real_storage
+    ):
+        """Ignored/unrated completed items never seed candidates or references."""
+        _save_book(
+            real_storage,
+            item_id="dune",
+            title="Dune",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+        )
+        _save_book(
+            real_storage,
+            item_id="neuro",
+            title="Neuromancer",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            ignored=True,
+        )
+        _save_book(
+            real_storage,
+            item_id="snow",
+            title="Snow Crash",
+            status=ConsumptionStatus.COMPLETED,
+            rating=None,
+        )
+        _save_book(
+            real_storage,
+            item_id="hyp",
+            title="Hyperion",
+            status=ConsumptionStatus.UNREAD,
+        )
+        _save_book(
+            real_storage,
+            item_id="saga",
+            title="Ignored Saga",
+            status=ConsumptionStatus.UNREAD,
+            ignored=True,
+        )
+
+        recs = real_engine.generate_recommendations(
+            content_type=ContentType.BOOK, count=5
+        )
+
+        titles = {rec["item"].title for rec in recs}
+        # Candidate pool: the unrated candidate is still recommended (backlog
+        # is unrated by nature); the ignored candidate is not.
+        assert "Hyperion" in titles
+        assert "Ignored Saga" not in titles
+
+        hyperion = next(rec for rec in recs if rec["item"].title == "Hyperion")
+        contributing = {item.title for item in hyperion["contributing_items"]}
+        # The rated, non-ignored signal item is cited; the ignored and the
+        # completed-but-unrated items never appear as "you liked" references.
+        assert "Dune" in contributing
+        assert "Neuromancer" not in contributing
+        assert "Snow Crash" not in contributing
+
+    def test_all_unrated_completed_yields_empty_regression(
+        self, real_engine, real_storage
+    ):
+        """Completed-but-unrated-only libraries produce a graceful empty result."""
+        _save_book(
+            real_storage,
+            item_id="u1",
+            title="Unrated One",
+            status=ConsumptionStatus.COMPLETED,
+            rating=None,
+        )
+        _save_book(
+            real_storage,
+            item_id="cand",
+            title="Candidate",
+            status=ConsumptionStatus.UNREAD,
+        )
+
+        recs = real_engine.generate_recommendations(
+            content_type=ContentType.BOOK, count=5
+        )
+
+        assert recs == []
+
+    def test_all_ignored_completed_yields_empty_regression(
+        self, real_engine, real_storage
+    ):
+        """Libraries whose only completed items are ignored return no recs."""
+        _save_book(
+            real_storage,
+            item_id="i1",
+            title="Ignored One",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            ignored=True,
+        )
+        _save_book(
+            real_storage,
+            item_id="cand",
+            title="Candidate",
+            status=ConsumptionStatus.UNREAD,
+        )
+
+        recs = real_engine.generate_recommendations(
+            content_type=ContentType.BOOK, count=5
+        )
+
+        assert recs == []
+
+
+class TestSimilaritySeedIgnoredRegression:
+    """Bug reported: ignored completed items seeded AI similarity search.
+
+    Bug reported: in AI mode the similarity seeds (reference items whose
+    embeddings form the query vector) were drawn from the unfiltered consumed
+    set, so an ignored completed item could steer the vector search toward
+    content the user explicitly rejected.
+    Root cause: ``_compute_similarity_scores`` seeded from the consumed set
+    without excluding ignored items, and the lookup fetch defaulted to
+    ``include_ignored=True``.
+    Fix: seeds are drawn from ``get_signal_items`` (completed, rated, not
+    ignored) and ``find_similar`` is called with ``include_ignored=False``.
+    This exercises the AI path (embedding_generator set) that the non-AI
+    ``real_engine`` regressions cannot reach.
+    """
+
+    def test_ignored_completed_item_not_used_as_similarity_seed_regression(
+        self, engine, mock_storage, mock_embedding_gen
+    ):
+        """An ignored completed item never has its embedding generated as a seed."""
+        liked = ContentItem(
+            id="liked",
+            title="Dune",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            metadata={"genre": "Science Fiction"},
+        )
+        ignored = ContentItem(
+            id="ign",
+            title="Ignored Favorite",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            ignored=True,
+            metadata={"genre": "Science Fiction"},
+        )
+        candidate = ContentItem(
+            id="cand",
+            title="Hyperion",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.UNREAD,
+            metadata={"genre": "Science Fiction"},
+        )
+        mock_storage.get_completed_items = Mock(
+            side_effect=lambda content_type=None, **kwargs: [liked, ignored]
+        )
+        mock_storage.get_unconsumed_items = Mock(return_value=[candidate])
+        mock_storage.search_similar = Mock(
+            return_value=[{"content_id": "cand", "score": 0.9}]
+        )
+        mock_storage.get_content_items = Mock(return_value=[candidate])
+
+        engine.generate_recommendations(content_type=ContentType.BOOK, count=1)
+
+        # find_similar embeds each reference (seed) item; the ignored item must
+        # never be embedded, while the rated signal item is used as a seed.
+        seeded_titles = {
+            call.args[0].title
+            for call in mock_embedding_gen.generate_content_embedding.call_args_list
+            if call.args
+        }
+        assert "Dune" in seeded_titles
+        assert "Ignored Favorite" not in seeded_titles
+
+        # The similarity lookup itself is fetched without ignored items.
+        assert any(
+            call.kwargs.get("include_ignored") is False
+            for call in mock_storage.get_content_items.call_args_list
+        )
+
+
+class TestConsumedItemsOfTypeRankingLeakRegression:
+    """Bug reported: ignored/unrated same-type completed items reordered recs.
+
+    Bug reported: ``consumed_items_of_type`` (passed to
+    ``ranker.rank(recently_completed=...)`` and the variety penalty) was
+    fetched unfiltered, so an ignored or completed-but-unrated book's genre
+    entered the ranker's always-on diversity bonus (``diversity_weight=0.1``)
+    and demoted an otherwise-top candidate sharing that genre.
+    Root cause: the full same-type completed set was reused for taste-shaped
+    ranking, not just for series ordering.
+    Fix: ranking draws from a signal subset (``get_signal_items(content_type)``)
+    while series ordering keeps the full completed set. Adapted from QA's
+    reproduction probe and run against real storage so the ranker path is
+    genuinely exercised.
+    """
+
+    @staticmethod
+    def _order(engine):
+        recs = engine.generate_recommendations(content_type=ContentType.BOOK, count=5)
+        return [rec["item"].title for rec in recs]
+
+    @staticmethod
+    def _seed_baseline(storage):
+        _save_book(
+            storage,
+            item_id="sig",
+            title="Gone Girl",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            genre="Mystery",
+        )
+        _save_book(
+            storage,
+            item_id="cf",
+            title="Fantasy Candidate",
+            status=ConsumptionStatus.UNREAD,
+            genre="Fantasy",
+        )
+        _save_book(
+            storage,
+            item_id="cs",
+            title="SciFi Candidate",
+            status=ConsumptionStatus.UNREAD,
+            genre="Science Fiction",
+        )
+
+    def test_ignored_completed_item_does_not_reorder_regression(
+        self, real_engine, real_storage
+    ):
+        """An ignored completed book must not reorder recommendations."""
+        self._seed_baseline(real_storage)
+        baseline = self._order(real_engine)
+
+        _save_book(
+            real_storage,
+            item_id="fan",
+            title="Ignored Fantasy",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            ignored=True,
+            genre="Fantasy",
+        )
+        after = self._order(real_engine)
+
+        assert after == baseline, (
+            "An ignored completed item changed recommendation order via the "
+            "ranker diversity bonus — issue #99 leak in ranking"
+        )
+
+    def test_unrated_completed_item_does_not_reorder_regression(
+        self, real_engine, real_storage
+    ):
+        """A completed-but-unrated book must not reorder recommendations."""
+        self._seed_baseline(real_storage)
+        baseline = self._order(real_engine)
+
+        _save_book(
+            real_storage,
+            item_id="fan",
+            title="Unrated Fantasy",
+            status=ConsumptionStatus.COMPLETED,
+            rating=None,
+            genre="Fantasy",
+        )
+        after = self._order(real_engine)
+
+        assert after == baseline, (
+            "A completed-but-unrated item changed recommendation order via the "
+            "ranker diversity bonus — issue #99 leak in ranking"
+        )
+
+    def test_rated_completion_reorders_positive_control(
+        self, real_engine, real_storage
+    ):
+        """Positive control: a rated, non-ignored completion DOES change order.
+
+        Proves the seed set genuinely drives ranking, so the "order unchanged"
+        assertions above are meaningful rather than vacuous. Two rated
+        completions matching the trailing candidate's genre push it up the
+        ranking via the (strongly weighted) preference signal.
+        """
+        self._seed_baseline(real_storage)
+        baseline = self._order(real_engine)
+
+        genre_by_title = {
+            "Fantasy Candidate": "Fantasy",
+            "SciFi Candidate": "Science Fiction",
+        }
+        trailing_genre = genre_by_title[baseline[-1]]
+        for index in range(2):
+            _save_book(
+                real_storage,
+                item_id=f"pref{index}",
+                title=f"Loved {index}",
+                status=ConsumptionStatus.COMPLETED,
+                rating=5,
+                genre=trailing_genre,
+            )
+        after = self._order(real_engine)
+
+        assert after != baseline, (
+            "A rated, non-ignored completion should reorder recommendations — "
+            "if it does not, the negative regressions above prove nothing"
+        )
+
+
+class TestVarietyPenaltySignalRegression:
+    """Bug reported: ignored/unrated items leaked into the variety penalty.
+
+    Bug reported: with a non-zero ``variety_penalty`` the genre-fatigue ladder
+    was built from the full same-type completed set, so an ignored or
+    completed-but-unrated book still marked its genre "recently finished" and
+    demoted an otherwise-unpenalised candidate sharing that genre.
+    Root cause: ``_apply_variety_penalty`` received the unfiltered
+    ``consumed_items_of_type`` set.
+    Fix: the engine passes the signal subset (``get_signal_items(content_type)``)
+    to the variety penalty, so only rated, non-ignored completions build the
+    ladder. Exercised end-to-end against real storage with a ``variety_penalty``
+    config (the path the ranker-diversity regression above does not cover). A
+    positive control confirms the ladder is genuinely live for these genres so
+    the "penalty stays zero" assertions are meaningful, not vacuous.
+    """
+
+    # variety_penalty == MAX gives a top-rung penalty fraction of 1.0, which
+    # fully zeroes a just-finished genre — the strongest, most observable rung.
+    _CONFIG = UserPreferenceConfig(
+        variety_penalty=UserPreferenceConfig.MAX_VARIETY_PENALTY
+    )
+
+    @staticmethod
+    def _seed_baseline(storage):
+        # A rated, non-ignored Mystery signal item makes recommendations exist
+        # and seeds the ladder with Mystery (a cluster none of the candidates
+        # share, so baseline candidate penalties are zero).
+        _save_book(
+            storage,
+            item_id="sig",
+            title="Gone Girl",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            genre="Mystery",
+        )
+        _save_book(
+            storage,
+            item_id="cf",
+            title="Fantasy Candidate",
+            status=ConsumptionStatus.UNREAD,
+            genre="Fantasy",
+        )
+        _save_book(
+            storage,
+            item_id="cs",
+            title="SciFi Candidate",
+            status=ConsumptionStatus.UNREAD,
+            genre="Science Fiction",
+        )
+
+    def _fantasy_penalty(self, engine):
+        recs = engine.generate_recommendations(
+            content_type=ContentType.BOOK,
+            count=5,
+            user_preference_config=self._CONFIG,
+        )
+        fantasy = next(rec for rec in recs if rec["item"].title == "Fantasy Candidate")
+        return fantasy["variety_penalty"]
+
+    def test_baseline_fantasy_candidate_unpenalised(self, real_engine, real_storage):
+        """With only a Mystery signal item, the Fantasy candidate has no penalty."""
+        self._seed_baseline(real_storage)
+        assert self._fantasy_penalty(real_engine) == 0.0
+
+    def test_rated_completed_fantasy_penalises_positive_control(
+        self, real_engine, real_storage
+    ):
+        """Positive control: a rated, non-ignored Fantasy completion penalises it.
+
+        Proves the ladder recognises the Fantasy cluster and applies a penalty,
+        so the ignored/unrated "stays zero" assertions below are meaningful.
+        """
+        self._seed_baseline(real_storage)
+        _save_book(
+            real_storage,
+            item_id="fan",
+            title="Rated Fantasy",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            genre="Fantasy",
+        )
+        assert self._fantasy_penalty(real_engine) > 0.0
+
+    def test_ignored_completed_fantasy_does_not_penalise_regression(
+        self, real_engine, real_storage
+    ):
+        """An ignored Fantasy completion must not enter the variety ladder."""
+        self._seed_baseline(real_storage)
+        _save_book(
+            real_storage,
+            item_id="fan",
+            title="Ignored Fantasy",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            ignored=True,
+            genre="Fantasy",
+        )
+        assert self._fantasy_penalty(real_engine) == 0.0, (
+            "An ignored completed item entered the variety ladder and "
+            "penalised a same-genre candidate — issue #99 leak in variety penalty"
+        )
+
+    def test_unrated_completed_fantasy_does_not_penalise_regression(
+        self, real_engine, real_storage
+    ):
+        """A completed-but-unrated Fantasy book must not enter the ladder."""
+        self._seed_baseline(real_storage)
+        _save_book(
+            real_storage,
+            item_id="fan",
+            title="Unrated Fantasy",
+            status=ConsumptionStatus.COMPLETED,
+            rating=None,
+            genre="Fantasy",
+        )
+        assert self._fantasy_penalty(real_engine) == 0.0, (
+            "A completed-but-unrated item entered the variety ladder and "
+            "penalised a same-genre candidate — issue #99 leak in variety penalty"
+        )
+
+
+class TestSeriesTrackingFullSetRegression:
+    """Series ordering must use the FULL completed set, not the signal set.
+
+    Bug guarded: issue #99 narrows taste-shaped inputs to the signal set
+    (completed, rated, not ignored). Series ordering must NOT be narrowed the
+    same way — whether the user has *consumed* an earlier entry is a fact
+    independent of rating or ignore state. If series tracking used the signal
+    set, an ignored or completed-but-unrated middle entry would vanish from
+    the consumed positions and strand the series: the next entry would be held
+    behind an entry the user has actually finished (and which can never
+    reappear as a candidate). The engine deliberately builds series tracking
+    from the full ``consumed_items_of_type``; these tests lock that in against
+    real storage.
+    """
+
+    @staticmethod
+    def _titles(engine):
+        recs = engine.generate_recommendations(content_type=ContentType.BOOK, count=5)
+        return [rec["item"].title for rec in recs]
+
+    def test_completed_rated_first_entry_unlocks_second(
+        self, real_engine, real_storage
+    ):
+        """Completing (and rating) #1 recommends #2 and holds #3."""
+        _save_book(
+            real_storage,
+            item_id="s1",
+            title="Foundation (Signal Saga #1)",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+        )
+        _save_book(
+            real_storage,
+            item_id="s2",
+            title="Foundation and Empire (Signal Saga #2)",
+            status=ConsumptionStatus.UNREAD,
+        )
+        _save_book(
+            real_storage,
+            item_id="s3",
+            title="Second Foundation (Signal Saga #3)",
+            status=ConsumptionStatus.UNREAD,
+        )
+
+        titles = self._titles(real_engine)
+
+        assert any(
+            "Foundation and Empire" in t for t in titles
+        ), "#2 should be recommended after completing #1"
+        assert not any(
+            "Second Foundation" in t for t in titles
+        ), "#3 must stay held until #2 is consumed"
+
+    def test_ignored_middle_entry_does_not_strand_series_regression(
+        self, real_engine, real_storage
+    ):
+        """An ignored completed #2 still counts, so #3 is recommended (not stranded).
+
+        If series tracking used the signal set, ignored #2 would drop out of the
+        consumed positions, #3 would be held behind an entry the user already
+        finished, and the series would strand.
+        """
+        _save_book(
+            real_storage,
+            item_id="s1",
+            title="Foundation (Signal Saga #1)",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+        )
+        _save_book(
+            real_storage,
+            item_id="s2",
+            title="Foundation and Empire (Signal Saga #2)",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            ignored=True,
+        )
+        _save_book(
+            real_storage,
+            item_id="s3",
+            title="Second Foundation (Signal Saga #3)",
+            status=ConsumptionStatus.UNREAD,
+        )
+        _save_book(
+            real_storage,
+            item_id="s4",
+            title="Foundation's Edge (Signal Saga #4)",
+            status=ConsumptionStatus.UNREAD,
+        )
+
+        titles = self._titles(real_engine)
+
+        assert any("Second Foundation" in t for t in titles), (
+            "#3 must be recommended even when the finished #2 was ignored — "
+            "series tracking must use the full completed set (issue #99)"
+        )
+        assert not any(
+            "Foundation's Edge" in t for t in titles
+        ), "#4 must stay held until #3 is consumed"
+
+    def test_unrated_middle_entry_does_not_strand_series_regression(
+        self, real_engine, real_storage
+    ):
+        """A completed-but-unrated #2 still counts, so #3 is recommended."""
+        _save_book(
+            real_storage,
+            item_id="s1",
+            title="Foundation (Signal Saga #1)",
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+        )
+        _save_book(
+            real_storage,
+            item_id="s2",
+            title="Foundation and Empire (Signal Saga #2)",
+            status=ConsumptionStatus.COMPLETED,
+            rating=None,
+        )
+        _save_book(
+            real_storage,
+            item_id="s3",
+            title="Second Foundation (Signal Saga #3)",
+            status=ConsumptionStatus.UNREAD,
+        )
+        _save_book(
+            real_storage,
+            item_id="s4",
+            title="Foundation's Edge (Signal Saga #4)",
+            status=ConsumptionStatus.UNREAD,
+        )
+
+        titles = self._titles(real_engine)
+
+        assert any("Second Foundation" in t for t in titles), (
+            "#3 must be recommended even when the finished #2 was unrated — "
+            "series tracking must use the full completed set (issue #99)"
+        )
+        assert not any(
+            "Foundation's Edge" in t for t in titles
+        ), "#4 must stay held until #3 is consumed"

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -400,3 +400,51 @@ class TestFindSimilarExceptionHandling:
 
         results = matcher.find_similar([ref])
         assert results == []
+
+
+class TestFindSimilarIgnoredRegression:
+    """Ignored items must not appear in the similarity lookup table.
+
+    Bug (issue #99): find_similar built its content_id -> item lookup with
+    ``get_content_items`` at the default ``include_ignored=True``, so an
+    ignored item returned by the vector search could be surfaced as a similar
+    candidate feeding recommendation scoring.
+
+    Root cause: find_similar did not expose or thread an ``include_ignored``
+    flag to its lookup fetch.
+
+    Fix: find_similar accepts ``include_ignored`` and passes it to
+    ``get_content_items``; recommendation callers pass False.
+    """
+
+    def test_threads_include_ignored_to_lookup_fetch_regression(
+        self, matcher: SimilarityMatcher, mock_storage: Mock
+    ) -> None:
+        """include_ignored is forwarded to the get_content_items lookup."""
+        ref = make_item(item_id="ref1", title="Reference Book")
+        mock_storage.search_similar.return_value = [{"content_id": "a", "score": 0.9}]
+        mock_storage.get_content_items.return_value = [
+            make_item(item_id="a", title="Book A")
+        ]
+
+        matcher.find_similar([ref], include_ignored=False)
+
+        assert (
+            mock_storage.get_content_items.call_args.kwargs["include_ignored"] is False
+        )
+
+    def test_defaults_to_including_ignored(
+        self, matcher: SimilarityMatcher, mock_storage: Mock
+    ) -> None:
+        """The lookup defaults to include_ignored=True for other callers."""
+        ref = make_item(item_id="ref1", title="Reference Book")
+        mock_storage.search_similar.return_value = [{"content_id": "a", "score": 0.9}]
+        mock_storage.get_content_items.return_value = [
+            make_item(item_id="a", title="Book A")
+        ]
+
+        matcher.find_similar([ref])
+
+        assert (
+            mock_storage.get_content_items.call_args.kwargs["include_ignored"] is True
+        )

--- a/tests/test_sqlite_db.py
+++ b/tests/test_sqlite_db.py
@@ -4552,3 +4552,78 @@ class TestCrossSourceDuplicateDetectionRegression:
             (dup_id,),
         )
         assert cursor.fetchone()[0] == 0
+
+
+class TestIgnoredSignalFetchRegression:
+    """Ignored items must be excludable from recommendation-signal fetches.
+
+    Bug (issue #99): ``get_completed_items`` / ``get_unconsumed_items`` had no
+    way to exclude ignored items, so ignored content leaked into the
+    recommendation signal (preferences, scoring, similarity, explanations).
+
+    Root cause: both wrappers always delegated to ``get_content_items`` with
+    the default ``include_ignored=True``.
+
+    Fix: both wrappers accept ``include_ignored`` and thread it through, so the
+    engine can fetch a clean signal set while library views keep seeing
+    ignored items.
+    """
+
+    @pytest.mark.parametrize("ignored_rating", [5, None])
+    def test_get_completed_items_excludes_ignored_when_flag_false_regression(
+        self, temp_db: SQLiteDB, ignored_rating: int | None
+    ) -> None:
+        """include_ignored=False drops ignored completed items regardless of rating.
+
+        The ``None`` case covers an item that is both ignored *and* unrated —
+        it must still be excluded via the ignored flag.
+        """
+        kept = ContentItem(
+            id="kept",
+            title="Kept Book",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+        )
+        ignored = ContentItem(
+            id="ignored",
+            title="Ignored Book",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=ignored_rating,
+        )
+        temp_db.save_content_item(kept)
+        ignored_db_id = temp_db.save_content_item(ignored)
+        temp_db.set_item_ignored(ignored_db_id, True)
+
+        default_titles = {i.title for i in temp_db.get_completed_items()}
+        assert default_titles == {"Kept Book", "Ignored Book"}
+
+        filtered = temp_db.get_completed_items(include_ignored=False)
+        assert {i.title for i in filtered} == {"Kept Book"}
+
+    def test_get_unconsumed_items_excludes_ignored_when_flag_false_regression(
+        self, temp_db: SQLiteDB
+    ) -> None:
+        """include_ignored=False drops ignored unconsumed items."""
+        kept = ContentItem(
+            id="kept",
+            title="Kept Game",
+            content_type=ContentType.VIDEO_GAME,
+            status=ConsumptionStatus.UNREAD,
+        )
+        ignored = ContentItem(
+            id="ignored",
+            title="Ignored Game",
+            content_type=ContentType.VIDEO_GAME,
+            status=ConsumptionStatus.UNREAD,
+        )
+        temp_db.save_content_item(kept)
+        ignored_db_id = temp_db.save_content_item(ignored)
+        temp_db.set_item_ignored(ignored_db_id, True)
+
+        default_titles = {i.title for i in temp_db.get_unconsumed_items()}
+        assert default_titles == {"Kept Game", "Ignored Game"}
+
+        filtered = temp_db.get_unconsumed_items(include_ignored=False)
+        assert {i.title for i in filtered} == {"Kept Game"}

--- a/tests/test_storage_manager.py
+++ b/tests/test_storage_manager.py
@@ -537,3 +537,122 @@ class TestConcurrentSaveContentItem:
             row = conn.execute("PRAGMA busy_timeout").fetchone()
         assert row is not None
         assert row[0] >= 5000
+
+
+class TestGetSignalItemsRegression:
+    """Bug reported: ignored/unrated items leaked into the recommendation signal.
+
+    Bug reported: every recommendation surface re-derived "completed, rated,
+    and not ignored" (or forgot to), so ignored items and completed-but-unrated
+    items contaminated preferences, scoring, similarity, and explanations.
+    Root cause: there was no single accessor for the taste-signal set; call
+    sites used ``get_completed_items`` with default filters.
+    Fix: ``StorageManager.get_signal_items`` centralizes the three-part filter
+    (completed AND rated AND not ignored) so every consumer routes through it.
+    """
+
+    @staticmethod
+    def _book(item_id, title, status, rating):
+        return ContentItem(
+            id=item_id,
+            title=title,
+            content_type=ContentType.BOOK,
+            status=status,
+            rating=rating,
+        )
+
+    def test_signal_items_keeps_only_completed_rated_non_ignored_regression(
+        self, temp_storage_manager: StorageManager
+    ) -> None:
+        """get_signal_items returns completed, rated, non-ignored items only."""
+        keep = self._book("keep", "Signal Book", ConsumptionStatus.COMPLETED, rating=5)
+        unrated = self._book(
+            "unrated", "Unrated Book", ConsumptionStatus.COMPLETED, rating=None
+        )
+        unread = self._book("unread", "Backlog Book", ConsumptionStatus.UNREAD, None)
+        ignored = self._book(
+            "ignored", "Ignored Book", ConsumptionStatus.COMPLETED, rating=5
+        )
+
+        temp_storage_manager.save_content_item(keep)
+        temp_storage_manager.save_content_item(unrated)
+        temp_storage_manager.save_content_item(unread)
+        ignored_db_id = temp_storage_manager.save_content_item(ignored)
+        temp_storage_manager.set_item_ignored(ignored_db_id, True)
+
+        titles = {item.title for item in temp_storage_manager.get_signal_items()}
+        assert titles == {"Signal Book"}
+
+    def test_signal_items_excludes_item_that_is_both_ignored_and_unrated_regression(
+        self, temp_storage_manager: StorageManager
+    ) -> None:
+        """An item that is both ignored and unrated is excluded."""
+        keep = self._book("keep", "Signal Book", ConsumptionStatus.COMPLETED, 4)
+        ignored_unrated = self._book(
+            "combo", "Ignored Unrated", ConsumptionStatus.COMPLETED, rating=None
+        )
+        temp_storage_manager.save_content_item(keep)
+        combo_db_id = temp_storage_manager.save_content_item(ignored_unrated)
+        temp_storage_manager.set_item_ignored(combo_db_id, True)
+
+        titles = {item.title for item in temp_storage_manager.get_signal_items()}
+        assert titles == {"Signal Book"}
+
+    def test_signal_items_empty_when_all_unrated_regression(
+        self, temp_storage_manager: StorageManager
+    ) -> None:
+        """The accessor returns [] when every completed item is unrated."""
+        for index in range(2):
+            temp_storage_manager.save_content_item(
+                self._book(
+                    f"u{index}",
+                    f"Unrated {index}",
+                    ConsumptionStatus.COMPLETED,
+                    rating=None,
+                )
+            )
+
+        assert temp_storage_manager.get_signal_items() == []
+
+    def test_signal_items_empty_when_all_ignored_regression(
+        self, temp_storage_manager: StorageManager
+    ) -> None:
+        """The accessor returns [] when every completed item is ignored."""
+        for index in range(2):
+            db_id = temp_storage_manager.save_content_item(
+                self._book(
+                    f"i{index}",
+                    f"Ignored {index}",
+                    ConsumptionStatus.COMPLETED,
+                    rating=5,
+                )
+            )
+            temp_storage_manager.set_item_ignored(db_id, True)
+
+        assert temp_storage_manager.get_signal_items() == []
+
+    def test_signal_items_forwards_params_to_get_completed_items_regression(
+        self, temp_storage_manager: StorageManager
+    ) -> None:
+        """user_id, content_type, limit, and include_ignored are forwarded intact.
+
+        Guards against a user_id/content_type delegation swap and confirms the
+        ignore filter is expressed via the SQL flag.
+        """
+        captured: dict[str, object] = {}
+
+        def fake_completed(**kwargs: object) -> list[ContentItem]:
+            captured.update(kwargs)
+            return []
+
+        temp_storage_manager.get_completed_items = fake_completed  # type: ignore[method-assign]
+
+        result = temp_storage_manager.get_signal_items(
+            user_id=7, content_type=ContentType.MOVIE, limit=3
+        )
+
+        assert result == []
+        assert captured["user_id"] == 7
+        assert captured["content_type"] == ContentType.MOVIE
+        assert captured["limit"] == 3
+        assert captured["include_ignored"] is False

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -3414,3 +3414,73 @@ class TestTraktPollDeviceApproval:
 
         assert response.status_code == 500
         assert response.json()["detail"] == "Storage not initialized"
+
+
+class TestStreamRecommendationsSignalRegression:
+    """Bug reported: streaming blurbs cited ignored/unrated items as taste refs.
+
+    Bug reported: ``/recommendations/stream`` fetched the LLM blurb "taste
+    reference" list via ``get_completed_items(min_rating=None)`` with no
+    ignored/unrated filter, so a streamed "since you enjoyed X" blurb could
+    cite an ignored or completed-but-unrated item.
+    Root cause: ``generate_sse`` called ``get_completed_items`` directly
+    instead of the shared signal accessor.
+    Fix: it now calls ``get_signal_items``, so the blurb generator only ever
+    receives the taste-signal set.
+    """
+
+    def test_blurb_generation_receives_signal_items_regression(
+        self, client, mock_components
+    ) -> None:
+        """The blurb generator is fed the signal set, not the full completed set."""
+        engine = mock_components["engine"]
+        storage = mock_components["storage"]
+
+        candidate = ContentItem(
+            id="cand",
+            title="Hyperion",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.UNREAD,
+        )
+        engine.generate_recommendations.return_value = [
+            {
+                "item": candidate,
+                "score": 0.9,
+                "similarity_score": 0.0,
+                "preference_score": 0.0,
+                "reasoning": "because sci-fi",
+                "score_breakdown": {},
+                "variety_penalty": 0.0,
+                "contributing_items": [],
+            }
+        ]
+
+        signal_item = ContentItem(
+            id="sig",
+            title="Dune",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+        )
+        ignored_item = ContentItem(
+            id="ign",
+            title="Ignored Favorite",
+            content_type=ContentType.BOOK,
+            status=ConsumptionStatus.COMPLETED,
+            rating=5,
+            ignored=True,
+        )
+        storage.get_signal_items.return_value = [signal_item]
+        storage.get_completed_items.return_value = [signal_item, ignored_item]
+        storage.get_user_preference_config.return_value = None
+        engine.generate_blurb_for_item.return_value = "a blurb"
+
+        response = client.get("/api/recommendations/stream?type=book&count=1")
+
+        assert response.status_code == 200
+        assert engine.generate_blurb_for_item.called
+        # generate_blurb_for_item(content_type, item, consumed_items, refs)
+        consumed_arg = engine.generate_blurb_for_item.call_args.args[2]
+        consumed_titles = {item.title for item in consumed_arg}
+        assert consumed_titles == {"Dune"}
+        assert "Ignored Favorite" not in consumed_titles


### PR DESCRIPTION
## What

Ignored items and completed-but-unrated items were still shaping recommendations. Issue #99 asked for ignored items to be ignored everywhere, and for unrated items (completed or not) to carry no signal. They weren't.

The leak had four faces, all drawing the "what has this user consumed" set without filtering:
- **The engine** used them in preference analysis, the scoring context, similarity seeds, the ranker diversity bonus, the variety penalty, and the "because you liked X" explanations.
- **The web streaming blurbs** (the most visible surface) could cite an ignored or unrated item as the reason for a recommendation.
- **The conversational assistant** built its preference profile and RAG context from them.
- **Ignored items** could also slip through as candidates.

## How

A single source of truth: `StorageManager.get_signal_items()` returns the taste-signal set (completed, rated, and not ignored), with the ignored filter pushed into SQL via a new `include_ignored` flag. Every recommendation-shaping surface now routes through it, so they all respect the same rule uniformly instead of each re-deriving the set.

One deliberate exception: **series ordering** keeps the full completed set. Whether you have consumed an earlier entry is a consumption fact independent of rating or ignore state, so an ignored or unrated earlier entry must still hold back a later one (otherwise the next entry strands). This is documented in the code, in `ARCHITECTURE.md`/`docs/SCORING.md`, and locked in by tests.

Unconsumed items are still recommended as candidates. They're unrated by nature, so "unrated carries no signal" means they don't shape recommendations, not that they stop being recommendable.

## Behavior note

A user whose completed library is entirely unrated (or entirely ignored) now has an empty signal set and gets no personalized recommendations, matching the existing cold-start behavior. This is the intended consequence of "unrated carries no signal" and doesn't affect anyone with rated history.

## Testing

Real-storage regression tests across every surface (engine, ranker, variety penalty, similarity seeds, streaming blurbs, conversation profile/context, and the series-ordering exception), several with positive controls so the "stays unchanged" assertions aren't vacuous. Full quality gate green: black, ruff, mypy, 3305 pytest, 515 vitest.

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)