### PR TITLE
feat(ingestion): split goodreads into goodreads_csv, add goodreads_rss

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,6 +14,7 @@ Responsible for parsing and normalizing data from various sources.
 
 **Current Sources:**
 - Goodreads CSV exports (books)
+- Goodreads public shelves via RSS (books)
 - The StoryGraph CSV exports (books)
 - Steam Web API (video games)
 - GOG OAuth API (video games)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -118,8 +118,8 @@ Each source is configured under `inputs:` in `config/config.yaml`. Enable the on
 
 ```yaml
 inputs:
-  goodreads:
-    plugin: goodreads
+  goodreads_csv:
+    plugin: goodreads_csv
     path: "inputs/goodreads_library_export.csv"
     enabled: true
 
@@ -162,7 +162,7 @@ You can have multiple instances of the same plugin (e.g., two `json_import` sour
 
 ```bash
 # Sync a specific source
-python3.11 -m src.cli update --source goodreads
+python3.11 -m src.cli update --source goodreads_csv
 
 # Sync all enabled sources
 python3.11 -m src.cli update --source all
@@ -182,17 +182,17 @@ database (post-migration or freshly created), or both.
 ```bash
 # Create a brand-new source directly in the database (no YAML edit needed)
 python3.11 -m src.cli source plugins             # see what plugins are available
-python3.11 -m src.cli source create my_books goodreads
+python3.11 -m src.cli source create my_books goodreads_csv
 python3.11 -m src.cli source set-secret my_books api_key   # add credentials
 
 # Move an existing YAML source into the database (one-time, idempotent)
-python3.11 -m src.cli source migrate goodreads
+python3.11 -m src.cli source migrate goodreads_csv
 
 # Inspect / edit fields after migration or creation
-python3.11 -m src.cli source show goodreads
-python3.11 -m src.cli source set goodreads path inputs/new_export.csv
-python3.11 -m src.cli source disable goodreads          # disabled sources are skipped during sync
-python3.11 -m src.cli source enable goodreads
+python3.11 -m src.cli source show goodreads_csv
+python3.11 -m src.cli source set goodreads_csv path inputs/new_export.csv
+python3.11 -m src.cli source disable goodreads_csv          # disabled sources are skipped during sync
+python3.11 -m src.cli source enable goodreads_csv
 python3.11 -m src.cli source set-secret steam api_key   # hidden prompt
 
 # Remove a DB-backed source entirely (clears stored secrets too)
@@ -203,15 +203,15 @@ All `source` subcommands except `set-secret` and `clear-secret` accept
 `--format json` for scripting parity with the web API:
 
 ```bash
-python3.11 -m src.cli source show goodreads --format json
-python3.11 -m src.cli source migrate goodreads --format json
+python3.11 -m src.cli source show goodreads_csv --format json
+python3.11 -m src.cli source migrate goodreads_csv --format json
 ```
 
 For atomic multi-field updates (the CLI equivalent of the web
 `PUT /api/sync/sources/<id>/config` bulk endpoint), use `source apply` with
 a JSON dict of values from a file or stdin. The example below uses
 `generic_csv` because it has both `path` and `content_type` in its schema —
-plugin-specific sources like `goodreads` only expose the fields their
+plugin-specific sources like `goodreads_csv` only expose the fields their
 schema declares (run `python3.11 -m src.cli source schema <id>` to see them):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ rest.
 
 | Source | Type | Setup |
 |--------|------|-------|
-| **Goodreads** | Books | [goodreads](src/ingestion/sources/goodreads/README.md) |
+| **Goodreads (CSV export)** | Books | [goodreads_csv](src/ingestion/sources/goodreads_csv/README.md) |
+| **Goodreads (public shelves via RSS)** | Books | [goodreads_rss](src/ingestion/sources/goodreads_rss/README.md) |
 | **The StoryGraph** | Books | [storygraph_csv](src/ingestion/sources/storygraph_csv/README.md) |
 | **Steam** | Games | [steam](src/ingestion/sources/steam/README.md) |
 | **GOG** | Games | [gog](src/ingestion/sources/gog/README.md) |
@@ -112,8 +113,8 @@ features:
 
 # Configure your data sources (see each source's setup guide for fields)
 inputs:
-  goodreads:
-    plugin: goodreads
+  goodreads_csv:
+    plugin: goodreads_csv
     path: "inputs/goodreads_library_export.csv"
     enabled: true
 
@@ -131,6 +132,14 @@ enrichment providers, conversation tuning). Scorer weights are explained in
 the most recent import; `source_priority` uses the highest-priority source;
 `keep_existing` only fills missing fields. Metadata (genres, tags) is always
 merged additively.
+
+### Upgrading
+
+The Goodreads CSV plugin was renamed from `goodreads` to `goodreads_csv`.
+Existing Goodreads items and any DB-stored source configs are relabeled from
+`goodreads` to `goodreads_csv` automatically on first startup, so no action is
+needed there. If you configure Goodreads via `config.yaml`, rename
+`plugin: goodreads` to `plugin: goodreads_csv`.
 
 ## CLI usage
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -49,7 +49,7 @@ ingestion:
   conflict_strategy: "last_write_wins"
   # Source priority ordering (highest priority first).
   # Only used with source_priority strategy.
-  source_priority: ["goodreads", "steam"]
+  source_priority: ["goodreads_csv", "goodreads_rss", "steam"]
 
 # Input sources configuration
 # Each entry is a user-defined name with a 'plugin' field specifying the plugin type.
@@ -67,11 +67,24 @@ ingestion:
 # write to the source_configs / credentials tables. See the "Source
 # configuration precedence" section in ARCHITECTURE.md.
 inputs:
-  goodreads:
-    plugin: goodreads
+  goodreads_csv:
+    plugin: goodreads_csv
     path: "inputs/goodreads_library_export.csv"
     content_type: "book"  # Content type for enrichment (book, movie, tv_show, video_game)
     enabled: true
+
+  # Goodreads — sync PUBLIC shelves directly via RSS (no CSV export needed).
+  # Requires the profile to be public. Paste your numeric user ID or the
+  # profile URL (e.g. https://www.goodreads.com/user/show/12345-name).
+  goodreads_rss:
+    plugin: goodreads_rss
+    user_id: ""  # Goodreads numeric user ID or public profile URL
+    shelves:
+      - "read"
+      - "currently-reading"
+      - "to-read"
+    content_type: "book"
+    enabled: false
 
   # The StoryGraph — CSV export from your library (no API; pure file import).
   # Generate the file at Manage Account -> Manage Your Data ->

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -11,7 +11,7 @@ commands accept `--format json` for scripting.
 
 ```bash
 # Import data
-python3.11 -m src.cli update --source goodreads
+python3.11 -m src.cli update --source goodreads_csv
 python3.11 -m src.cli update --source steam
 python3.11 -m src.cli update --source all
 
@@ -91,18 +91,18 @@ can live in YAML (bootstrap), in the database (created or migrated), or both.
 ```bash
 # Create a brand-new source directly in the database (no YAML edit needed)
 python3.11 -m src.cli source plugins             # see what plugins are available
-python3.11 -m src.cli source create my_books goodreads
+python3.11 -m src.cli source create my_books goodreads_csv
 python3.11 -m src.cli source set-secret my_books api_key   # add credentials
 
 # Move an existing YAML source into the database (one-time, idempotent)
-python3.11 -m src.cli source migrate goodreads
+python3.11 -m src.cli source migrate goodreads_csv
 
 # Inspect / edit fields after migration or creation
-python3.11 -m src.cli source show goodreads
-python3.11 -m src.cli source schema goodreads           # list editable fields
-python3.11 -m src.cli source set goodreads path inputs/new_export.csv
-python3.11 -m src.cli source disable goodreads          # disabled sources are skipped during sync
-python3.11 -m src.cli source enable goodreads
+python3.11 -m src.cli source show goodreads_csv
+python3.11 -m src.cli source schema goodreads_csv           # list editable fields
+python3.11 -m src.cli source set goodreads_csv path inputs/new_export.csv
+python3.11 -m src.cli source disable goodreads_csv          # disabled sources are skipped during sync
+python3.11 -m src.cli source enable goodreads_csv
 
 # Remove a DB-backed source entirely (clears stored secrets too)
 python3.11 -m src.cli source remove my_books

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -9,7 +9,8 @@ sources in the UI/CLI, parallel sync, and library export.
 
 | Source | Type | Setup guide |
 |--------|------|-------------|
-| **Goodreads** | Books | [goodreads](../src/ingestion/sources/goodreads/README.md) — CSV export from your Goodreads library |
+| **Goodreads** | Books | [goodreads_csv](../src/ingestion/sources/goodreads_csv/README.md) — CSV export from your Goodreads library |
+| **Goodreads (RSS)** | Books | [goodreads_rss](../src/ingestion/sources/goodreads_rss/README.md) — sync public shelves via RSS (user ID or profile URL; no CSV export) |
 | **The StoryGraph** | Books | [storygraph_csv](../src/ingestion/sources/storygraph_csv/README.md) — CSV export from your StoryGraph library |
 | **Steam** | Games | [steam](../src/ingestion/sources/steam/README.md) — automatic import via Steam Web API |
 | **GOG** | Games | [gog](../src/ingestion/sources/gog/README.md) — OAuth; imports library and wishlist |

--- a/docs/DEVELOPMENT_PATTERNS.md
+++ b/docs/DEVELOPMENT_PATTERNS.md
@@ -47,7 +47,7 @@ This ensures every plan step is tracked, has clear acceptance criteria, and noth
 ## Adding New Data Sources
 
 1. Create parser in `src/ingestion/sources/`
-2. Follow existing patterns (goodreads.py, steam.py)
+2. Follow existing patterns (goodreads_csv.py, steam.py)
 3. Yield `ContentItem` objects
 4. Add comprehensive tests with mocked APIs
 5. Update CLI/web to support new source

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -572,7 +572,8 @@ enrichment:
 
 ## Existing Plugins to Reference
 
-- `src/ingestion/sources/goodreads/goodreads.py` - File-based CSV parser
+- `src/ingestion/sources/goodreads_csv/goodreads_csv.py` - File-based CSV parser
+- `src/ingestion/sources/goodreads_rss/goodreads_rss.py` - Simple GET + pagination, no auth
 - `src/ingestion/sources/steam/steam.py` - API-based with rate limiting
 - `src/ingestion/sources/gog/gog.py` - OAuth-based API with token refresh
 - `src/ingestion/sources/epic_games/epic_games.py` - OAuth-based API via Legendary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "click>=8.1.0,<9.0.0",
     "tabulate>=0.9.0,<1.0.0",
     "pandas>=2.0.0,<3.0.0",
+    "defusedxml>=0.7.1,<1.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "requests>=2.31.0,<3.0.0",
     "watchfiles>=0.21.0,<2.0.0",
@@ -38,6 +39,7 @@ dev = [
     "types-click>=7.1.0",
     "types-requests>=2.31.0",
     "types-tabulate>=0.9.0",
+    "types-defusedxml>=0.7.0",
     "python-semantic-release>=9.0.0,<11.0.0",
 ]
 

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -346,7 +346,8 @@ def update(ctx: click.Context, source: str, workers: int | None) -> None:
             click.echo(f"  {source_id:20s} plugin={plugin_name} [{status}]")
         return
 
-    # Migrate any config-file credentials to encrypted DB storage
+    # Migrate any config-file credentials to encrypted DB storage. The source
+    # label and plugin migrations run once in the top-level ``cli`` callback.
     migrate_config_credentials(config, storage)
 
     # Check if embeddings are enabled

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -25,6 +25,10 @@ from src.cli.config import (
     create_storage_manager,
     load_config,
 )
+from src.storage.source_migration import (
+    migrate_source_config_plugins,
+    migrate_source_labels,
+)
 
 
 @click.group()
@@ -61,6 +65,12 @@ def cli(ctx: click.Context, config: Path | None) -> None:
     except Exception as error:
         click.echo(f"Error initializing components: {error}", err=True)
         sys.exit(1)
+
+    # Relabel stored goodreads source values and plugin names after the plugin
+    # rename. Runs for every CLI command so a CLI-only user is migrated even if
+    # they never run ``update`` (the web app runs both on startup/reload).
+    migrate_source_labels(ctx.obj["storage"])
+    migrate_source_config_plugins(ctx.obj["storage"])
 
 
 # Register commands

--- a/src/ingestion/plugin_base.py
+++ b/src/ingestion/plugin_base.py
@@ -118,7 +118,7 @@ class SourcePlugin(ABC):
         """Unique identifier for this plugin.
 
         Used in config as inputs.<name>.* and in CLI as --source <name>.
-        Should be lowercase with underscores (e.g., "goodreads", "steam", "generic_csv").
+        Should be lowercase with underscores (e.g., "goodreads_csv", "steam", "generic_csv").
 
         Returns:
             Plugin identifier string

--- a/src/ingestion/registry.py
+++ b/src/ingestion/registry.py
@@ -33,7 +33,7 @@ class PluginRegistry:
         registry.discover_plugins()
 
         # Get a specific plugin
-        plugin = registry.get_plugin("goodreads")
+        plugin = registry.get_plugin("goodreads_csv")
 
         # Get all enabled plugins based on config
         enabled = registry.get_enabled_plugins(config)
@@ -170,7 +170,7 @@ class PluginRegistry:
 
         Args:
             module: Imported module to scan
-            source: Description of source for logging (e.g., "builtin:goodreads")
+            source: Description of source for logging (e.g., "builtin:goodreads_csv")
         """
         for attr_name in dir(module):
             if attr_name.startswith("_"):

--- a/src/ingestion/sources/goodreads/__init__.py
+++ b/src/ingestion/sources/goodreads/__init__.py
@@ -1,3 +1,0 @@
-"""goodreads plugin package."""
-
-from src.ingestion.sources.goodreads.goodreads import *  # noqa: F401, F403

--- a/src/ingestion/sources/goodreads_csv/README.md
+++ b/src/ingestion/sources/goodreads_csv/README.md
@@ -1,4 +1,4 @@
-# Goodreads
+# Goodreads (CSV Export)
 
 Imports books from a Goodreads CSV export.
 
@@ -12,8 +12,11 @@ Imports books from a Goodreads CSV export.
 
 ```yaml
 inputs:
-  goodreads:
+  goodreads_csv:
+    plugin: goodreads_csv
     path: "/path/to/goodreads_export.csv"
+    content_type: "book"
+    enabled: true
 ```
 
 | Field | Type | Required | Description |
@@ -26,6 +29,6 @@ inputs:
 - Status mapping: `read` → completed, `currently-reading` → currently consuming, anything else → unread.
 
 ## Development
-- Implementation: [`goodreads.py`](goodreads.py)
-- Tests: [`test_goodreads.py`](test_goodreads.py)
-- Plugin class: `GoodreadsPlugin`
+- Implementation: [`goodreads_csv.py`](goodreads_csv.py)
+- Tests: [`test_goodreads_csv.py`](test_goodreads_csv.py)
+- Plugin class: `GoodreadsCsvPlugin`

--- a/src/ingestion/sources/goodreads_csv/__init__.py
+++ b/src/ingestion/sources/goodreads_csv/__init__.py
@@ -1,0 +1,3 @@
+"""goodreads_csv plugin package."""
+
+from src.ingestion.sources.goodreads_csv.goodreads_csv import *  # noqa: F401, F403

--- a/src/ingestion/sources/goodreads_csv/goodreads_csv.py
+++ b/src/ingestion/sources/goodreads_csv/goodreads_csv.py
@@ -1,4 +1,4 @@
-"""Goodreads CSV export plugin."""
+"""The Goodreads CSV export plugin."""
 
 from __future__ import annotations
 
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class GoodreadsPlugin(SourcePlugin):
+class GoodreadsCsvPlugin(SourcePlugin):
     """Plugin for importing books from Goodreads CSV exports.
 
     Goodreads allows exporting your library as a CSV file from:
@@ -34,15 +34,15 @@ class GoodreadsPlugin(SourcePlugin):
 
     @property
     def name(self) -> str:
-        return "goodreads"
+        return "goodreads_csv"
 
     @property
     def display_name(self) -> str:
-        return "Goodreads"
+        return "Goodreads (CSV Export)"
 
     @property
     def description(self) -> str:
-        return "Import books from Goodreads export"
+        return "Import books from a Goodreads library CSV export"
 
     @property
     def content_types(self) -> list[ContentType]:

--- a/src/ingestion/sources/goodreads_csv/test_goodreads_csv.py
+++ b/src/ingestion/sources/goodreads_csv/test_goodreads_csv.py
@@ -1,4 +1,4 @@
-"""Tests for Goodreads plugin."""
+"""Tests for the Goodreads CSV plugin."""
 
 from datetime import date
 from pathlib import Path
@@ -6,44 +6,44 @@ from pathlib import Path
 import pytest
 
 from src.ingestion.plugin_base import SourceError, SourcePlugin
-from src.ingestion.sources.goodreads.goodreads import GoodreadsPlugin
+from src.ingestion.sources.goodreads_csv.goodreads_csv import GoodreadsCsvPlugin
 from src.models.content import ConsumptionStatus, ContentType
 
 
 @pytest.fixture()
-def plugin() -> GoodreadsPlugin:
-    """Create a GoodreadsPlugin instance."""
-    return GoodreadsPlugin()
+def plugin() -> GoodreadsCsvPlugin:
+    """Create a GoodreadsCsvPlugin instance."""
+    return GoodreadsCsvPlugin()
 
 
-class TestGoodreadsPluginProperties:
-    """Tests for GoodreadsPlugin metadata properties."""
+class TestGoodreadsCsvPluginProperties:
+    """Tests for GoodreadsCsvPlugin metadata properties."""
 
-    def test_is_source_plugin(self, plugin: GoodreadsPlugin) -> None:
-        """Test that GoodreadsPlugin is a SourcePlugin subclass."""
+    def test_is_source_plugin(self, plugin: GoodreadsCsvPlugin) -> None:
+        """Test that GoodreadsCsvPlugin is a SourcePlugin subclass."""
         assert isinstance(plugin, SourcePlugin)
 
-    def test_name(self, plugin: GoodreadsPlugin) -> None:
+    def test_name(self, plugin: GoodreadsCsvPlugin) -> None:
         """Test plugin name identifier."""
-        assert plugin.name == "goodreads"
+        assert plugin.name == "goodreads_csv"
 
-    def test_display_name(self, plugin: GoodreadsPlugin) -> None:
+    def test_display_name(self, plugin: GoodreadsCsvPlugin) -> None:
         """Test human-readable display name."""
-        assert plugin.display_name == "Goodreads"
+        assert plugin.display_name == "Goodreads (CSV Export)"
 
-    def test_content_types(self, plugin: GoodreadsPlugin) -> None:
+    def test_content_types(self, plugin: GoodreadsCsvPlugin) -> None:
         """Test that plugin provides books."""
         assert plugin.content_types == [ContentType.BOOK]
 
-    def test_requires_api_key(self, plugin: GoodreadsPlugin) -> None:
+    def test_requires_api_key(self, plugin: GoodreadsCsvPlugin) -> None:
         """Test that plugin does not require an API key."""
         assert plugin.requires_api_key is False
 
-    def test_requires_network(self, plugin: GoodreadsPlugin) -> None:
+    def test_requires_network(self, plugin: GoodreadsCsvPlugin) -> None:
         """Test that plugin does not require network access."""
         assert plugin.requires_network is False
 
-    def test_config_schema(self, plugin: GoodreadsPlugin) -> None:
+    def test_config_schema(self, plugin: GoodreadsCsvPlugin) -> None:
         """Test configuration schema defines csv_path."""
         schema = plugin.get_config_schema()
 
@@ -52,26 +52,26 @@ class TestGoodreadsPluginProperties:
         assert schema[0].field_type is str
         assert schema[0].required is True
 
-    def test_get_source_identifier(self, plugin: GoodreadsPlugin) -> None:
+    def test_get_source_identifier(self, plugin: GoodreadsCsvPlugin) -> None:
         """Test source identifier matches plugin name."""
-        assert plugin.get_source_identifier() == "goodreads"
+        assert plugin.get_source_identifier() == "goodreads_csv"
 
-    def test_get_info(self, plugin: GoodreadsPlugin) -> None:
+    def test_get_info(self, plugin: GoodreadsCsvPlugin) -> None:
         """Test plugin info includes all metadata."""
         info = plugin.get_info()
 
-        assert info.name == "goodreads"
-        assert info.display_name == "Goodreads"
+        assert info.name == "goodreads_csv"
+        assert info.display_name == "Goodreads (CSV Export)"
         assert info.content_types == [ContentType.BOOK]
         assert info.requires_api_key is False
         assert info.requires_network is False
 
 
-class TestGoodreadsPluginValidation:
-    """Tests for GoodreadsPlugin config validation."""
+class TestGoodreadsCsvPluginValidation:
+    """Tests for GoodreadsCsvPlugin config validation."""
 
     def test_validate_valid_config(
-        self, plugin: GoodreadsPlugin, tmp_path: Path
+        self, plugin: GoodreadsCsvPlugin, tmp_path: Path
     ) -> None:
         """Test validation passes with valid CSV path."""
         csv_file = tmp_path / "books.csv"
@@ -81,21 +81,21 @@ class TestGoodreadsPluginValidation:
 
         assert errors == []
 
-    def test_validate_missing_path(self, plugin: GoodreadsPlugin) -> None:
+    def test_validate_missing_path(self, plugin: GoodreadsCsvPlugin) -> None:
         """Test validation fails when path is missing."""
         errors = plugin.validate_config({})
 
         assert len(errors) == 1
         assert "'path' is required" in errors[0]
 
-    def test_validate_empty_path(self, plugin: GoodreadsPlugin) -> None:
+    def test_validate_empty_path(self, plugin: GoodreadsCsvPlugin) -> None:
         """Test validation fails when path is empty."""
         errors = plugin.validate_config({"path": ""})
 
         assert len(errors) == 1
         assert "'path' is required" in errors[0]
 
-    def test_validate_nonexistent_file(self, plugin: GoodreadsPlugin) -> None:
+    def test_validate_nonexistent_file(self, plugin: GoodreadsCsvPlugin) -> None:
         """Test validation fails when CSV file does not exist."""
         errors = plugin.validate_config({"path": "/nonexistent/books.csv"})
 
@@ -103,10 +103,10 @@ class TestGoodreadsPluginValidation:
         assert "CSV file not found" in errors[0]
 
 
-class TestGoodreadsPluginFetch:
-    """Tests for GoodreadsPlugin.fetch()."""
+class TestGoodreadsCsvPluginFetch:
+    """Tests for GoodreadsCsvPlugin.fetch()."""
 
-    def test_fetch_basic(self, plugin: GoodreadsPlugin, tmp_path: Path) -> None:
+    def test_fetch_basic(self, plugin: GoodreadsCsvPlugin, tmp_path: Path) -> None:
         """Test basic CSV parsing through the plugin interface."""
         csv_content = """Book Id,Title,Author,My Rating,Exclusive Shelf,Date Read,My Review
 123,Test Book,Test Author,4,read,2025/01/15,Great book!
@@ -127,7 +127,7 @@ class TestGoodreadsPluginFetch:
         assert items[0].date_completed == date(2025, 1, 15)
         assert items[0].review == "Great book!"
         assert items[0].content_type == ContentType.BOOK
-        assert items[0].source == "goodreads"
+        assert items[0].source == "goodreads_csv"
 
         # Second item (unread)
         assert items[1].title == "Another Book"
@@ -138,7 +138,7 @@ class TestGoodreadsPluginFetch:
         assert items[1].review is None
 
     def test_fetch_currently_reading(
-        self, plugin: GoodreadsPlugin, tmp_path: Path
+        self, plugin: GoodreadsCsvPlugin, tmp_path: Path
     ) -> None:
         """Test parsing of currently-reading status."""
         csv_content = """Book Id,Title,Author,My Rating,Exclusive Shelf,Date Read
@@ -153,7 +153,7 @@ class TestGoodreadsPluginFetch:
         assert items[0].status == ConsumptionStatus.CURRENTLY_CONSUMING
 
     def test_fetch_empty_title_skipped(
-        self, plugin: GoodreadsPlugin, tmp_path: Path
+        self, plugin: GoodreadsCsvPlugin, tmp_path: Path
     ) -> None:
         """Test that rows with empty titles are skipped."""
         csv_content = """Book Id,Title,Author,My Rating,Exclusive Shelf
@@ -169,7 +169,7 @@ class TestGoodreadsPluginFetch:
         assert items[0].title == "Valid Book"
 
     def test_fetch_sets_source_identifier(
-        self, plugin: GoodreadsPlugin, tmp_path: Path
+        self, plugin: GoodreadsCsvPlugin, tmp_path: Path
     ) -> None:
         """Test that fetched items have the correct source identifier."""
         csv_content = """Book Id,Title,Author,My Rating,Exclusive Shelf
@@ -183,15 +183,15 @@ class TestGoodreadsPluginFetch:
         assert items[0].source == plugin.get_source_identifier()
 
     def test_fetch_file_not_found_raises_source_error(
-        self, plugin: GoodreadsPlugin
+        self, plugin: GoodreadsCsvPlugin
     ) -> None:
         """Test that fetching a nonexistent file raises SourceError."""
         with pytest.raises(SourceError, match="CSV file not found") as exc_info:
             list(plugin.fetch({"path": "/nonexistent/books.csv"}))
 
-        assert exc_info.value.plugin_name == "goodreads"
+        assert exc_info.value.plugin_name == "goodreads_csv"
 
-    def test_fetch_metadata(self, plugin: GoodreadsPlugin, tmp_path: Path) -> None:
+    def test_fetch_metadata(self, plugin: GoodreadsCsvPlugin, tmp_path: Path) -> None:
         """Test that metadata fields are populated correctly."""
         csv_content = (
             "Book Id,Title,Author,My Rating,Exclusive Shelf,"
@@ -211,7 +211,7 @@ class TestGoodreadsPluginFetch:
         assert items[0].metadata["publisher"] == "Test Publisher"
 
     def test_fetch_invalid_rating(
-        self, plugin: GoodreadsPlugin, tmp_path: Path
+        self, plugin: GoodreadsCsvPlugin, tmp_path: Path
     ) -> None:
         """Test that invalid ratings are treated as None."""
         csv_content = """Book Id,Title,Author,My Rating,Exclusive Shelf
@@ -224,7 +224,9 @@ class TestGoodreadsPluginFetch:
 
         assert items[0].rating is None
 
-    def test_fetch_invalid_date(self, plugin: GoodreadsPlugin, tmp_path: Path) -> None:
+    def test_fetch_invalid_date(
+        self, plugin: GoodreadsCsvPlugin, tmp_path: Path
+    ) -> None:
         """Test that invalid dates are treated as None."""
         csv_content = """Book Id,Title,Author,My Rating,Exclusive Shelf,Date Read
 123,Test Book,Test Author,4,read,not-a-date

--- a/src/ingestion/sources/goodreads_rss/README.md
+++ b/src/ingestion/sources/goodreads_rss/README.md
@@ -1,0 +1,64 @@
+# Goodreads (Public Shelves via RSS)
+
+Syncs books from a **public** Goodreads profile via the per-shelf RSS feeds.
+No CSV export is required — the plugin reads your shelves directly over the
+network.
+
+## Content type
+- `book`
+
+## Requirements
+- A **public** Goodreads profile. If your profile is private, Goodreads returns
+  an empty feed and nothing is imported.
+- Your Goodreads numeric user ID (see below). No API key or login is needed.
+
+## Configuration
+
+```yaml
+inputs:
+  goodreads_rss:
+    plugin: goodreads_rss
+    user_id: "12345"          # numeric ID or full profile URL
+    shelves:
+      - "read"
+      - "currently-reading"
+      - "to-read"
+    content_type: "book"
+    enabled: false
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `user_id` | str | yes | Goodreads numeric user ID or public profile URL. |
+| `shelves` | list | no | Shelves to sync (default: `read`, `currently-reading`, `to-read`). |
+
+## Finding your user ID
+Open your Goodreads profile in a browser. The URL looks like
+`https://www.goodreads.com/user/show/12345-your-name` — the number (`12345`) is
+your user ID. You can paste either the bare number or the whole URL into
+`user_id`; a `https://www.goodreads.com/review/list/12345` URL works too.
+
+## Notes
+- Reads `title`, `author_name`, `isbn`, `book_id`, `num_pages` (also the nested
+  `<book><num_pages>`), `user_rating`, `average_rating`, `book_published`,
+  `user_read_at`, and `book_description`. Missing or empty fields are tolerated.
+- Metadata keys: `book_id`, `isbn`, `pages`, and `year_published` are shared
+  with the [goodreads_csv](../goodreads_csv/README.md) plugin; this plugin also
+  carries `average_rating`, `description`, and `shelf` (the shelf the item was
+  found on). `isbn13` and `publisher` are **not** provided — Goodreads RSS does
+  not expose them, so those keys are absent rather than empty.
+- Status mapping: `read` → completed, `currently-reading` → currently consuming,
+  `to-read` and any custom shelf → unread.
+- Rating: `user_rating` of `0` means unrated (stored as no rating); `1`–`5` are
+  kept as-is.
+- Deduplication: the three default shelves are mutually exclusive, but custom
+  shelves can overlap them. A book appearing on more than one requested shelf is
+  imported once with the strongest status
+  (completed > currently consuming > unread).
+- Each shelf feed is paginated (`per_page=100`); the plugin walks every page
+  until one comes back empty, so large shelves import in full.
+
+## Development
+- Implementation: [`goodreads_rss.py`](goodreads_rss.py)
+- Tests: [`test_goodreads_rss.py`](test_goodreads_rss.py)
+- Plugin class: `GoodreadsRssPlugin`

--- a/src/ingestion/sources/goodreads_rss/__init__.py
+++ b/src/ingestion/sources/goodreads_rss/__init__.py
@@ -1,0 +1,3 @@
+"""goodreads_rss plugin package."""
+
+from src.ingestion.sources.goodreads_rss.goodreads_rss import *  # noqa: F401, F403

--- a/src/ingestion/sources/goodreads_rss/goodreads_rss.py
+++ b/src/ingestion/sources/goodreads_rss/goodreads_rss.py
@@ -1,0 +1,429 @@
+"""Goodreads public-shelf sync via RSS.
+
+Goodreads exposes every *public* profile's shelves as RSS feeds at
+``https://www.goodreads.com/review/list/<user_id>.rss?shelf=<shelf>``. This
+plugin fetches one feed per requested shelf, paginates through all results,
+and maps each ``<item>`` to a :class:`ContentItem`. The ``metadata`` dict
+shares ``book_id``/``isbn``/``pages``/``year_published`` with the sibling
+:mod:`goodreads_csv` plugin and additionally carries ``average_rating``,
+``description``, and ``shelf``. RSS cannot supply ``isbn13`` or ``publisher``,
+so those keys are absent.
+
+Unlike the CSV plugin there is no manual export step — the profile just has to
+be public. The three default shelves (``read``, ``currently-reading``,
+``to-read``) are mutually exclusive, but users may add custom shelves that
+overlap them, so :meth:`GoodreadsRssPlugin.fetch` deduplicates within a single
+run and keeps the strongest consumption status
+(``completed`` > ``currently_consuming`` > ``unread``).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterator
+from datetime import date
+from email.utils import parsedate_to_datetime
+from typing import TYPE_CHECKING, Any
+from xml.etree.ElementTree import Element
+
+import defusedxml.ElementTree as ET
+import requests
+from defusedxml.common import DefusedXmlException
+
+from src.ingestion.plugin_base import (
+    ConfigField,
+    ProgressCallback,
+    SourceError,
+    SourcePlugin,
+)
+from src.models.content import ConsumptionStatus, ContentItem, ContentType
+from src.utils.request_errors import scrub_request_error
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
+
+logger = logging.getLogger(__name__)
+
+# Base host for Goodreads RSS feeds.
+GOODREADS_BASE = "https://www.goodreads.com"
+
+# Shelves synced when the user does not override the ``shelves`` config field.
+DEFAULT_SHELVES = ["read", "currently-reading", "to-read"]
+
+# Goodreads paginates RSS feeds; request the max page size and walk pages
+# until one comes back empty.
+PER_PAGE = 100
+
+# Hard ceiling on pages walked per shelf. At PER_PAGE=100 this covers 50,000
+# books on a single shelf; hitting it means a broken feed or a redirect loop,
+# so we fail loudly instead of paginating forever.
+MAX_PAGES = 500
+
+# Per-request timeout in seconds.
+REQUEST_TIMEOUT = 30
+
+# Consumption-status precedence for cross-shelf deduplication. A book that
+# appears on several requested shelves is yielded once with the strongest
+# status.
+_STATUS_RANK = {
+    ConsumptionStatus.UNREAD.value: 0,
+    ConsumptionStatus.CURRENTLY_CONSUMING.value: 1,
+    ConsumptionStatus.COMPLETED.value: 2,
+}
+
+
+class GoodreadsRssError(SourceError):
+    """Exception raised when the Goodreads RSS source fails.
+
+    Subclasses :class:`SourceError` so the ingestion pipeline handles it like
+    any other source failure. Messages are scrubbed of the request URL to
+    avoid leaking the user's profile identifier into logs.
+    """
+
+
+def parse_goodreads_user_id(raw: str) -> str:
+    """Extract the numeric Goodreads user ID from a raw config value.
+
+    Accepts either a bare numeric ID (returned unchanged) or a Goodreads
+    profile / review-list URL, from which the first digit run after
+    ``/user/show/`` or ``/review/list/`` is extracted.
+
+    Args:
+        raw: A numeric ID or a Goodreads URL.
+
+    Returns:
+        The numeric user ID as a string.
+
+    Raises:
+        ValueError: If no numeric user ID can be extracted.
+    """
+    text = raw.strip()
+    if not text:
+        raise ValueError("Goodreads 'user_id' is empty")
+    if text.isdigit():
+        return text
+    for marker in ("/user/show/", "/review/list/"):
+        index = text.find(marker)
+        if index == -1:
+            continue
+        match = re.match(r"\d+", text[index + len(marker) :])
+        if match:
+            return match.group(0)
+    raise ValueError(f"Could not extract a Goodreads user ID from: {raw!r}")
+
+
+def _coerce_string_list(value: Any, field_name: str) -> tuple[list[str], str | None]:
+    """Coerce a YAML value into a list of strings.
+
+    Returns ``(values, error)``. Error is non-None when *value* is not a list
+    of strings.
+    """
+    if isinstance(value, str):
+        return [], f"'{field_name}' must be a list, got string"
+    if not isinstance(value, list):
+        return [], f"'{field_name}' must be a list"
+    coerced: list[str] = []
+    for entry in value:
+        if not isinstance(entry, str):
+            return [], f"'{field_name}' entries must be strings"
+        coerced.append(entry)
+    return coerced, None
+
+
+def _status_for_shelf(shelf: str) -> ConsumptionStatus:
+    """Map a Goodreads shelf name to a consumption status.
+
+    ``read`` -> completed, ``currently-reading`` -> currently consuming;
+    ``to-read`` and any custom shelf -> unread.
+    """
+    if shelf == "read":
+        return ConsumptionStatus.COMPLETED
+    if shelf == "currently-reading":
+        return ConsumptionStatus.CURRENTLY_CONSUMING
+    return ConsumptionStatus.UNREAD
+
+
+def _child_text(item: Element, tag: str) -> str:
+    """Return the stripped text of a direct child element, or ``""``."""
+    text = item.findtext(tag)
+    return text.strip() if text else ""
+
+
+def _pages(item: Element) -> str | None:
+    """Extract page count from ``<num_pages>`` or nested ``<book><num_pages>``."""
+    top = _child_text(item, "num_pages")
+    if top:
+        return top
+    book = item.find("book")
+    if book is not None:
+        nested = book.findtext("num_pages")
+        if nested and nested.strip():
+            return nested.strip()
+    return None
+
+
+def _parse_rss_date(raw: str) -> date | None:
+    """Parse an RFC 822 Goodreads timestamp into a ``date`` (``None`` on failure)."""
+    if not raw:
+        return None
+    try:
+        parsed = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    return parsed.date() if parsed is not None else None
+
+
+class GoodreadsRssPlugin(SourcePlugin):
+    """Plugin for syncing public Goodreads shelves via RSS.
+
+    Fetches one RSS feed per requested shelf, paginates through every result,
+    and yields deduplicated :class:`ContentItem` objects. Requires the target
+    profile to be public; no API key is needed.
+    """
+
+    @property
+    def name(self) -> str:
+        return "goodreads_rss"
+
+    @property
+    def display_name(self) -> str:
+        return "Goodreads (Public Shelves via RSS)"
+
+    @property
+    def description(self) -> str:
+        return "Sync books from public Goodreads shelves via RSS"
+
+    @property
+    def content_types(self) -> list[ContentType]:
+        return [ContentType.BOOK]
+
+    @property
+    def requires_api_key(self) -> bool:
+        return False
+
+    @property
+    def requires_network(self) -> bool:
+        return True
+
+    def get_config_schema(self) -> list[ConfigField]:
+        return [
+            ConfigField(
+                name="user_id",
+                field_type=str,
+                required=True,
+                description="Goodreads numeric user ID or public profile URL",
+            ),
+            ConfigField(
+                name="shelves",
+                field_type=list,
+                required=False,
+                default=list(DEFAULT_SHELVES),
+                description=(
+                    "Shelves to sync (default: read, currently-reading, "
+                    "to-read). Custom shelf names are treated as unread."
+                ),
+            ),
+        ]
+
+    def validate_config(
+        self,
+        config: dict[str, Any],
+        storage: StorageManager | None = None,
+        user_id: int = 1,
+    ) -> list[str]:
+        errors: list[str] = []
+
+        raw_user_id = config.get("user_id")
+        user_id_str = str(raw_user_id).strip() if raw_user_id is not None else ""
+        if not user_id_str:
+            errors.append(
+                "'user_id' is required (Goodreads numeric user ID or profile URL)"
+            )
+        else:
+            try:
+                parse_goodreads_user_id(user_id_str)
+            except ValueError as error:
+                errors.append(str(error))
+
+        shelves_raw = config.get("shelves")
+        if shelves_raw is not None:
+            shelves, shelves_error = _coerce_string_list(shelves_raw, "shelves")
+            if shelves_error is not None:
+                errors.append(shelves_error)
+            elif any(not shelf.strip() for shelf in shelves):
+                errors.append("'shelves' entries must be non-empty strings")
+
+        return errors
+
+    def fetch(
+        self,
+        config: dict[str, Any],
+        progress_callback: ProgressCallback | None = None,
+    ) -> Iterator[ContentItem]:
+        """Fetch books from a user's public Goodreads shelves.
+
+        Args:
+            config: Must contain 'user_id'; optional 'shelves' list.
+            progress_callback: Optional callback for progress updates.
+
+        Yields:
+            ContentItem for each unique book across the requested shelves.
+
+        Raises:
+            GoodreadsRssError: On network failure or malformed RSS.
+        """
+        raw_user_id = config.get("user_id")
+        user_id_str = str(raw_user_id).strip() if raw_user_id is not None else ""
+        try:
+            user_id = parse_goodreads_user_id(user_id_str)
+        except ValueError as error:
+            raise GoodreadsRssError(self.name, str(error)) from error
+
+        # ``.get(key, default)`` only returns the default when the key is
+        # absent; an explicit ``shelves: null`` yields ``None``, which is not
+        # iterable. Fall back to defaults for both cases while leaving an
+        # explicit empty list intact so ``[]`` still means "sync nothing".
+        shelves = config.get("shelves")
+        if shelves is None:
+            shelves = DEFAULT_SHELVES
+        source = self.get_source_identifier(config)
+
+        # Accumulate before yielding: custom shelves can overlap the defaults,
+        # so a book must be collapsed to its strongest status before emission.
+        items_by_key: dict[str, ContentItem] = {}
+        order: list[str] = []
+
+        for shelf in shelves:
+            status = _status_for_shelf(shelf)
+            for element in self._iter_shelf_items(user_id, shelf):
+                content = self._build_item(element, shelf, status, source)
+                if content is None:
+                    continue
+                key = content.id or f"{content.title}{content.author}"
+                existing = items_by_key.get(key)
+                if existing is None:
+                    items_by_key[key] = content
+                    order.append(key)
+                elif _STATUS_RANK[content.status] > _STATUS_RANK[existing.status]:
+                    items_by_key[key] = content
+
+        total = len(order)
+        logger.info(
+            "Collected %d unique books across %d Goodreads shelves",
+            total,
+            len(shelves),
+        )
+        for index, key in enumerate(order):
+            content = items_by_key[key]
+            if progress_callback:
+                progress_callback(index + 1, total, content.title)
+            yield content
+
+    def _iter_shelf_items(self, user_id: str, shelf: str) -> Iterator[Element]:
+        """Yield every ``<item>`` element on a shelf, walking all RSS pages.
+
+        Terminates on the first empty page. Raises :class:`GoodreadsRssError`
+        if a shelf exceeds :data:`MAX_PAGES`, which signals a broken feed or a
+        redirect loop rather than a genuinely huge shelf.
+        """
+        for page in range(1, MAX_PAGES + 1):
+            xml_text = self._fetch_page(user_id, shelf, page)
+            items = self._parse_items(xml_text, shelf)
+            if not items:
+                return
+            yield from items
+        raise GoodreadsRssError(
+            self.name,
+            f"Shelf '{shelf}' exceeded the {MAX_PAGES}-page fetch limit",
+        )
+
+    def _fetch_page(self, user_id: str, shelf: str, page: int) -> str:
+        """GET a single RSS page for a shelf, returning the response body."""
+        url = f"{GOODREADS_BASE}/review/list/{user_id}.rss"
+        params: dict[str, str | int] = {
+            "shelf": shelf,
+            "per_page": PER_PAGE,
+            "page": page,
+        }
+        try:
+            response = requests.get(url, params=params, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+        except requests.RequestException as error:
+            scrubbed = scrub_request_error(error)
+            logger.error("Error fetching Goodreads shelf '%s': %s", shelf, scrubbed)
+            raise GoodreadsRssError(
+                self.name, f"Failed to fetch shelf '{shelf}': {scrubbed}"
+            ) from error
+        return response.text
+
+    def _parse_items(self, xml_text: str, shelf: str) -> list[Element]:
+        """Parse an RSS page into its ``<item>`` elements.
+
+        Uses ``defusedxml`` rather than the stdlib parser: the feed is
+        untrusted remote XML, and defusedxml blocks both XXE (external entity)
+        attacks and entity-expansion denial-of-service (billion-laughs /
+        quadratic-blowup).
+
+        Both malformed XML (``ParseError``) and hostile entity/DTD payloads
+        (``DefusedXmlException``) surface as :class:`GoodreadsRssError`. The
+        defused-payload message is deliberately generic so the untrusted feed
+        content, request URL, and user id never leak into logs or errors.
+        """
+        try:
+            root = ET.fromstring(xml_text)
+        except ET.ParseError as error:
+            raise GoodreadsRssError(
+                self.name, f"Malformed RSS for shelf '{shelf}': {error}"
+            ) from error
+        except DefusedXmlException as error:
+            raise GoodreadsRssError(
+                self.name, f"Malformed or unsafe RSS for shelf '{shelf}'"
+            ) from error
+        return root.findall(".//item")
+
+    def _build_item(
+        self,
+        element: Element,
+        shelf: str,
+        status: ConsumptionStatus,
+        source: str,
+    ) -> ContentItem | None:
+        """Build a ContentItem from an RSS ``<item>`` element.
+
+        Returns ``None`` for items without a title. The ``metadata`` dict shares
+        ``book_id``/``isbn``/``pages``/``year_published`` with the goodreads_csv
+        plugin and additionally carries ``average_rating``, ``description``, and
+        ``shelf``. RSS cannot supply ``isbn13`` or ``publisher``, so those keys
+        are omitted entirely rather than set to ``None``.
+        """
+        title = _child_text(element, "title")
+        if not title:
+            return None
+
+        book_id = _child_text(element, "book_id") or None
+        date_completed = None
+        if status == ConsumptionStatus.COMPLETED:
+            date_completed = _parse_rss_date(_child_text(element, "user_read_at"))
+
+        metadata: dict[str, Any] = {
+            "book_id": book_id or "",
+            "isbn": _child_text(element, "isbn") or None,
+            "pages": _pages(element),
+            "year_published": _child_text(element, "book_published") or None,
+            "average_rating": _child_text(element, "average_rating") or None,
+            "description": _child_text(element, "book_description") or None,
+            "shelf": shelf,
+        }
+
+        return ContentItem(
+            id=book_id,
+            title=title,
+            author=_child_text(element, "author_name") or None,
+            content_type=ContentType.BOOK,
+            rating=self.normalize_rating(_child_text(element, "user_rating") or None),
+            status=status,
+            date_completed=date_completed,
+            metadata=metadata,
+            source=source,
+        )

--- a/src/ingestion/sources/goodreads_rss/test_goodreads_rss.py
+++ b/src/ingestion/sources/goodreads_rss/test_goodreads_rss.py
@@ -1,0 +1,1091 @@
+"""Tests for the Goodreads RSS plugin."""
+
+from __future__ import annotations
+
+import math
+from datetime import date
+from typing import Any
+
+import pytest
+import requests
+
+from src.ingestion.plugin_base import SourceError, SourcePlugin
+from src.ingestion.sources.goodreads_rss import goodreads_rss
+from src.ingestion.sources.goodreads_rss.goodreads_rss import (
+    GoodreadsRssError,
+    GoodreadsRssPlugin,
+    parse_goodreads_user_id,
+)
+from src.models.content import ConsumptionStatus, ContentType
+
+
+@pytest.fixture()
+def plugin() -> GoodreadsRssPlugin:
+    """Create a GoodreadsRssPlugin instance."""
+    return GoodreadsRssPlugin()
+
+
+def _item(
+    *,
+    title: str,
+    author: str = "",
+    isbn: str = "",
+    book_id: str = "",
+    num_pages: str = "",
+    nested_pages: str = "",
+    user_rating: str = "0",
+    average_rating: str = "",
+    book_published: str = "",
+    user_read_at: str = "",
+    book_description: str = "",
+) -> str:
+    """Render a single Goodreads-style ``<item>`` element."""
+    book_el = (
+        f'<book id="{book_id}"><num_pages>{nested_pages}</num_pages></book>'
+        if nested_pages
+        else ""
+    )
+    return f"""<item>
+      <title>{title}</title>
+      <author_name>{author}</author_name>
+      <isbn>{isbn}</isbn>
+      <book_id>{book_id}</book_id>
+      <num_pages>{num_pages}</num_pages>
+      <user_rating>{user_rating}</user_rating>
+      <average_rating>{average_rating}</average_rating>
+      <book_published>{book_published}</book_published>
+      <user_read_at>{user_read_at}</user_read_at>
+      <book_description>{book_description}</book_description>
+      {book_el}
+    </item>"""
+
+
+def _feed(items_xml: str) -> str:
+    """Wrap item XML in a minimal RSS envelope."""
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<rss version="2.0"><channel><title>shelf</title>{items_xml}'
+        "</channel></rss>"
+    )
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``requests.Response`` used by the fake ``get``."""
+
+    def __init__(self, text: str, status_code: int = 200) -> None:
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            response = requests.Response()
+            response.status_code = self.status_code
+            error = requests.HTTPError(f"{self.status_code} Server Error")
+            error.response = response
+            raise error
+
+
+def _make_get(pages_by_shelf: dict[str, list[str]]) -> Any:
+    """Build a fake ``requests.get`` that serves canned pages per shelf.
+
+    Any page beyond the supplied list returns an empty feed, which terminates
+    the plugin's pagination loop.
+    """
+
+    def _get(url: str, params: dict[str, Any] | None = None, timeout: int = 0) -> Any:
+        assert params is not None
+        shelf = params["shelf"]
+        page = params["page"]
+        pages = pages_by_shelf.get(shelf, [])
+        if 1 <= page <= len(pages):
+            return _FakeResponse(pages[page - 1])
+        return _FakeResponse(_feed(""))
+
+    return _get
+
+
+def _make_paginating_get(shelf: str, count: int) -> tuple[Any, list[dict[str, Any]]]:
+    """Build a fake ``requests.get`` that paginates ``count`` books server-side.
+
+    Unlike :func:`_make_get`, this fake honours the ``per_page`` and ``page``
+    query params the plugin sends, slicing a flat list of ``count`` synthetic
+    books exactly as Goodreads would. It exercises the real pagination loop:
+    the plugin must walk every page and stop only when a page comes back empty
+    (there is no "short page means last page" shortcut, so an exact multiple of
+    ``per_page`` must still terminate on the trailing empty page).
+
+    Returns the fake ``get`` and a list capturing each request's params, so
+    callers can assert how many pages were fetched.
+    """
+    all_items = [
+        _item(title=f"Book {index}", book_id=str(index)) for index in range(count)
+    ]
+    calls: list[dict[str, Any]] = []
+
+    def _get(url: str, params: dict[str, Any] | None = None, timeout: int = 0) -> Any:
+        assert params is not None
+        assert params["shelf"] == shelf
+        calls.append(dict(params))
+        per_page = int(params["per_page"])
+        page = int(params["page"])
+        start = (page - 1) * per_page
+        chunk = all_items[start : start + per_page]
+        return _FakeResponse(_feed("".join(chunk)))
+
+    return _get, calls
+
+
+class TestParseGoodreadsUserId:
+    """Tests for the pure ``parse_goodreads_user_id`` helper."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("12345", "12345"),
+            ("https://www.goodreads.com/user/show/12345-jane-doe", "12345"),
+            ("https://www.goodreads.com/review/list/12345", "12345"),
+            ("https://www.goodreads.com/review/list/12345?shelf=read&page=2", "12345"),
+            (
+                "https://www.goodreads.com/user/show/12345-jane-doe?shelf=read",
+                "12345",
+            ),
+            ("http://www.goodreads.com/user/show/12345-jane-doe/", "12345"),
+            ("  67890  ", "67890"),
+        ],
+    )
+    def test_extracts_id(self, raw: str, expected: str) -> None:
+        """Test numeric IDs and profile URLs resolve to the numeric ID."""
+        assert parse_goodreads_user_id(raw) == expected
+
+    @pytest.mark.parametrize(
+        ("raw", "message"),
+        [
+            ("", "empty"),
+            ("not-a-url", "Could not extract"),
+            ("https://www.goodreads.com/book/show/999-some-book", "Could not extract"),
+            # A recognised marker with no digit run after it must still raise,
+            # exercising the ``if match:`` false branch inside the loop.
+            ("https://www.goodreads.com/user/show/jane-doe", "Could not extract"),
+            ("https://www.goodreads.com/review/list/no-digits", "Could not extract"),
+        ],
+    )
+    def test_invalid_raises(self, raw: str, message: str) -> None:
+        """Test that inputs without a user ID raise ValueError with a clear message."""
+        with pytest.raises(ValueError, match=message):
+            parse_goodreads_user_id(raw)
+
+
+class TestGoodreadsRssPluginProperties:
+    """Tests for GoodreadsRssPlugin metadata properties."""
+
+    def test_is_source_plugin(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test that GoodreadsRssPlugin is a SourcePlugin subclass."""
+        assert isinstance(plugin, SourcePlugin)
+
+    def test_name(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test plugin name identifier."""
+        assert plugin.name == "goodreads_rss"
+
+    def test_display_name(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test human-readable display name."""
+        assert plugin.display_name == "Goodreads (Public Shelves via RSS)"
+
+    def test_description(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test the one-line plugin description."""
+        assert plugin.description == "Sync books from public Goodreads shelves via RSS"
+
+    def test_content_types(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test that plugin provides books."""
+        assert plugin.content_types == [ContentType.BOOK]
+
+    def test_requires_api_key(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test that plugin does not require an API key."""
+        assert plugin.requires_api_key is False
+
+    def test_requires_network(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test that plugin requires network access."""
+        assert plugin.requires_network is True
+
+    def test_config_schema(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test configuration schema defines user_id and shelves."""
+        schema = plugin.get_config_schema()
+
+        assert [field.name for field in schema] == ["user_id", "shelves"]
+        assert schema[0].field_type is str
+        assert schema[0].required is True
+        assert schema[1].field_type is list
+        assert schema[1].required is False
+        assert schema[1].default == ["read", "currently-reading", "to-read"]
+
+    def test_get_source_identifier_default(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test source identifier defaults to the plugin name."""
+        assert plugin.get_source_identifier() == "goodreads_rss"
+
+    def test_get_source_identifier_from_config(
+        self, plugin: GoodreadsRssPlugin
+    ) -> None:
+        """Test source identifier uses the injected _source_id when present."""
+        assert plugin.get_source_identifier({"_source_id": "my_books"}) == "my_books"
+
+
+class TestGoodreadsRssPluginValidation:
+    """Tests for GoodreadsRssPlugin config validation."""
+
+    def test_valid_config(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test validation passes for a well-formed config."""
+        errors = plugin.validate_config(
+            {"user_id": "12345", "shelves": ["read", "to-read"]}
+        )
+
+        assert errors == []
+
+    def test_valid_config_without_shelves(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test validation passes when shelves is omitted (defaults apply)."""
+        assert plugin.validate_config({"user_id": "12345"}) == []
+
+    def test_empty_user_id(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test validation fails when user_id is empty."""
+        errors = plugin.validate_config({"user_id": ""})
+
+        assert len(errors) == 1
+        assert "'user_id' is required" in errors[0]
+
+    def test_missing_user_id(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test validation fails when user_id is absent."""
+        errors = plugin.validate_config({})
+
+        assert len(errors) == 1
+        assert "'user_id' is required" in errors[0]
+
+    def test_unparseable_user_id(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test validation fails when user_id is present but has no numeric ID.
+
+        Exercises the ``parse_goodreads_user_id`` ValueError branch inside
+        ``validate_config`` — distinct from the empty/missing-user_id branch.
+        """
+        errors = plugin.validate_config({"user_id": "not-a-url", "shelves": ["read"]})
+
+        assert any("Could not extract" in error for error in errors)
+
+    def test_shelves_not_a_list_string(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test validation fails when shelves is a string, not a list."""
+        errors = plugin.validate_config({"user_id": "12345", "shelves": "read"})
+
+        assert any("must be a list" in error for error in errors)
+
+    def test_shelves_not_a_list_int(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test validation fails when shelves is a non-list, non-string scalar.
+
+        Exercises the ``_coerce_string_list`` ``not isinstance(value, list)``
+        branch, distinct from the string branch above.
+        """
+        errors = plugin.validate_config({"user_id": "12345", "shelves": 5})
+
+        assert any("must be a list" in error for error in errors)
+
+    def test_shelves_entry_not_a_string(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test validation fails when a shelves entry is not a string.
+
+        Exercises the ``_coerce_string_list`` per-entry type check: a list with
+        a non-string element is rejected before the emptiness check runs.
+        """
+        errors = plugin.validate_config({"user_id": "12345", "shelves": ["read", 5]})
+
+        assert any("entries must be strings" in error for error in errors)
+
+    def test_empty_shelf_name(self, plugin: GoodreadsRssPlugin) -> None:
+        """Test validation fails when a shelf name is blank."""
+        errors = plugin.validate_config({"user_id": "12345", "shelves": ["read", "  "]})
+
+        assert any("non-empty" in error for error in errors)
+
+
+class TestGoodreadsRssPluginFetch:
+    """Tests for GoodreadsRssPlugin.fetch()."""
+
+    def test_status_mapping_per_shelf(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test each shelf maps to the expected consumption status."""
+        cases = {
+            "read": ConsumptionStatus.COMPLETED,
+            "currently-reading": ConsumptionStatus.CURRENTLY_CONSUMING,
+            "to-read": ConsumptionStatus.UNREAD,
+            "favorites": ConsumptionStatus.UNREAD,
+        }
+        for shelf, expected in cases.items():
+            fake_get = _make_get({shelf: [_feed(_item(title="A Book", book_id="1"))]})
+            monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+            items = list(plugin.fetch({"user_id": "12345", "shelves": [shelf]}))
+
+            assert len(items) == 1
+            assert items[0].status == expected
+
+    def test_rating_zero_is_unrated(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test user_rating of 0 becomes None."""
+        fake_get = _make_get(
+            {"read": [_feed(_item(title="Book", book_id="1", user_rating="0"))]}
+        )
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert items[0].rating is None
+
+    def test_rating_normalized(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a numeric user_rating is normalized to the 1-5 scale."""
+        fake_get = _make_get(
+            {"read": [_feed(_item(title="Book", book_id="1", user_rating="4"))]}
+        )
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert items[0].rating == 4
+
+    @pytest.mark.parametrize(
+        ("raw_rating", "expected"),
+        [
+            ("0", None),
+            ("1", 1),
+            ("2", 2),
+            ("3", 3),
+            ("4", 4),
+            ("5", 5),
+            ("", None),
+        ],
+    )
+    def test_rating_normalization_over_0_to_5_range(
+        self,
+        plugin: GoodreadsRssPlugin,
+        monkeypatch: pytest.MonkeyPatch,
+        raw_rating: str,
+        expected: int | None,
+    ) -> None:
+        """Test ratings across the valid 0-5 Goodreads range normalize correctly.
+
+        A 0 (or blank) Goodreads rating is treated as unrated (None) and 1-5
+        pass through unchanged. This covers only the in-range values Goodreads
+        emits, not out-of-range handling.
+        """
+        fake_get = _make_get(
+            {"read": [_feed(_item(title="Book", book_id="1", user_rating=raw_rating))]}
+        )
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert items[0].rating == expected
+
+    def test_metadata_extraction(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test metadata keys extracted from an RSS item."""
+        fake_get = _make_get(
+            {
+                "read": [
+                    _feed(
+                        _item(
+                            title="Dune",
+                            author="Frank Herbert",
+                            isbn="0441013597",
+                            book_id="234225",
+                            num_pages="412",
+                            average_rating="4.25",
+                            book_published="1965",
+                            book_description="A desert planet.",
+                        )
+                    )
+                ]
+            }
+        )
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        item = items[0]
+        assert item.title == "Dune"
+        assert item.author == "Frank Herbert"
+        assert item.content_type == ContentType.BOOK
+        assert item.id == "234225"
+        assert item.metadata["book_id"] == "234225"
+        assert item.metadata["isbn"] == "0441013597"
+        assert item.metadata["pages"] == "412"
+        assert item.metadata["year_published"] == "1965"
+        assert item.metadata["average_rating"] == "4.25"
+        assert item.metadata["description"] == "A desert planet."
+        assert item.metadata["shelf"] == "read"
+        # RSS cannot supply these, so the keys are omitted entirely.
+        assert "isbn13" not in item.metadata
+        assert "publisher" not in item.metadata
+
+    def test_pages_from_nested_book_element(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test page count falls back to the nested <book><num_pages>."""
+        fake_get = _make_get(
+            {"read": [_feed(_item(title="Book", book_id="1", nested_pages="320"))]}
+        )
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert items[0].metadata["pages"] == "320"
+
+    def test_date_completed_from_read_shelf(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test date_completed is parsed from user_read_at on the read shelf."""
+        fake_get = _make_get(
+            {
+                "read": [
+                    _feed(
+                        _item(
+                            title="Book",
+                            book_id="1",
+                            user_read_at="Wed, 10 Jan 2018 00:00:00 -0800",
+                        )
+                    )
+                ]
+            }
+        )
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert items[0].date_completed == date(2018, 1, 10)
+
+    def test_malformed_read_date_yields_none(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a non-empty but unparseable user_read_at leaves date_completed None.
+
+        Exercises the ``_parse_rss_date`` except branch: a garbage timestamp
+        must be swallowed into ``None`` rather than raising.
+        """
+        fake_get = _make_get(
+            {
+                "read": [
+                    _feed(_item(title="Book", book_id="1", user_read_at="not-a-date"))
+                ]
+            }
+        )
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert items[0].date_completed is None
+
+    def test_pagination_across_two_full_pages(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test two populated pages are both consumed before termination."""
+        page1 = _feed(
+            "".join(_item(title=f"P1-{n}", book_id=f"1{n}") for n in range(3))
+        )
+        page2 = _feed(
+            "".join(_item(title=f"P2-{n}", book_id=f"2{n}") for n in range(3))
+        )
+        fake_get = _make_get({"read": [page1, page2]})  # page 3 auto-empty
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert len(items) == 6
+
+    @pytest.mark.parametrize("count", [0, 1, 99, 100, 101, 250])
+    def test_pagination_returns_all_items_at_boundaries(
+        self,
+        plugin: GoodreadsRssPlugin,
+        monkeypatch: pytest.MonkeyPatch,
+        count: int,
+    ) -> None:
+        """Test every book is returned across page boundaries of PER_PAGE.
+
+        Covers the classic off-by-one pagination bug: an exact multiple of the
+        page size (100) must still yield all items and terminate on the
+        trailing empty page, and larger counts (250 -> 3 pages) must not drop
+        the tail. A count of 0 must be a clean empty result.
+        """
+        fake_get, calls = _make_paginating_get("read", count)
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert len(items) == count
+        assert {item.title for item in items} == {
+            f"Book {index}" for index in range(count)
+        }
+        # The loop must fetch one page beyond the last populated page to see
+        # the empty terminator: ceil(count / PER_PAGE) + 1 requests (and a bare
+        # 1 request when there are no items at all).
+        expected_pages = math.ceil(count / goodreads_rss.PER_PAGE) + 1
+        assert len(calls) == expected_pages
+        assert [call["page"] for call in calls] == list(range(1, expected_pages + 1))
+
+    def test_fully_sparse_item_yields_sane_content_item(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test an item with only a title (no author/isbn/rating/date) is sane.
+
+        Missing optional fields must produce a ContentItem with ``None`` values
+        rather than empty strings or a crash.
+        """
+        sparse = "<item><title>Lonely Book</title></item>"
+        fake_get = _make_get({"read": [_feed(sparse)]})
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert len(items) == 1
+        item = items[0]
+        assert item.title == "Lonely Book"
+        assert item.author is None
+        assert item.id is None
+        assert item.rating is None
+        assert item.date_completed is None
+        assert item.metadata["isbn"] is None
+        assert item.metadata["pages"] is None
+        assert item.metadata["year_published"] is None
+        assert item.metadata["book_id"] == ""
+
+    def test_custom_shelf_name_passed_through_verbatim(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a hyphenated custom shelf name reaches the request unmodified.
+
+        URL-encoding of the shelf value is delegated to ``requests`` via the
+        ``params`` dict, so the plugin must pass the raw shelf name through.
+        """
+        requested: list[str] = []
+
+        def _get(
+            url: str, params: dict[str, Any] | None = None, timeout: int = 0
+        ) -> Any:
+            assert params is not None
+            requested.append(params["shelf"])
+            # Serve one item on page 1 and an empty terminator afterwards so
+            # the pagination loop stops instead of spinning.
+            if params["page"] == 1:
+                return _FakeResponse(_feed(_item(title="Book", book_id="1")))
+            return _FakeResponse(_feed(""))
+
+        monkeypatch.setattr(goodreads_rss.requests, "get", _get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["sci-fi"]}))
+
+        assert requested[0] == "sci-fi"
+        assert items[0].status == ConsumptionStatus.UNREAD
+
+    def test_dedup_read_plus_custom_shelf_keeps_completed(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a book on 'read' and a custom shelf is emitted once as COMPLETED.
+
+        The custom shelf is requested first (UNREAD) and the read shelf must
+        upgrade the surviving item to COMPLETED, preserving its read date.
+        """
+        favorite = _item(title="Shared", book_id="42")
+        read = _item(
+            title="Shared",
+            book_id="42",
+            user_read_at="Wed, 10 Jan 2018 00:00:00 -0800",
+        )
+        fake_get = _make_get({"favorites": [_feed(favorite)], "read": [_feed(read)]})
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(
+            plugin.fetch({"user_id": "12345", "shelves": ["favorites", "read"]})
+        )
+
+        assert len(items) == 1
+        assert items[0].status == ConsumptionStatus.COMPLETED
+        assert items[0].date_completed == date(2018, 1, 10)
+
+    def test_dedup_across_overlapping_shelves(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test an overlapping book is yielded once with the strongest status."""
+        read_book = _item(
+            title="Shared",
+            book_id="99",
+            user_read_at="Wed, 10 Jan 2018 00:00:00 -0800",
+        )
+        to_read_book = _item(title="Shared", book_id="99")
+        fake_get = _make_get(
+            {
+                "to-read": [_feed(to_read_book)],
+                "read": [_feed(read_book)],
+            }
+        )
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        # to-read is fetched first, then read upgrades the status.
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["to-read", "read"]}))
+
+        assert len(items) == 1
+        assert items[0].status == ConsumptionStatus.COMPLETED
+        assert items[0].date_completed == date(2018, 1, 10)
+
+    def test_dedup_falls_back_to_title_author(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test dedup keys on title+author when book_id is absent."""
+        read_book = _item(title="Untitled", author="Anon")
+        to_read_book = _item(title="Untitled", author="Anon")
+        fake_get = _make_get(
+            {
+                "to-read": [_feed(to_read_book)],
+                "read": [_feed(read_book)],
+            }
+        )
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["to-read", "read"]}))
+
+        assert len(items) == 1
+        assert items[0].status == ConsumptionStatus.COMPLETED
+
+    def test_default_shelves_used_when_omitted(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test fetch queries the three default shelves when none are given."""
+        requested: list[str] = []
+
+        def _get(
+            url: str, params: dict[str, Any] | None = None, timeout: int = 0
+        ) -> Any:
+            assert params is not None
+            requested.append(params["shelf"])
+            return _FakeResponse(_feed(""))
+
+        monkeypatch.setattr(goodreads_rss.requests, "get", _get)
+
+        list(plugin.fetch({"user_id": "12345"}))
+
+        assert requested == ["read", "currently-reading", "to-read"]
+
+    def test_explicit_empty_shelves_fetches_nothing(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test an explicit empty ``shelves`` list fetches nothing and no HTTP.
+
+        Distinct from omitting ``shelves`` (which applies the three defaults):
+        an explicit ``[]`` means "sync no shelves", so no request is made.
+        """
+
+        def _fail_get(
+            url: str, params: dict[str, Any] | None = None, timeout: int = 0
+        ) -> Any:
+            raise AssertionError("no request should be made for empty shelves")
+
+        monkeypatch.setattr(goodreads_rss.requests, "get", _fail_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": []}))
+
+        assert items == []
+
+    def test_duplicate_shelf_names_collapse_to_one(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a shelf listed twice yields each book once (dedup collapses it)."""
+        fake_get = _make_get({"read": [_feed(_item(title="Book", book_id="1"))]})
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read", "read"]}))
+
+        assert len(items) == 1
+
+    def test_progress_callback_invoked_in_order(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test progress_callback fires once per emitted item with (i, total, title)."""
+        page = _feed(
+            _item(title="One", book_id="1")
+            + _item(title="Two", book_id="2")
+            + _item(title="Three", book_id="3")
+        )
+        fake_get = _make_get({"read": [page]})
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        calls: list[tuple[int, int | None, str | None]] = []
+
+        def _callback(index: int, total: int | None, title: str | None) -> None:
+            calls.append((index, total, title))
+
+        list(
+            plugin.fetch(
+                {"user_id": "12345", "shelves": ["read"]},
+                progress_callback=_callback,
+            )
+        )
+
+        assert calls == [(1, 3, "One"), (2, 3, "Two"), (3, 3, "Three")]
+
+    def test_unicode_and_entities_round_trip(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test XML entities and accented characters decode into a clean item.
+
+        A ``&amp;`` entity in the title and an accented author name must survive
+        parsing and emerge as their decoded Unicode forms.
+        """
+        fake_get = _make_get(
+            {
+                "read": [
+                    _feed(
+                        _item(
+                            title="Cakes &amp; Ale",
+                            author="Émile Zola",
+                            book_id="1",
+                        )
+                    )
+                ]
+            }
+        )
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert items[0].title == "Cakes & Ale"
+        assert items[0].author == "Émile Zola"
+
+    def test_sets_source_identifier(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test fetched items carry the configured source identifier."""
+        fake_get = _make_get({"read": [_feed(_item(title="Book", book_id="1"))]})
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(
+            plugin.fetch(
+                {"user_id": "12345", "shelves": ["read"], "_source_id": "my_books"}
+            )
+        )
+
+        assert items[0].source == "my_books"
+
+    def test_untitled_items_skipped(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test items with an empty title are skipped."""
+        fake_get = _make_get(
+            {
+                "read": [
+                    _feed(
+                        _item(title="", book_id="1") + _item(title="Real", book_id="2")
+                    )
+                ]
+            }
+        )
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert [item.title for item in items] == ["Real"]
+
+    def test_empty_shelf_is_clean_no_op(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a shelf with no items yields nothing and raises nothing."""
+        fake_get = _make_get({"read": [_feed("")]})
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        items = list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        assert items == []
+
+
+class TestGoodreadsRssRegression:
+    """Regression tests for the Goodreads RSS plugin.
+
+    SYMPTOM: a ``shelves: null`` (or a bare ``shelves:``) entry in the YAML
+    config crashed ``fetch()`` with ``TypeError: 'NoneType' object is not
+    iterable``.
+
+    ROOT CAUSE: ``config.get("shelves", DEFAULT_SHELVES)`` only substitutes the
+    default when the key is ABSENT; a present-but-null key returns ``None``, and
+    ``validate_config`` treated null as valid, so validation passed and ``fetch``
+    then tried to iterate ``None``.
+
+    FIX: ``fetch()`` resolves ``config.get("shelves")`` and falls back to
+    ``DEFAULT_SHELVES`` only when the result is ``None``, while an explicit empty
+    list still syncs nothing.
+    """
+
+    def test_explicit_null_shelves_uses_defaults(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test an explicit ``shelves: null`` falls back to the three defaults.
+
+        A YAML ``shelves:`` with no value yields ``None`` (key present), which
+        ``config.get("shelves", DEFAULT_SHELVES)`` would NOT default. fetch must
+        treat it like an omitted key rather than raising ``TypeError`` on a
+        non-iterable ``None``.
+        """
+        requested: list[str] = []
+
+        def _get(
+            url: str, params: dict[str, Any] | None = None, timeout: int = 0
+        ) -> Any:
+            assert params is not None
+            requested.append(params["shelf"])
+            return _FakeResponse(_feed(""))
+
+        monkeypatch.setattr(goodreads_rss.requests, "get", _get)
+
+        list(plugin.fetch({"user_id": "12345", "shelves": None}))
+
+        assert requested == ["read", "currently-reading", "to-read"]
+
+
+class TestGoodreadsRssPluginErrors:
+    """Tests for GoodreadsRssPlugin error handling."""
+
+    def test_http_error_raises_without_url(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test an HTTP error raises GoodreadsRssError with no URL leaked."""
+
+        def _get(
+            url: str, params: dict[str, Any] | None = None, timeout: int = 0
+        ) -> Any:
+            return _FakeResponse("", status_code=500)
+
+        monkeypatch.setattr(goodreads_rss.requests, "get", _get)
+
+        with pytest.raises(GoodreadsRssError) as exc_info:
+            list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        message = str(exc_info.value)
+        assert "HTTP 500" in message
+        assert "goodreads.com" not in message
+        assert "12345" not in message
+        assert isinstance(exc_info.value, SourceError)
+
+    def test_not_found_profile_raises_clean_error(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a 404 (private/nonexistent profile) raises a scrubbed error.
+
+        The message must carry the status code but neither the host nor the
+        user id, so a private-profile failure cannot leak the identifier.
+        """
+
+        def _get(
+            url: str, params: dict[str, Any] | None = None, timeout: int = 0
+        ) -> Any:
+            return _FakeResponse("", status_code=404)
+
+        monkeypatch.setattr(goodreads_rss.requests, "get", _get)
+
+        with pytest.raises(GoodreadsRssError) as exc_info:
+            list(plugin.fetch({"user_id": "98765", "shelves": ["read"]}))
+
+        message = str(exc_info.value)
+        assert "HTTP 404" in message
+        assert "goodreads.com" not in message
+        assert "98765" not in message
+
+    def test_connection_error_raises(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a transport error raises GoodreadsRssError."""
+
+        def _get(
+            url: str, params: dict[str, Any] | None = None, timeout: int = 0
+        ) -> Any:
+            raise requests.ConnectionError("connection refused to www.goodreads.com")
+
+        monkeypatch.setattr(goodreads_rss.requests, "get", _get)
+
+        with pytest.raises(GoodreadsRssError) as exc_info:
+            list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        message = str(exc_info.value)
+        assert "ConnectionError" in message
+        assert "goodreads.com" not in message
+
+    def test_malformed_xml_raises(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test malformed RSS raises GoodreadsRssError."""
+
+        def _get(
+            url: str, params: dict[str, Any] | None = None, timeout: int = 0
+        ) -> Any:
+            return _FakeResponse("<rss><channel><item></broken>")
+
+        monkeypatch.setattr(goodreads_rss.requests, "get", _get)
+
+        with pytest.raises(GoodreadsRssError, match="Malformed RSS"):
+            list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+    def test_invalid_user_id_raises(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test an unparseable user_id raises before any network call.
+
+        A fail-loud fake ``requests.get`` proves the parse guard rejects the
+        user_id up front, so the plugin never makes an outbound request for a
+        malformed identifier.
+        """
+
+        def _fail_get(
+            url: str, params: dict[str, Any] | None = None, timeout: int = 0
+        ) -> Any:
+            raise AssertionError("requests.get must not be called for a bad user_id")
+
+        monkeypatch.setattr(goodreads_rss.requests, "get", _fail_get)
+
+        with pytest.raises(GoodreadsRssError, match="Could not extract"):
+            list(plugin.fetch({"user_id": "not-a-url", "shelves": ["read"]}))
+
+    def test_later_shelf_failure_aborts_and_yields_nothing(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test an HTTP error on a later shelf raises and emits no items.
+
+        The first shelf returns a book, but the second shelf 500s. Because
+        fetch accumulates every shelf before yielding, the failure aborts the
+        whole run: the caller sees GoodreadsRssError and no items.
+        """
+
+        def _get(
+            url: str, params: dict[str, Any] | None = None, timeout: int = 0
+        ) -> Any:
+            assert params is not None
+            if params["shelf"] == "read":
+                if params["page"] == 1:
+                    return _FakeResponse(_feed(_item(title="Book", book_id="1")))
+                return _FakeResponse(_feed(""))
+            return _FakeResponse("", status_code=500)
+
+        monkeypatch.setattr(goodreads_rss.requests, "get", _get)
+
+        emitted = []
+        with pytest.raises(GoodreadsRssError):
+            for item in plugin.fetch(
+                {"user_id": "12345", "shelves": ["read", "to-read"]}
+            ):
+                emitted.append(item)
+
+        assert emitted == []
+
+    def test_exceeding_max_pages_raises(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a shelf that never returns an empty page fails at the page ceiling.
+
+        A feed that always yields a fresh item would paginate forever; the
+        MAX_PAGES cap must convert that into a loud GoodreadsRssError.
+        """
+
+        def _get(
+            url: str, params: dict[str, Any] | None = None, timeout: int = 0
+        ) -> Any:
+            assert params is not None
+            page = params["page"]
+            return _FakeResponse(_feed(_item(title=f"B{page}", book_id=str(page))))
+
+        monkeypatch.setattr(goodreads_rss.requests, "get", _get)
+
+        with pytest.raises(GoodreadsRssError, match="page fetch limit"):
+            list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+
+# A billion-laughs / entity-expansion payload. Nine nested internal entities
+# would each expand ten-fold, so &lol9; alone resolves to 10^9 "lol" strings
+# in a naive parser — enough to exhaust memory. defusedxml must reject the
+# entity declarations at parse time before any expansion occurs.
+_BILLION_LAUGHS = (
+    '<?xml version="1.0"?>'
+    "<!DOCTYPE lolz ["
+    '<!ENTITY lol "lol">'
+    '<!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">'
+    '<!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">'
+    '<!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">'
+    '<!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">'
+    '<!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">'
+    '<!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">'
+    '<!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">'
+    '<!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">'
+    '<!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">'
+    "]>"
+    '<rss version="2.0"><channel><item><title>&lol9;</title>'
+    "</channel></rss>"
+)
+
+# An external-entity (XXE) payload attempting to read a local file. defusedxml
+# must refuse to resolve the external reference.
+_XXE_PAYLOAD = (
+    '<?xml version="1.0"?>'
+    '<!DOCTYPE rss [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>'
+    '<rss version="2.0"><channel><item><title>&xxe;</title>'
+    "</channel></rss>"
+)
+
+
+class TestGoodreadsRssPluginSecurity:
+    """Security tests for the defusedxml-based RSS parser.
+
+    The feed is untrusted remote XML, so the parser must reject entity-
+    expansion (billion-laughs) and external-entity (XXE) payloads at parse
+    time rather than expanding them (memory bomb) or resolving external
+    references (local-file disclosure).
+    """
+
+    def test_billion_laughs_is_rejected_without_expansion(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test an entity-expansion bomb is rejected, not expanded.
+
+        Regression guard for the stdlib->defusedxml swap: the parser must
+        raise on the entity declarations before any expansion, so the fetch
+        raises rather than returning a memory-bomb title or hanging. defusedxml
+        raises a DefusedXmlException subclass, which the plugin wraps in a
+        GoodreadsRssError whose message never echoes the hostile payload.
+        """
+        fake_get = _make_get({"read": [_BILLION_LAUGHS]})
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        with pytest.raises(GoodreadsRssError) as exc_info:
+            list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        message = str(exc_info.value)
+        # Positive assertion so a blank/broken message cannot satisfy the test.
+        assert "Malformed or unsafe RSS" in message
+        assert "lol" not in message
+        assert "ENTITY" not in message
+        assert "12345" not in message
+        assert "goodreads.com" not in message
+
+    def test_external_entity_is_rejected(
+        self, plugin: GoodreadsRssPlugin, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test an external-entity (XXE) payload is refused, not resolved.
+
+        A DOCTYPE that declares a SYSTEM entity pointing at a local file must
+        be rejected by defusedxml so the file contents can never leak into a
+        ContentItem title. The plugin wraps the defused exception in a
+        GoodreadsRssError whose message never echoes the payload, URL, or user
+        id.
+        """
+        fake_get = _make_get({"read": [_XXE_PAYLOAD]})
+        monkeypatch.setattr(goodreads_rss.requests, "get", fake_get)
+
+        with pytest.raises(GoodreadsRssError) as exc_info:
+            list(plugin.fetch({"user_id": "12345", "shelves": ["read"]}))
+
+        message = str(exc_info.value)
+        # Positive assertion so a blank/broken message cannot satisfy the test.
+        assert "Malformed or unsafe RSS" in message
+        assert "passwd" not in message
+        assert "SYSTEM" not in message
+        assert "12345" not in message
+        assert "goodreads.com" not in message

--- a/src/models/content.py
+++ b/src/models/content.py
@@ -94,7 +94,7 @@ class ContentItem(BaseModel):
     date_completed: date | None = None
 
     # Source tracking - which plugin/source this came from
-    source: str | None = None  # e.g., "goodreads", "steam", "manual"
+    source: str | None = None  # e.g., "goodreads_csv", "steam", "manual"
 
     # Runtime-only: parent item ID (e.g., TV show ID for a season item).
     # Set during recommendation expansion, not persisted.

--- a/src/storage/schema.py
+++ b/src/storage/schema.py
@@ -181,7 +181,7 @@ def create_schema(conn: sqlite3.Connection) -> None:
             rating INTEGER CHECK (rating >= 1 AND rating <= 5),
             review TEXT,
             date_completed DATE,
-            source TEXT,  -- Which plugin/source this came from (goodreads, steam, etc.)
+            source TEXT,  -- Which plugin/source this came from (goodreads_csv, steam, etc.)
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             UNIQUE(user_id, external_id, content_type)

--- a/src/storage/source_migration.py
+++ b/src/storage/source_migration.py
@@ -1,0 +1,100 @@
+"""Auto-migrate stored source labels and plugin names after a rename."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.storage.manager import StorageManager
+
+logger = logging.getLogger(__name__)
+
+# The default/example ingestion block was renamed from ``goodreads`` to
+# ``goodreads_csv``. The value stored in ``content_items.source`` is the
+# user's config-block KEY, not the plugin name, so this migration matches the
+# literal historical key ``goodreads`` and rewrites only that exact value.
+# Arbitrary user-chosen keys are intentionally left untouched.
+_OLD_SOURCE = "goodreads"
+_NEW_SOURCE = "goodreads_csv"
+
+# The plugin itself was renamed from ``goodreads`` to ``goodreads_csv``. A
+# source config moved into the database stores the PLUGIN NAME in
+# ``source_configs.plugin``; the values coincide with the source labels above
+# but name a different concept, so they get their own constants.
+_OLD_PLUGIN = "goodreads"
+_NEW_PLUGIN = "goodreads_csv"
+
+
+def migrate_source_labels(
+    storage: StorageManager,
+    user_id: int = 1,
+) -> None:
+    """Relabel stored ``goodreads`` source values to ``goodreads_csv``.
+
+    Updates every ``content_items`` row whose ``source`` is the literal
+    historical key ``goodreads`` so it reflects the renamed default ingestion
+    block ``goodreads_csv``. ChromaDB does not store the source, so no
+    vector-store change is needed.
+
+    This is safe to call on every startup: once the rows are relabeled the
+    UPDATE matches nothing and the call is a silent no-op.
+
+    Args:
+        storage: StorageManager instance (provides SQLite access).
+        user_id: User ID whose items are relabeled (default 1), matching the
+            single-user scope of the credential migration.
+    """
+    with storage.connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE content_items SET source = ? WHERE source = ? AND user_id = ?",
+            (_NEW_SOURCE, _OLD_SOURCE, user_id),
+        )
+        updated = cursor.rowcount
+        if updated:
+            conn.commit()
+            logger.info(
+                "Relabeled %d content item(s) from source %r to %r",
+                updated,
+                _OLD_SOURCE,
+                _NEW_SOURCE,
+            )
+
+
+def migrate_source_config_plugins(
+    storage: StorageManager,
+    user_id: int = 1,
+) -> None:
+    """Relabel stored ``goodreads`` plugin values to ``goodreads_csv``.
+
+    Updates every ``source_configs`` row whose ``plugin`` is the historical
+    plugin name ``goodreads`` so a source config a user moved into the database
+    keeps resolving after the plugin rename. Without this, once a
+    ``plugin = 'goodreads'`` row exists ``get_plugin('goodreads')`` returns
+    ``None`` and that source silently stops syncing.
+
+    This is safe to call on every startup: once the rows are relabeled the
+    UPDATE matches nothing and the call is a silent no-op.
+
+    Args:
+        storage: StorageManager instance (provides SQLite access).
+        user_id: User ID whose source configs are relabeled (default 1),
+            matching the single-user scope of ``migrate_source_labels`` and the
+            user-scoped ``source_configs`` table.
+    """
+    with storage.connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE source_configs SET plugin = ? WHERE plugin = ? AND user_id = ?",
+            (_NEW_PLUGIN, _OLD_PLUGIN, user_id),
+        )
+        updated = cursor.rowcount
+        if updated:
+            conn.commit()
+            logger.info(
+                "Relabeled %d source config(s) from plugin %r to %r",
+                updated,
+                _OLD_PLUGIN,
+                _NEW_PLUGIN,
+            )

--- a/src/web/api.py
+++ b/src/web/api.py
@@ -109,7 +109,7 @@ class UpdateRequest(BaseModel):
 
     source: str = Field(
         ...,
-        description="Data source (e.g. goodreads, steam, sonarr, radarr, or 'all')",
+        description="Data source (e.g. goodreads_csv, steam, sonarr, radarr, or 'all')",
     )
     max_workers: int | None = Field(
         None,

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -23,6 +23,10 @@ from src.cli.config import (
 from src.conversation.engine import create_conversation_engine
 from src.conversation.memory import MemoryManager
 from src.storage.credential_migration import migrate_config_credentials
+from src.storage.source_migration import (
+    migrate_source_config_plugins,
+    migrate_source_labels,
+)
 from src.web.api import APP_VERSION
 from src.web.api import router as api_router
 from src.web.chat_api import router as chat_router
@@ -131,6 +135,10 @@ def create_app(config_path: Path | None = None) -> FastAPI:
 
         # Migrate sensitive config credentials to encrypted DB storage
         migrate_config_credentials(config, storage)
+        # Relabel stored goodreads source values and plugin names after the
+        # plugin rename
+        migrate_source_labels(storage)
+        migrate_source_config_plugins(storage)
 
         # Store in app state
         app_state.config = config

--- a/src/web/state.py
+++ b/src/web/state.py
@@ -12,6 +12,10 @@ import watchfiles
 
 from src.cli.config import load_config
 from src.storage.credential_migration import migrate_config_credentials
+from src.storage.source_migration import (
+    migrate_source_config_plugins,
+    migrate_source_labels,
+)
 
 if TYPE_CHECKING:
     from src.conversation.engine import ConversationEngine
@@ -152,6 +156,10 @@ def reload_config() -> bool:
         # Mutates config in place: sensitive fields are popped after migration.
         if app_state.storage is not None:
             migrate_config_credentials(config, app_state.storage)
+            # Relabel stored goodreads source values and plugin names after the
+            # plugin rename
+            migrate_source_labels(app_state.storage)
+            migrate_source_config_plugins(app_state.storage)
         app_state.config = config
         logger.info("Reloaded config from %s", config_path)
         return True

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -17,12 +17,18 @@ def cli_runner() -> CliRunner:
 
 
 def _cli_patches():
-    """Context manager stack for CLI patches."""
+    """Context manager stack for CLI patches.
+
+    The top-level ``cli`` callback runs the source migrations on every command,
+    so they are patched here to keep them off the MagicMock storage in tests.
+    """
     return (
         patch("src.cli.main.load_config"),
         patch("src.cli.main.create_storage_manager"),
         patch("src.cli.main.create_llm_components"),
         patch("src.cli.main.create_recommendation_engine"),
+        patch("src.cli.main.migrate_source_labels"),
+        patch("src.cli.main.migrate_source_config_plugins"),
     )
 
 
@@ -44,12 +50,14 @@ def _invoke_with_mocks(
         input_text: Simulated stdin input
         llm_client: Optional LLM client mock (default: None/AI disabled)
     """
-    p_config, p_storage, p_llm, p_engine = _cli_patches()
+    p_config, p_storage, p_llm, p_engine, p_labels, p_plugins = _cli_patches()
     with (
         p_config as mock_load,
         p_storage as mock_storage_fn,
         p_llm as mock_llm,
         p_engine,
+        p_labels,
+        p_plugins,
     ):
         mock_load.return_value = config or {}
         mock_storage_fn.return_value = mock_storage

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -1,8 +1,19 @@
 """Tests for CLI __main__ entry point."""
 
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
 from click.testing import CliRunner
 
 from src.cli.main import cli
+from src.ingestion.sync import SyncResult
+from src.llm.embeddings import EmbeddingGenerator
+from src.llm.recommendations import RecommendationGenerator
+from src.recommendations.engine import RecommendationEngine
+from src.storage.manager import StorageManager
 
 
 def test_cli_main_module_exposes_cli_entry_point() -> None:
@@ -18,3 +29,140 @@ def test_cli_help_via_runner() -> None:
     result = runner.invoke(cli, ["--help"])
     assert result.exit_code == 0
     assert "Recommendinator CLI" in result.output
+
+
+def test_non_update_command_runs_both_source_migrations() -> None:
+    """Both source migrations run on a non-update command (``status``).
+
+    The rename migrations live on the top-level ``cli`` callback, so a CLI-only
+    user is migrated even when they never run ``update``. Each migration must
+    fire exactly once with the real storage instance.
+    """
+    mock_storage = MagicMock(spec=StorageManager)
+    with (
+        patch("src.cli.main.load_config", return_value={}),
+        patch("src.cli.main.create_storage_manager", return_value=mock_storage),
+        patch(
+            "src.cli.main.create_llm_components",
+            return_value=(
+                None,
+                MagicMock(spec=EmbeddingGenerator),
+                MagicMock(spec=RecommendationGenerator),
+            ),
+        ),
+        patch(
+            "src.cli.main.create_recommendation_engine",
+            return_value=MagicMock(spec=RecommendationEngine),
+        ),
+        patch("src.cli.main.migrate_source_labels") as spy_labels,
+        patch("src.cli.main.migrate_source_config_plugins") as spy_plugins,
+        patch(
+            "src.cli.commands.importlib.metadata.version",
+            return_value="0.6.0",
+        ),
+    ):
+        result = CliRunner().invoke(cli, ["status"])
+
+    assert result.exit_code == 0, result.output
+    spy_labels.assert_called_once_with(mock_storage)
+    spy_plugins.assert_called_once_with(mock_storage)
+
+
+def test_update_does_not_double_invoke_source_migrations(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``update`` runs each source migration exactly once, not twice.
+
+    The migrations were hoisted to the ``cli`` callback; ``update`` must no
+    longer invoke them itself. Rather than patching the ``src.cli.main``
+    bindings (which a reintroduced call through ``update``'s OWN import would
+    bypass entirely), this drives the REAL migration against a REAL on-disk
+    ``StorageManager``:
+
+    * The ``cli`` callback runs the unpatched, real migration on the seeded
+      ``goodreads`` row, so its side effect (the relabel + its single
+      "Relabeled" log line) is observable proof the callback migration fired.
+    * A ``create=True`` spy on ``src.cli.commands.migrate_source_labels`` /
+      ``migrate_source_config_plugins`` — the exact binding a reintroduced
+      ``from src.storage.source_migration import ...`` in ``commands.py`` plus a
+      call inside ``update()`` would resolve through — is asserted NEVER called.
+      Because the real migration is idempotent (a second run on already-migrated
+      data is a silent no-op), a re-invocation cannot be caught by its own side
+      effect; the command-binding guard is what fails if the bug returns.
+
+    The sync layer and plugin validation are mocked so the command body actually
+    executes (rather than exiting early on ``--help``).
+    """
+    config = {
+        "inputs": {
+            "goodreads_csv": {
+                "plugin": "goodreads_csv",
+                "path": "inputs/goodreads_library_export.csv",
+                "enabled": True,
+            }
+        },
+        "recommendations": {"min_rating_for_preference": 4},
+    }
+    storage = StorageManager(sqlite_path=tmp_path / "test.db")
+    with storage.connection() as conn:
+        conn.execute(
+            "INSERT INTO content_items (user_id, title, content_type, status, source) "
+            "VALUES (1, 'Some Title', 'book', 'completed', 'goodreads')"
+        )
+        conn.commit()
+
+    def _fake_sync(**kwargs: Any) -> list[SyncResult]:
+        sources = kwargs.get("sources") or []
+        return [
+            SyncResult(source_name=plugin.display_name) for plugin, _config in sources
+        ]
+
+    with (
+        patch("src.cli.main.load_config", return_value=config),
+        patch("src.cli.main.create_storage_manager", return_value=storage),
+        patch(
+            "src.cli.main.create_llm_components",
+            return_value=(
+                None,
+                MagicMock(spec=EmbeddingGenerator),
+                MagicMock(spec=RecommendationGenerator),
+            ),
+        ),
+        patch(
+            "src.cli.main.create_recommendation_engine",
+            return_value=MagicMock(spec=RecommendationEngine),
+        ),
+        patch(
+            "src.cli.commands.execute_multi_source_sync", side_effect=_fake_sync
+        ) as spy_sync,
+        patch(
+            "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
+            return_value=[],
+        ),
+        patch("src.cli.commands.migrate_source_labels", create=True) as guard_labels,
+        patch(
+            "src.cli.commands.migrate_source_config_plugins", create=True
+        ) as guard_plugins,
+    ):
+        with caplog.at_level(logging.INFO):
+            result = CliRunner().invoke(cli, ["update"])
+
+    assert result.exit_code == 0, result.output
+    # Proves the update body actually executed (it reached the sync call)
+    # rather than exiting early as the old ``--help`` invocation did.
+    spy_sync.assert_called_once()
+
+    # The real callback migration ran exactly once against real storage: the
+    # seeded 'goodreads' row is relabeled and exactly one "Relabeled" line logs.
+    with storage.connection() as conn:
+        rows = conn.execute("SELECT source FROM content_items").fetchall()
+    assert [row[0] for row in rows] == ["goodreads_csv"]
+    relabel_logs = [
+        record for record in caplog.records if "Relabeled" in record.getMessage()
+    ]
+    assert len(relabel_logs) == 1
+    assert "content item(s)" in relabel_logs[0].getMessage()
+
+    # ``update`` must NOT re-invoke either migration through its own import.
+    guard_labels.assert_not_called()
+    guard_plugins.assert_not_called()

--- a/tests/cli/test_cli_recommend.py
+++ b/tests/cli/test_cli_recommend.py
@@ -107,6 +107,8 @@ def _invoke_recommend_with_engine(
         patch("src.cli.main.create_storage_manager") as mock_storage_fn,
         patch("src.cli.main.create_llm_components") as mock_llm,
         patch("src.cli.main.create_recommendation_engine", return_value=mock_engine),
+        patch("src.cli.main.migrate_source_labels"),
+        patch("src.cli.main.migrate_source_config_plugins"),
     ):
         mock_load.return_value = config or {}
         mock_storage = MagicMock(spec=StorageManager)

--- a/tests/cli/test_cli_status.py
+++ b/tests/cli/test_cli_status.py
@@ -26,13 +26,15 @@ def _status_invoke(
     version: str = "0.6.0",
 ) -> object:
     """Invoke the status command with version patch and full LLM control."""
-    p_config, p_storage, p_llm, p_engine = _cli_patches()
+    p_config, p_storage, p_llm, p_engine, p_labels, p_plugins = _cli_patches()
     mock_storage = MagicMock(spec=StorageManager)
     with (
         p_config as mock_load,
         p_storage as mock_storage_fn,
         p_llm as mock_llm,
         p_engine as mock_eng,
+        p_labels,
+        p_plugins,
         patch(
             "src.cli.commands.importlib.metadata.version",
             return_value=version,

--- a/tests/storage/test_source_migration.py
+++ b/tests/storage/test_source_migration.py
@@ -1,0 +1,316 @@
+"""Tests for the goodreads -> goodreads_csv source and plugin migrations."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from src.ingestion.registry import get_registry
+from src.ingestion.sources.goodreads_csv.goodreads_csv import GoodreadsCsvPlugin
+from src.storage.manager import StorageManager
+from src.storage.source_migration import (
+    migrate_source_config_plugins,
+    migrate_source_labels,
+)
+
+
+def _insert_user(storage: StorageManager, user_id: int) -> None:
+    """Insert a users row so content_items FK constraints are satisfied."""
+    with storage.connection() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO users (id, username) VALUES (?, ?)",
+            (user_id, f"user{user_id}"),
+        )
+        conn.commit()
+
+
+def _insert_item(storage: StorageManager, source: str, user_id: int = 1) -> None:
+    """Insert a minimal content item with the given source label."""
+    with storage.connection() as conn:
+        conn.execute(
+            "INSERT INTO content_items (user_id, title, content_type, status, source) "
+            "VALUES (?, 'Some Title', 'book', 'completed', ?)",
+            (user_id, source),
+        )
+        conn.commit()
+
+
+def _insert_source_config(
+    storage: StorageManager, source_id: str, plugin: str, user_id: int = 1
+) -> None:
+    """Insert a migrated source_configs row with the given plugin name."""
+    with storage.connection() as conn:
+        conn.execute(
+            "INSERT INTO source_configs (user_id, source_id, plugin, config_json) "
+            "VALUES (?, ?, ?, '{}')",
+            (user_id, source_id, plugin),
+        )
+        conn.commit()
+
+
+def _sources(storage: StorageManager) -> list[str]:
+    """Return every stored ``source`` value ordered by row id."""
+    with storage.connection() as conn:
+        cursor = conn.execute("SELECT source FROM content_items ORDER BY id")
+        return [row[0] for row in cursor.fetchall()]
+
+
+def _plugins(storage: StorageManager) -> list[tuple[int, str, str]]:
+    """Return every source_configs ``(user_id, source_id, plugin)`` by source_id."""
+    with storage.connection() as conn:
+        cursor = conn.execute(
+            "SELECT user_id, source_id, plugin FROM source_configs "
+            "ORDER BY user_id, source_id"
+        )
+        return [(row[0], row[1], row[2]) for row in cursor.fetchall()]
+
+
+class TestMigrateSourceLabels:
+    """Tests for migrate_source_labels."""
+
+    @pytest.fixture()
+    def storage(self, tmp_path: Path) -> StorageManager:
+        """Create a StorageManager with a temp DB."""
+        return StorageManager(sqlite_path=tmp_path / "test.db")
+
+    def test_relabels_goodreads_source(self, storage: StorageManager) -> None:
+        """An item with source='goodreads' is relabeled to 'goodreads_csv'."""
+        _insert_item(storage, "goodreads")
+
+        migrate_source_labels(storage)
+
+        assert _sources(storage) == ["goodreads_csv"]
+
+    def test_logs_count_on_migration(
+        self, storage: StorageManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The migration logs at INFO with the number of rows it updated."""
+        _insert_item(storage, "goodreads")
+        _insert_item(storage, "goodreads")
+
+        with caplog.at_level(logging.INFO):
+            migrate_source_labels(storage)
+
+        assert "Relabeled 2 content item(s)" in caplog.text
+
+    def test_idempotent_second_run_is_noop(
+        self, storage: StorageManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Running twice yields the same result and the second run reports nothing."""
+        _insert_item(storage, "goodreads")
+
+        migrate_source_labels(storage)
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO):
+            migrate_source_labels(storage)
+
+        assert _sources(storage) == ["goodreads_csv"]
+        # Second run matches no rows, so nothing is logged.
+        assert "Relabeled" not in caplog.text
+
+    def test_other_sources_untouched(self, storage: StorageManager) -> None:
+        """Items with other source labels are left exactly as-is."""
+        _insert_item(storage, "steam")
+        _insert_item(storage, "mybooks")
+        _insert_item(storage, "goodreads")
+        # An arbitrary user-chosen config-block key must not be rewritten.
+        _insert_item(storage, "goodreads_rss")
+
+        migrate_source_labels(storage)
+
+        assert _sources(storage) == [
+            "steam",
+            "mybooks",
+            "goodreads_csv",
+            "goodreads_rss",
+        ]
+
+    def test_scopes_to_requested_user(self, storage: StorageManager) -> None:
+        """Only the target user's goodreads rows are relabeled.
+
+        The migration is user-scoped (default user 1). A goodreads row owned by
+        another user must be left untouched when migrating user 1, and relabeled
+        only when that user is explicitly migrated.
+        """
+        _insert_user(storage, 2)
+        _insert_item(storage, "goodreads", user_id=1)
+        _insert_item(storage, "goodreads", user_id=2)
+
+        migrate_source_labels(storage)  # defaults to user_id=1
+
+        assert _sources(storage) == ["goodreads_csv", "goodreads"]
+
+        migrate_source_labels(storage, user_id=2)
+
+        assert _sources(storage) == ["goodreads_csv", "goodreads_csv"]
+
+    def test_empty_db_is_noop(
+        self, storage: StorageManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An empty database with no matching rows completes as a silent no-op."""
+        with caplog.at_level(logging.INFO):
+            migrate_source_labels(storage)
+
+        assert _sources(storage) == []
+        assert "Relabeled" not in caplog.text
+
+
+class TestMigrateSourceConfigPlugins:
+    """Tests for migrate_source_config_plugins."""
+
+    @pytest.fixture()
+    def storage(self, tmp_path: Path) -> StorageManager:
+        """Create a StorageManager with a temp DB."""
+        return StorageManager(sqlite_path=tmp_path / "test.db")
+
+    def test_relabels_goodreads_plugin(self, storage: StorageManager) -> None:
+        """A source_configs row with plugin='goodreads' becomes 'goodreads_csv'."""
+        _insert_source_config(storage, "my_books", "goodreads")
+
+        migrate_source_config_plugins(storage)
+
+        assert _plugins(storage) == [(1, "my_books", "goodreads_csv")]
+
+    def test_logs_count_on_migration(
+        self, storage: StorageManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The migration logs at INFO with the number of rows it updated."""
+        _insert_source_config(storage, "books_a", "goodreads")
+        _insert_source_config(storage, "books_b", "goodreads")
+
+        with caplog.at_level(logging.INFO):
+            migrate_source_config_plugins(storage)
+
+        assert "Relabeled 2 source config(s)" in caplog.text
+
+    def test_idempotent_second_run_is_noop(
+        self, storage: StorageManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Running twice yields the same result and the second run logs nothing."""
+        _insert_source_config(storage, "my_books", "goodreads")
+
+        migrate_source_config_plugins(storage)
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO):
+            migrate_source_config_plugins(storage)
+
+        assert _plugins(storage) == [(1, "my_books", "goodreads_csv")]
+        assert "Relabeled" not in caplog.text
+
+    def test_other_plugins_untouched(self, storage: StorageManager) -> None:
+        """Rows with other plugin names are left exactly as-is."""
+        _insert_source_config(storage, "games", "steam")
+        _insert_source_config(storage, "books", "goodreads")
+        _insert_source_config(storage, "shelves", "goodreads_rss")
+
+        migrate_source_config_plugins(storage)
+
+        assert _plugins(storage) == [
+            (1, "books", "goodreads_csv"),
+            (1, "games", "steam"),
+            (1, "shelves", "goodreads_rss"),
+        ]
+
+    def test_scopes_to_requested_user(self, storage: StorageManager) -> None:
+        """Only the target user's goodreads rows are relabeled.
+
+        A goodreads plugin row owned by another user must be left untouched when
+        migrating user 1, and relabeled only when that user is migrated.
+        """
+        _insert_user(storage, 2)
+        _insert_source_config(storage, "books", "goodreads", user_id=1)
+        _insert_source_config(storage, "books", "goodreads", user_id=2)
+
+        migrate_source_config_plugins(storage)  # defaults to user_id=1
+
+        assert _plugins(storage) == [
+            (1, "books", "goodreads_csv"),
+            (2, "books", "goodreads"),
+        ]
+
+        migrate_source_config_plugins(storage, user_id=2)
+
+        assert _plugins(storage) == [
+            (1, "books", "goodreads_csv"),
+            (2, "books", "goodreads_csv"),
+        ]
+
+    def test_empty_db_is_noop(
+        self, storage: StorageManager, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An empty database with no matching rows completes as a silent no-op."""
+        with caplog.at_level(logging.INFO):
+            migrate_source_config_plugins(storage)
+
+        assert _plugins(storage) == []
+        assert "Relabeled" not in caplog.text
+
+
+class TestMigratedPluginResolvesThroughRegistry:
+    """End-to-end: a migrated source_config must resolve through the registry.
+
+    The rename is a hard cutover — the old ``goodreads`` plugin name no longer
+    exists, so a stored ``plugin='goodreads'`` row would resolve to ``None`` and
+    silently stop syncing. These tests prove the migration rewrites the stored
+    plugin name to the value the registry actually serves, closing the loop.
+    """
+
+    @pytest.fixture()
+    def storage(self, tmp_path: Path) -> StorageManager:
+        """Create a StorageManager with a temp DB."""
+        return StorageManager(sqlite_path=tmp_path / "test.db")
+
+    def test_old_goodreads_plugin_name_does_not_resolve(self) -> None:
+        """The historical ``goodreads`` plugin name no longer resolves.
+
+        Proves the hard cutover: only ``goodreads_csv`` exists in the registry,
+        so an un-migrated ``plugin='goodreads'`` row would vanish.
+        """
+        registry = get_registry()
+
+        assert registry.get_plugin("goodreads") is None
+        assert isinstance(registry.get_plugin("goodreads_csv"), GoodreadsCsvPlugin)
+
+    def test_migrated_plugin_value_resolves_to_csv_plugin(
+        self, storage: StorageManager
+    ) -> None:
+        """After migration the stored plugin value resolves to GoodreadsCsvPlugin.
+
+        Reads the plugin name back out of the DB exactly as the sync path would
+        and looks it up in the registry, proving the round-trip: a previously
+        DB-configured Goodreads source keeps working after the rename instead of
+        silently vanishing.
+        """
+        _insert_source_config(storage, "my_books", "goodreads")
+
+        migrate_source_config_plugins(storage)
+
+        stored_plugin = _plugins(storage)[0][2]
+        assert stored_plugin == "goodreads_csv"
+        resolved = get_registry().get_plugin(stored_plugin)
+        assert isinstance(resolved, GoodreadsCsvPlugin)
+
+    def test_combined_source_and_config_relabel_consistently(
+        self, storage: StorageManager
+    ) -> None:
+        """A user with BOTH a goodreads source_config AND goodreads items.
+
+        Startup runs both migrations. Afterwards the source_config plugin must
+        resolve through the registry AND every content item must be re-attributed
+        to the same ``goodreads_csv`` label, so the source and its items stay
+        consistent rather than drifting apart.
+        """
+        _insert_source_config(storage, "goodreads", "goodreads")
+        _insert_item(storage, "goodreads")
+        _insert_item(storage, "goodreads")
+
+        # Mirrors the startup order in cli/main.py, app.py and state.py.
+        migrate_source_labels(storage)
+        migrate_source_config_plugins(storage)
+
+        assert _sources(storage) == ["goodreads_csv", "goodreads_csv"]
+        assert _plugins(storage) == [(1, "goodreads", "goodreads_csv")]
+        resolved = get_registry().get_plugin(_plugins(storage)[0][2])
+        assert isinstance(resolved, GoodreadsCsvPlugin)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,8 @@ def mock_config():
             "vector_db_path": "data/test_chroma",
         },
         "inputs": {
-            "goodreads": {
+            "goodreads_csv": {
+                "plugin": "goodreads_csv",
                 "path": "inputs/goodreads_library_export.csv",
                 "enabled": True,
             }
@@ -50,6 +51,8 @@ def mock_components(mock_config):
         patch("src.cli.main.create_llm_components") as mock_llm,
         patch("src.cli.main.create_recommendation_engine") as mock_engine,
         patch("src.cli.commands.migrate_config_credentials"),
+        patch("src.cli.main.migrate_source_labels") as mock_migrate_labels,
+        patch("src.cli.main.migrate_source_config_plugins") as mock_migrate_plugins,
     ):
         # Setup mocks
         mock_storage_manager = Mock(spec=StorageManager)
@@ -71,6 +74,8 @@ def mock_components(mock_config):
             "embedding_gen": mock_embedding_gen,
             "rec_gen": mock_rec_gen,
             "engine": mock_engine_instance,
+            "migrate_source_labels": mock_migrate_labels,
+            "migrate_source_config_plugins": mock_migrate_plugins,
         }
 
 
@@ -84,6 +89,22 @@ def test_cli_help():
     assert "recommend" in result.output
     assert "update" in result.output
     assert "complete" in result.output
+
+
+def test_migrations_run_on_cli_startup(mock_components):
+    """Both source migrations run in the top-level cli() callback.
+
+    A CLI-only user who never runs ``update`` must still be migrated, so the
+    label and plugin migrations are invoked once per command with the real
+    storage instance — proving the wiring, not just the migration units.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["status"])
+
+    assert result.exit_code == 0
+    storage = mock_components["storage"]
+    mock_components["migrate_source_labels"].assert_called_once_with(storage)
+    mock_components["migrate_source_config_plugins"].assert_called_once_with(storage)
 
 
 def test_recommend_command_help(mock_components):
@@ -553,8 +574,8 @@ class TestUpdateWorkersFlag:
                     "steam_id": "76561198000000000",
                     "enabled": True,
                 },
-                "goodreads": {
-                    "plugin": "goodreads",
+                "goodreads_csv": {
+                    "plugin": "goodreads_csv",
                     "path": "/tmp/goodreads.csv",
                     "enabled": True,
                 },
@@ -601,7 +622,7 @@ class TestUpdateWorkersFlag:
                 return_value=[],
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
                 return_value=[],
             ),
         ):
@@ -636,7 +657,7 @@ class TestUpdateWorkersFlag:
                 return_value=[],
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
                 return_value=[],
             ),
         ):
@@ -671,7 +692,7 @@ class TestUpdateWorkersFlag:
                 return_value=[],
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
                 return_value=[],
             ),
         ):
@@ -724,7 +745,7 @@ class TestUpdateWorkersFlag:
                 return_value=[],
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
                 return_value=[],
             ),
         ):
@@ -759,7 +780,7 @@ class TestUpdateWorkersFlag:
                 return_value=[],
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
                 return_value=[],
             ),
         ):
@@ -794,7 +815,7 @@ class TestUpdateWorkersFlag:
                 return_value=[],
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
                 return_value=[],
             ),
         ):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -446,3 +446,77 @@ class TestPluginRegistryAbstractClassRegression:
         assert (
             warning_records == []
         ), f"Expected no warnings, got: {[r.message for r in warning_records]}"
+
+
+class TestGoodreadsPluginRename:
+    """Real-discovery tests locking in the goodreads -> goodreads_csv rename.
+
+    These exercise the actual built-in plugin discovery (no fakes) so they
+    prove the rename is a true hard rename: the new identifier resolves and
+    the old one does not silently fall back to anything.
+    """
+
+    def test_goodreads_csv_resolves_to_renamed_class(
+        self, clean_registry: PluginRegistry
+    ) -> None:
+        """The renamed plugin resolves under 'goodreads_csv' with correct metadata."""
+        from src.ingestion.sources.goodreads_csv.goodreads_csv import (
+            GoodreadsCsvPlugin,
+        )
+
+        clean_registry.discover_plugins()
+        plugin = clean_registry.get_plugin("goodreads_csv")
+
+        assert isinstance(plugin, GoodreadsCsvPlugin)
+        assert plugin.name == "goodreads_csv"
+        assert plugin.display_name == "Goodreads (CSV Export)"
+
+    def test_old_goodreads_name_no_longer_resolves(
+        self, clean_registry: PluginRegistry
+    ) -> None:
+        """A config referencing the pre-rename 'goodreads' plugin finds nothing.
+
+        Guards against a stray backward-compat alias: the rename must be hard,
+        so the old identifier must not resolve to any plugin.
+        """
+        clean_registry.discover_plugins()
+
+        assert clean_registry.get_plugin("goodreads") is None
+        assert "goodreads" not in clean_registry.get_all_plugins()
+
+    def test_goodreads_rss_resolves(self, clean_registry: PluginRegistry) -> None:
+        """The new RSS sibling plugin resolves under 'goodreads_rss'."""
+        from src.ingestion.sources.goodreads_rss.goodreads_rss import (
+            GoodreadsRssPlugin,
+        )
+
+        clean_registry.discover_plugins()
+        plugin = clean_registry.get_plugin("goodreads_rss")
+
+        assert isinstance(plugin, GoodreadsRssPlugin)
+        assert plugin.name == "goodreads_rss"
+
+    def test_enabled_plugins_ignores_old_goodreads_key(
+        self, clean_registry: PluginRegistry
+    ) -> None:
+        """An input entry with plugin='goodreads' yields no enabled plugin.
+
+        The registry does not fall back to the renamed plugin, so a stale
+        config block silently contributes nothing rather than resolving to
+        goodreads_csv.
+        """
+        clean_registry.discover_plugins()
+
+        config = {
+            "inputs": {
+                "my_books": {
+                    "plugin": "goodreads",
+                    "enabled": True,
+                    "path": "/data/books.csv",
+                },
+            }
+        }
+
+        enabled = clean_registry.get_enabled_plugins(config)
+
+        assert enabled == []

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -51,8 +51,8 @@ def mock_config():
             "port": 8000,
         },
         "inputs": {
-            "goodreads": {
-                "plugin": "goodreads",
+            "goodreads_csv": {
+                "plugin": "goodreads_csv",
                 "path": "inputs/goodreads_library_export.csv",
                 "enabled": True,
             }
@@ -75,6 +75,8 @@ def mock_components(mock_config):
         patch("src.web.app.create_llm_components") as mock_llm,
         patch("src.web.app.create_recommendation_engine") as mock_engine,
         patch("src.web.app.migrate_config_credentials"),
+        patch("src.web.app.migrate_source_labels") as mock_migrate_labels,
+        patch("src.web.app.migrate_source_config_plugins") as mock_migrate_plugins,
     ):
         # Setup mocks
         mock_storage_manager = Mock(spec=StorageManager)
@@ -110,6 +112,8 @@ def mock_components(mock_config):
             "storage": mock_storage_manager,
             "embedding_gen": mock_embedding_gen,
             "engine": mock_engine_instance,
+            "migrate_source_labels": mock_migrate_labels,
+            "migrate_source_config_plugins": mock_migrate_plugins,
         }
 
         # Clean up sync manager after test
@@ -120,6 +124,17 @@ def mock_components(mock_config):
 def client(mock_components):
     """Create test client."""
     return TestClient(mock_components["app"])
+
+
+def test_create_app_runs_both_source_migrations(mock_components):
+    """create_app runs both source migrations with the real storage instance.
+
+    Proves the migrations are wired into web startup, not merely unit-tested:
+    a rename must relabel stored items and DB source configs on first boot.
+    """
+    storage = mock_components["storage"]
+    mock_components["migrate_source_labels"].assert_called_once_with(storage)
+    mock_components["migrate_source_config_plugins"].assert_called_once_with(storage)
 
 
 class TestRootEndpoint:
@@ -338,12 +353,12 @@ def test_sync_sources_endpoint(client, mock_config):
     assert response.status_code == 200
     sources = response.json()
     assert isinstance(sources, list)
-    # mock_config has exactly goodreads enabled
+    # mock_config has exactly goodreads_csv enabled
     assert len(sources) == 1
-    goodreads = next((s for s in sources if s["id"] == "goodreads"), None)
+    goodreads = next((s for s in sources if s["id"] == "goodreads_csv"), None)
     assert goodreads is not None
-    assert goodreads["display_name"] == "Goodreads"
-    assert goodreads["plugin_display_name"] == "Goodreads"
+    assert goodreads["display_name"] == "Goodreads CSV"
+    assert goodreads["plugin_display_name"] == "Goodreads (CSV Export)"
 
 
 def test_sync_sources_lists_all_with_enabled_flag(client):
@@ -355,8 +370,8 @@ def test_sync_sources_lists_all_with_enabled_flag(client):
     """
     app_state.config = {
         "inputs": {
-            "goodreads": {
-                "plugin": "goodreads",
+            "goodreads_csv": {
+                "plugin": "goodreads_csv",
                 "path": "inputs/books.csv",
                 "enabled": True,
             },
@@ -386,7 +401,7 @@ def test_sync_sources_lists_all_with_enabled_flag(client):
     sources = response.json()
     by_id = {s["id"]: s for s in sources}
 
-    assert by_id["goodreads"]["enabled"] is True
+    assert by_id["goodreads_csv"]["enabled"] is True
     assert by_id["sonarr"]["enabled"] is True
     assert by_id["steam"]["enabled"] is False
     assert by_id["radarr"]["enabled"] is False
@@ -483,11 +498,11 @@ def test_update_endpoint(client, mock_components):
 
     with (
         patch(
-            "src.ingestion.sources.goodreads.GoodreadsPlugin.fetch",
+            "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.fetch",
             return_value=iter([mock_item]),
         ),
         patch(
-            "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+            "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
             return_value=[],
         ),
     ):
@@ -496,7 +511,7 @@ def test_update_endpoint(client, mock_components):
         ] * 768
         mock_components["storage"].save_content_item.return_value = 1
 
-        response = client.post("/api/update", json={"source": "goodreads"})
+        response = client.post("/api/update", json={"source": "goodreads_csv"})
 
         assert response.status_code == 200
         data = response.json()
@@ -627,11 +642,11 @@ def test_update_endpoint_all_sources(client, mock_components):
 
     with (
         patch(
-            "src.ingestion.sources.goodreads.GoodreadsPlugin.fetch",
+            "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.fetch",
             return_value=iter([mock_book]),
         ),
         patch(
-            "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+            "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
             return_value=[],
         ),
         patch(
@@ -655,7 +670,7 @@ def test_update_endpoint_all_sources(client, mock_components):
         # New async behavior: returns sync started message with sources list
         assert "message" in data
         assert "sources" in data
-        assert "goodreads" in data["sources"]
+        assert "goodreads_csv" in data["sources"]
         assert "steam" in data["sources"]
 
 
@@ -2193,21 +2208,21 @@ class TestUpdateEndpoint409Conflict:
             mock_manager = Mock(spec=SyncManager)
             mock_manager.start_sync.return_value = (
                 False,
-                "Sync already in progress for Goodreads",
+                "Sync already in progress for Goodreads CSV",
             )
             mock_get_sync_manager.return_value = mock_manager
 
             with patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
                 return_value=[],
             ):
-                response = client.post("/api/update", json={"source": "goodreads"})
+                response = client.post("/api/update", json={"source": "goodreads_csv"})
 
             assert response.status_code == 409
             detail = response.json()["detail"]
             assert "Sync already in progress" in detail
-            assert "Goodreads" in detail
-            assert mock_manager.start_sync.call_args.args[0] == "Goodreads"
+            assert "Goodreads CSV" in detail
+            assert mock_manager.start_sync.call_args.args[0] == "Goodreads CSV"
 
     def test_update_allows_different_sources_concurrently(
         self, client: TestClient, mock_components: dict
@@ -2215,7 +2230,7 @@ class TestUpdateEndpoint409Conflict:
         """A second source is accepted while a different source is running.
 
         Plants a real RUNNING job for Steam in the global SyncManager
-        before triggering a Goodreads sync. The endpoint must reject
+        before triggering a Goodreads CSV sync. The endpoint must reject
         only when the SAME label is running — different labels return
         200 even with another sync still in flight.
         """
@@ -2231,23 +2246,27 @@ class TestUpdateEndpoint409Conflict:
         assert manager.is_running("Steam") is True
 
         with patch(
-            "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+            "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
             return_value=[],
         ):
             # Drop the captured execute_multi_source_sync into a no-op so
             # the second sync's daemon doesn't try to actually run.
             with patch(
                 "src.web.api.execute_multi_source_sync",
-                return_value=[SyncJob(source="Goodreads", status=SyncStatus.RUNNING)],
+                return_value=[
+                    SyncJob(source="Goodreads CSV", status=SyncStatus.RUNNING)
+                ],
             ):
-                response = client.post("/api/update", json={"source": "goodreads"})
+                response = client.post("/api/update", json={"source": "goodreads_csv"})
 
         assert response.status_code == 200, response.text
         assert "Sync started" in response.json()["message"]
         # Manager now tracks both jobs; the Steam one is still running
-        # and the Goodreads one was added on top.
+        # and the Goodreads CSV one was added on top.
         assert manager.is_running("Steam") is True
-        assert "Goodreads" in {job["source"] for job in manager.get_status()["jobs"]}
+        assert "Goodreads CSV" in {
+            job["source"] for job in manager.get_status()["jobs"]
+        }
 
 
 class TestUpdateEndpointParallelSync:
@@ -2298,7 +2317,7 @@ class TestUpdateEndpointParallelSync:
                 side_effect=self._make_capture(captured_kwargs, completion),
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
                 return_value=[],
             ),
         ):
@@ -2322,7 +2341,7 @@ class TestUpdateEndpointParallelSync:
                 side_effect=self._make_capture(captured_kwargs, completion),
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
                 return_value=[],
             ),
         ):
@@ -2346,7 +2365,7 @@ class TestUpdateEndpointParallelSync:
                 side_effect=self._make_capture(captured_kwargs, completion),
             ),
             patch(
-                "src.ingestion.sources.goodreads.GoodreadsPlugin.validate_config",
+                "src.ingestion.sources.goodreads_csv.GoodreadsCsvPlugin.validate_config",
                 return_value=[],
             ),
         ):

--- a/tests/web/test_source_config_api.py
+++ b/tests/web/test_source_config_api.py
@@ -79,6 +79,8 @@ def client(
         patch("src.web.app.create_llm_components") as mock_llm,
         patch("src.web.app.create_recommendation_engine") as mock_engine,
         patch("src.web.app.migrate_config_credentials"),
+        patch("src.web.app.migrate_source_labels"),
+        patch("src.web.app.migrate_source_config_plugins"),
     ):
         mock_llm.return_value = (
             Mock(spec=OllamaClient),

--- a/tests/web/test_state.py
+++ b/tests/web/test_state.py
@@ -6,12 +6,13 @@ from collections.abc import AsyncIterator
 from dataclasses import fields
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
 from src.conversation.engine import ConversationEngine
 from src.llm.client import OllamaClient
+from src.storage.manager import StorageManager
 from src.web.state import (
     AppState,
     ConfigWatcher,
@@ -58,6 +59,30 @@ class TestReloadConfig:
         assert result is True
         assert app_state.config["ollama"]["model"] == "test-model"
         assert "old" not in app_state.config
+
+    def test_reload_config_runs_both_source_migrations(self, tmp_path: Path) -> None:
+        """reload_config runs both source migrations with the stored storage.
+
+        When storage is present, a hot-reload must relabel stored items and DB
+        source configs, mirroring the migrations that run on web startup.
+        """
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("ollama:\n  model: test-model\n")
+
+        app_state.config_path = str(config_file)
+        storage = Mock(spec=StorageManager)
+        app_state.storage = storage
+
+        with (
+            patch("src.web.state.migrate_config_credentials"),
+            patch("src.web.state.migrate_source_labels") as mock_labels,
+            patch("src.web.state.migrate_source_config_plugins") as mock_plugins,
+        ):
+            result = reload_config()
+
+        assert result is True
+        mock_labels.assert_called_once_with(storage)
+        mock_plugins.assert_called_once_with(storage)
 
     def test_reload_config_no_config_path(self) -> None:
         """reload_config returns False when no config_path is stored."""

--- a/uv.lock
+++ b/uv.lock
@@ -541,6 +541,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2152,6 +2161,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "cryptography" },
+    { name = "defusedxml" },
     { name = "fastapi" },
     { name = "legendary-gl" },
     { name = "pandas" },
@@ -2178,6 +2188,7 @@ dev = [
     { name = "python-semantic-release" },
     { name = "ruff" },
     { name = "types-click" },
+    { name = "types-defusedxml" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "types-tabulate" },
@@ -2189,6 +2200,7 @@ requires-dist = [
     { name = "chromadb", marker = "extra == 'ai'", specifier = ">=1.0.0,<2.0.0" },
     { name = "click", specifier = ">=8.1.0,<9.0.0" },
     { name = "cryptography", specifier = ">=41.0.0,<45.0.0" },
+    { name = "defusedxml", specifier = ">=0.7.1,<1.0.0" },
     { name = "fastapi", specifier = ">=0.104.0,<1.0.0" },
     { name = "legendary-gl", specifier = ">=0.20.0,<1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.0,<2.0.0" },
@@ -2205,6 +2217,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.6,<1.0.0" },
     { name = "tabulate", specifier = ">=0.9.0,<1.0.0" },
     { name = "types-click", marker = "extra == 'dev'", specifier = ">=7.1.0" },
+    { name = "types-defusedxml", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
     { name = "types-tabulate", marker = "extra == 'dev'", specifier = ">=0.9.0" },
@@ -2615,6 +2628,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/ff/0e6a56108d45c80c61cdd4743312d0304d8192482aea4cce96c554aaa90d/types-click-7.1.8.tar.gz", hash = "sha256:b6604968be6401dc516311ca50708a0a28baa7a0cb840efd7412f0dbbff4e092", size = 10015, upload-time = "2021-11-23T12:28:01.701Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/ad/607454a5f991c5b3e14693a7113926758f889138371058a5f72f567fa131/types_click-7.1.8-py3-none-any.whl", hash = "sha256:8cb030a669e2e927461be9827375f83c16b8178c365852c060a34e24871e7e81", size = 12929, upload-time = "2021-11-23T12:27:59.493Z" },
+]
+
+[[package]]
+name = "types-defusedxml"
+version = "0.7.0.20260504"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/d2/4553c8fa9cdebfe1e84b950cf790a4d2376a97fa016e43f7c65323fa6c7d/types_defusedxml-0.7.0.20260504.tar.gz", hash = "sha256:2ab2828a3f97111ba1c16cee273ad4124a831fc9198c41bf8368ff6ea48ad300", size = 10729, upload-time = "2026-05-04T05:22:50.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/2d/8a4b5ba1d732b8bc691f0efbb1c6f77cb5f6f473b2afe181d83d910773c5/types_defusedxml-0.7.0.20260504-py3-none-any.whl", hash = "sha256:a959e3a0a43b93e464bd625d91ec9193a2703ddc10443bdd627792485fae0b10", size = 13467, upload-time = "2026-05-04T05:22:49.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

Closes #95.

Two things, really. First it renames the CSV goodreads plugin to `goodreads_csv`, matching the name-by-method convention `storygraph_csv` already set. Second it adds a new `goodreads_rss` plugin that syncs your public Goodreads shelves over RSS, so you don't have to keep exporting a CSV.

### `goodreads_rss`

- Point it at your numeric Goodreads user id **or** a profile URL (it pulls the id out of the URL for you).
- `shelves` defaults to `read`, `currently-reading`, and `to-read`, so it lines up with what the CSV export gave you. You can narrow it to whichever shelves you want, since there can be N of them.
- Status comes from the shelf: `read` maps to completed, `currently-reading` to in progress, `to-read` and any custom shelf to unread. If a book shows up on more than one requested shelf it's deduped to the strongest status.
- Needs a public profile. No API key.

### Data migration (the DB side of the rename)

The rename would otherwise strand existing data, so on startup we relabel it:

- Stored item `source` labels go from `goodreads` to `goodreads_csv`.
- Source configs saved in the database (the "migrate to DB" ones) get their `plugin` relabeled too, so a DB-configured Goodreads source keeps resolving and syncing instead of silently vanishing.

The migration is idempotent, scoped per user, and runs on every CLI command and on web startup/reload, so CLI-only and web-only users both get it.

## Breaking change

If your `config.yaml` sets `plugin: goodreads`, change it to `plugin: goodreads_csv`. Stored data relabels itself automatically, but the config file is yours to update.

## Safety notes

The RSS feed is third party content, so it's parsed with `defusedxml` (blocks XXE and billion-laughs entity expansion), pagination is capped so a misbehaving feed can't loop forever, and request/parse errors are scrubbed so they never leak the feed URL or your user id.

## How to test

1. **RSS sync:** add a `goodreads_rss` input to your config with your user id (or profile URL) and run a sync. Confirm books come in from all three default shelves with sensible statuses and ratings. Try narrowing `shelves` to just `["read"]` and re-sync.
2. **Profile URL:** set `user_id` to a full `goodreads.com/user/show/<id>-name` URL and confirm it still resolves.
3. **Rename + migration:** if you have existing goodreads data, start the app and confirm your old items now show `source: goodreads_csv` and still appear. Update your config's `plugin: goodreads` to `goodreads_csv`.
4. **DB-configured source:** if you'd migrated a Goodreads source into the DB, confirm it still syncs after upgrade.
5. **Empty/edge:** try `shelves: []` (syncs nothing) and a private/nonexistent profile (clean error, no traceback).

## Follow-up (not in this PR)

Right now a pure-config `plugin: goodreads` that isn't updated fails the way any unknown plugin does today (the source is skipped). If you want unknown-plugin configs to surface loudly in the CLI/UI as "needs attention" rather than silently skipping, that's a separate, app-wide change worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
