### PR TITLE
fix(recommendations): fall back to latest season date for completed TV shows missing date_completed

### DIFF
--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -102,7 +102,12 @@ whole is still "currently consuming." A show with at least one fully-watched
 season claims a rung on the ladder for its genres, dated by that season's
 watched date rather than the show's (absent) completion date. That date comes
 from Trakt's per-season last-watched time, or from the timestamp of a manual
-season check-off in the library editor. The show's next season is still a
+season check-off in the library editor. The same season-date fallback also
+covers a **completed** TV show that has no recorded completion date (for
+example one tracked only per-season, so its `date_completed` is absent): it is
+dated by its most recent watched-season timestamp instead of being treated as
+undated, so a show you just finished lands on the freshest rungs rather than
+sinking to the weakest one. The show's next season is still a
 series continuation, so it gets the same halved penalty described above —
 finishing season 1 nudges season 2 down without burying it. A finished season
 with no recorded date (e.g. imported via CSV/JSON, watched before this

--- a/src/recommendations/variety.py
+++ b/src/recommendations/variety.py
@@ -9,9 +9,11 @@ the strongest rung.
 
 The ladder is built from the user's completion events ordered by completion
 date (newest first). A completion event is a fully COMPLETED item, or an
-ongoing TV show with at least one finished season — that season's completion
-is dated by its most recent watched-season timestamp rather than
-``date_completed``. Each distinct thematic genre cluster encountered claims
+ongoing TV show with at least one finished season. A completion is normally
+dated by ``date_completed``, but a TV show whose ``date_completed`` is absent
+(a fully-watched show tracked only per-season, or an ongoing show mid-run) is
+dated by its most recent watched-season timestamp instead. Each distinct
+thematic genre cluster encountered claims
 the next rung; the most recently finished cluster receives the strongest
 penalty and the penalty decays linearly to zero over
 :data:`VARIETY_LADDER_STEPS` rungs. A candidate is penalised by the strongest
@@ -74,11 +76,15 @@ def _is_completion_event(item: ContentItem) -> bool:
 def _completion_recency(item: ContentItem) -> date | None:
     """Completion date used for ladder ordering, or None if undated.
 
-    Fully completed items use ``date_completed``; an ongoing show uses its most
-    recent watched-season date. An undated event still lands on the ladder but
-    sorts to the weakest rung.
+    Completed items use ``date_completed``, but a completed TV show whose
+    ``date_completed`` is None (its finish date lives only in season timestamps)
+    falls back to its most recent watched-season date. An ongoing show likewise
+    uses its most recent watched-season date. An undated event still lands on
+    the ladder but sorts to the weakest rung.
     """
     if item.status == ConsumptionStatus.COMPLETED:
+        if item.date_completed is None and item.content_type == ContentType.TV_SHOW:
+            return latest_season_watched_date(item)
         return item.date_completed
     return latest_season_watched_date(item)
 
@@ -111,9 +117,10 @@ def build_variety_ladder(
     Items with status :attr:`ConsumptionStatus.COMPLETED` contribute — items
     the user is actively consuming do not otherwise represent a *finished*
     genre. The one exception is an ongoing TV show with at least one finished
-    season: that season's completion is dated by its most recent watched-season
-    timestamp rather than the show's (absent) ``date_completed``. Items are
-    scanned newest-first; each distinct thematic cluster claims the
+    season. A completion is dated by ``date_completed``, except a TV show
+    lacking one is dated by its most recent watched-season timestamp (covering
+    both an ongoing show and a completed show tracked only per-season). Items
+    are scanned newest-first; each distinct thematic cluster claims the
     next rung until ``steps`` distinct clusters have been recorded. Rung ``i``
     receives penalty ``top_penalty * (steps - i) / steps``.
 

--- a/tests/test_variety.py
+++ b/tests/test_variety.py
@@ -18,6 +18,7 @@ from src.recommendations.variety import (
     VARIETY_LADDER_STEPS,
     VARIETY_SERIES_CONTINUATION_FACTOR,
     VARIETY_TOP_PENALTY,
+    _completion_recency,
     build_variety_ladder,
     variety_penalty_for,
 )
@@ -330,3 +331,152 @@ class TestOngoingTvShowFinishedSeasons:
         )
         # The dated completion is fresher, so it claims the single rung.
         assert set(ladder) == {"crime_thriller"}
+
+
+def _completed_show(
+    title: str,
+    genres: list[str],
+    *,
+    completed_on: date | None,
+    season_dates: dict[str, str] | None = None,
+    db_id: int | None = None,
+) -> ContentItem:
+    """Build a COMPLETED TV show carrying *genres* and optional season dates."""
+    metadata: dict[str, object] = {"genres": genres}
+    if season_dates is not None:
+        metadata["seasons_watched_dates"] = season_dates
+    return ContentItem(
+        id=title.lower().replace(" ", "_"),
+        db_id=db_id,
+        title=title,
+        content_type=ContentType.TV_SHOW,
+        status=ConsumptionStatus.COMPLETED,
+        date_completed=completed_on,
+        metadata=metadata,
+    )
+
+
+class TestCompletionRecency:
+    """Tests for :func:`_completion_recency`."""
+
+    def test_completed_tv_show_without_date_uses_latest_season_date(self) -> None:
+        """A completed show with a NULL date_completed falls back to season dates."""
+        show = _completed_show(
+            "DuckTales",
+            ["Animation"],
+            completed_on=None,
+            season_dates={
+                "3": "2026-06-01T00:00:00+00:00",
+                "4": "2026-07-17T00:00:00+00:00",
+            },
+        )
+        assert _completion_recency(show) == date(2026, 7, 17)
+
+    def test_completed_tv_show_with_date_ignores_season_fallback(self) -> None:
+        """A present date_completed wins; the season fallback never overrides it."""
+        show = _completed_show(
+            "DuckTales",
+            ["Animation"],
+            completed_on=date(2026, 1, 1),
+            season_dates={"4": "2026-07-17T00:00:00+00:00"},
+        )
+        assert _completion_recency(show) == date(2026, 1, 1)
+
+    def test_completed_tv_show_without_date_or_season_dates_stays_none(self) -> None:
+        """A completed show with no date and no season dates degrades to None.
+
+        The TV fallback finds no parseable date, so the show remains undated and
+        sorts to the weakest rung just like any other undated completion.
+        """
+        show = _completed_show("No Dates", ["Animation"], completed_on=None)
+        assert _completion_recency(show) is None
+
+    def test_completed_book_without_date_stays_none(self) -> None:
+        """A completed non-TV item never gets the TV season fallback."""
+        book = _completed("Undated Book", ["Fantasy"], completed_on=None)
+        assert _completion_recency(book) is None
+
+    def test_completed_non_tv_ignores_stray_season_dates(self) -> None:
+        """A non-TV item with stray season dates still returns None.
+
+        Pins the ``content_type == ContentType.TV_SHOW`` guard: even malformed
+        metadata carrying ``seasons_watched_dates`` on a movie must not trigger
+        the TV-only season-date fallback.
+        """
+        movie = ContentItem(
+            id="stray_movie",
+            title="Stray Movie",
+            content_type=ContentType.MOVIE,
+            status=ConsumptionStatus.COMPLETED,
+            date_completed=None,
+            metadata={
+                "genres": ["Animation"],
+                "seasons_watched_dates": {"1": "2026-07-17T00:00:00+00:00"},
+            },
+        )
+        assert _completion_recency(movie) is None
+
+
+class TestCompletedTvShowSeasonDateFallbackRegression:
+    """Regression tests for completed shows whose finish date is season-only."""
+
+    def test_completed_animated_show_season_date_penalizes_animation(self) -> None:
+        """Regression test: a completed show dated only by season timestamps.
+
+        Bug reported: DuckTales was COMPLETED and rated 4, its genres include
+        Animation, but its ``date_completed`` column was NULL and its finish
+        date lived only in ``metadata['seasons_watched_dates']``. Because
+        ``_completion_recency`` returned only ``date_completed`` for COMPLETED
+        items, DuckTales was treated as undated and sorted below every *dated*
+        completion. With five dated non-animation completions ahead of it, the
+        five-rung ladder filled up before reaching DuckTales, so the
+        animation_family cluster never landed on the ladder and the animated
+        candidate Bob's Burgers took a 0.0 variety penalty.
+        Fix: for a COMPLETED TV show with a NULL date_completed,
+        ``_completion_recency`` falls back to the latest watched-season date, so
+        the show is dated by its most recent season and claims a fresh rung.
+        """
+        ducktales = _completed_show(
+            "DuckTales",
+            ["Animation"],
+            completed_on=None,
+            season_dates={"4": "2026-07-17T00:00:00+00:00"},
+            db_id=1,
+        )
+        # Five dated, non-animation completions. Their completion dates all sit
+        # a little before DuckTales' latest season date (2026-07-17), so once
+        # DuckTales is treated as dated it is the freshest event and claims the
+        # top rung. Before the fix it was treated as *undated* and sorted below
+        # all five, filling every rung and dropping animation_family entirely.
+        other_dated = [
+            _completed_show(
+                "Crime Show", ["Crime"], completed_on=date(2026, 7, 12), db_id=2
+            ),
+            _completed_show(
+                "Space Show",
+                ["Science Fiction"],
+                completed_on=date(2026, 7, 13),
+                db_id=3,
+            ),
+            _completed_show(
+                "Dragon Show", ["Fantasy"], completed_on=date(2026, 7, 14), db_id=4
+            ),
+            _completed_show(
+                "West Show", ["Western"], completed_on=date(2026, 7, 15), db_id=5
+            ),
+            _completed_show(
+                "War Show", ["War"], completed_on=date(2026, 7, 16), db_id=6
+            ),
+        ]
+
+        ladder = build_variety_ladder([ducktales, *other_dated])
+
+        # DuckTales' cluster now lands on the ladder: dating it by its season
+        # timestamp makes it the freshest completion instead of an undated event
+        # that sorts below the five dated shows and off the five-rung ladder.
+        assert "animation_family" in ladder
+
+        bobs_burgers = _candidate("Bob's Burgers", ["Animation", "Comedy"])
+        penalty = variety_penalty_for(bobs_burgers, ladder)
+        # Before the fix this penalty was 0.0 (animation_family never on ladder).
+        assert penalty > 0.0


### PR DESCRIPTION
## What

Finishing a TV show did not always feed the "variety after completion" penalty. If a show was marked completed but its finish date only lived in the per season watch data (`date_completed` was NULL), the variety ladder treated it as undated and pushed it to the weakest rung. The ladder only keeps the 5 most recently completed genre clusters, so a just finished show could fall off it entirely and never influence the genre fatigue penalty.

Concretely: finishing DuckTales (animated) left the top rec, Bob's Burgers (also animated), with no hit even with the setting at 4 out of 5. DuckTales had no `date_completed`, so it sank below 5 newer dated completions and its animation cluster never made the ladder.

## The fix

`_completion_recency` now falls back to the latest watched season date for a completed TV show when `date_completed` is missing, which is already how ongoing shows get dated. So a show you just finished lands on the freshest rungs instead of sinking. Books, movies and games are untouched.

It is a one function change plus docs. No data migration, and existing rows with a NULL `date_completed` just work now.

## Tests

- Unit coverage for `_completion_recency`: the fallback fires for a completed TV show with season dates, does not override a real `date_completed`, returns None when there are no season dates, and never fires for non TV items.
- A regression that rebuilds the DuckTales / Bob's Burgers scenario and asserts the animated candidate gets a non zero variety penalty. It was 0 before the fix.

## How to test

1. With variety after completion on (4 to 5), have a completed animated TV show whose `date_completed` is empty but that has season watch data.
2. Generate TV recommendations and confirm another animated show now takes a variety penalty instead of topping the list unpenalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
